### PR TITLE
Layer envelope calculation fixes

### DIFF
--- a/src/feature_style_processor.cpp
+++ b/src/feature_style_processor.cpp
@@ -250,7 +250,7 @@ void feature_style_processor<Processor>::apply_to_layer(layer const& lay, Proces
     {
         layer_ext.clip(map_ext);
         // forward project layer extent back into native projection
-        if (!prj_trans.forward(layer_ext))
+        if (!prj_trans.forward(layer_ext, PROJ_ENVELOPE_POINTS))
             std::clog << "WARNING: layer " << lay.name()
                 << " extent " << layer_ext << " in map projection "
                 << " did not reproject properly back to layer projection\n";


### PR DESCRIPTION
I've been seeing some features going missing from tiles when projecting from a EPSG4326 layer onto a Robinson-projection map.  After a bit of debugging, it seems that the envelope for the layer isn't getting calculated properly.  This one-line change fixes the rendering in most cases.

The remainder of the cases where the envelope doesn't seem right are tiles on the very edges of the map (specifically around Alaska), where there's a lot of curvature in the Robinson projection.  I can fix this by increasing the PROJ_ENVELOPE_POINTS value.  Would it be useful to make that a configurable parameter on the map definition?

Cheers!

Olly
