### PR TITLE
Fixed bug in shield line placement

### DIFF
--- a/include/mapnik/placement_finder.hpp
+++ b/include/mapnik/placement_finder.hpp
@@ -77,6 +77,10 @@ struct placement : boost::noncopyable
     std::pair<double, double> dimensions;
     bool collect_extents;
     box2d<double> extents;
+
+    // additional boxes attached to the text labels which must also be
+    // placed in order for the text placement to succeed. e.g: shields.
+    std::vector<box2d<double> > additional_boxes;
 };
 
 

--- a/src/agg/process_shield_symbolizer.cpp
+++ b/src/agg/process_shield_symbolizer.cpp
@@ -229,12 +229,17 @@ void  agg_renderer<T>::process(shield_symbolizer const& sym,
 
                     else if (geom.num_points() > 1 && how_placed == LINE_PLACEMENT)
                     {
-                        placement text_placement(info, sym, scale_factor_, label_ext.width(), label_ext.height(), true);
-                        
+                        placement text_placement(info, sym, scale_factor_, w, h, false);
+                        position const& pos = sym.get_displacement();
+
                         text_placement.avoid_edges = sym.get_avoid_edges();
+                        text_placement.additional_boxes.push_back(
+                           box2d<double>(-0.5 * label_ext.width() - boost::get<0>(pos),
+                                         -0.5 * label_ext.height() - boost::get<1>(pos),
+                                         0.5 * label_ext.width() - boost::get<0>(pos),
+                                         0.5 * label_ext.height() - boost::get<1>(pos)));
                         finder.find_point_placements<path_type>(text_placement, placement_options, path);
 
-                        position const&  pos = sym.get_displacement();
                         for (unsigned int ii = 0; ii < text_placement.placements.size(); ++ ii)
                         {
                             double x = floor(text_placement.placements[ii].starting_x);
@@ -244,13 +249,13 @@ void  agg_renderer<T>::process(shield_symbolizer const& sym,
                             double ly = y - boost::get<1>(pos);
                             int px=int(floor(lx - (0.5*w))) + 1;
                             int py=int(floor(ly - (0.5*h))) + 1;
+                            label_ext.re_center(lx, ly);
 
                             render_marker(px,py,**marker,tr,sym.get_opacity());
 
-                            if (writer.first) writer.first->add_box(label_ext, feature, t_, writer.second);
-
                             box2d<double> dim = ren.prepare_glyphs(&text_placement.placements[ii]);
                             ren.render(x,y);
+                            if (writer.first) writer.first->add_box(label_ext, feature, t_, writer.second);
                         }
                         finder.update_detector(text_placement);
                         if (writer.first) writer.first->add_text(text_placement, faces, feature, t_, writer.second);

--- a/src/placement_finder.cpp
+++ b/src/placement_finder.cpp
@@ -38,6 +38,7 @@
 #include <boost/utility.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/foreach.hpp>
 
 //stl
 #include <string>
@@ -480,6 +481,23 @@ void placement_finder<DetectorT>::find_point_placement(placement & p,
             c_envelopes.push(e);  // add character's envelope to temp storage
         }
         x += cwidth;  // move position to next character
+    }
+
+    // check the placement of any additional envelopes
+    if (!p.allow_overlap && !p.additional_boxes.empty())
+    {
+       BOOST_FOREACH(box2d<double> box, p.additional_boxes) 
+       {
+          box2d<double> pt(box.minx() + current_placement->starting_x,
+                           box.miny() + current_placement->starting_y,
+                           box.maxx() + current_placement->starting_x,
+                           box.maxy() + current_placement->starting_y);
+
+          // abort the whole placement if the additional envelopes can't be placed.
+          if (!detector_.has_point_placement(pt, p.minimum_distance)) return;
+
+          c_envelopes.push(pt);
+       }
     }
 
     // since there was no early exit, add the character envelopes to the placements' envelopes


### PR DESCRIPTION
this fixes a bug with shield+text placement along a line. it seems what was happening previously was that the label box was being expanded to the size of the shield and being used to place text. however, this was not giving the right answer where dx/dy were being used. the patch expands line placement to include "additional boxes", i.e: when searching for a line placement it checks that some boxes offset from the position can be
placed.
