### PR TITLE
Building Symbolizer to support height as expression

### DIFF
--- a/include/mapnik/attribute_collector.hpp
+++ b/include/mapnik/attribute_collector.hpp
@@ -213,6 +213,12 @@ struct symbolizer_attributes : public boost::static_visitor<>
 
     void operator () (building_symbolizer const& sym)
     {
+    	expression_ptr const& height_expr = sym.height();
+		if (height_expr)
+		{
+			expression_attributes f_attr(names_);
+			boost::apply_visitor(f_attr,*height_expr);
+		}
         collect_metawriter(sym);
     }
     // TODO - support remaining syms

--- a/include/mapnik/polygon_symbolizer.hpp
+++ b/include/mapnik/polygon_symbolizer.hpp
@@ -26,6 +26,7 @@
 // mapnik
 #include <mapnik/color.hpp>
 #include <mapnik/symbolizer.hpp>
+#include <mapnik/filter_factory.hpp>
 
 namespace mapnik 
 {
@@ -79,11 +80,10 @@ struct MAPNIK_DECL building_symbolizer : public symbolizer_base
     explicit building_symbolizer() 
         : symbolizer_base(),
         fill_(color(128,128,128)),
-        height_(0.0),
         opacity_(1.0)
         {}
        
-    building_symbolizer(color const& fill,double height)
+    building_symbolizer(color const& fill, expression_ptr height)
         : symbolizer_base(),
         fill_(fill),
         height_(height),
@@ -97,11 +97,11 @@ struct MAPNIK_DECL building_symbolizer : public symbolizer_base
     {
         fill_ = fill;
     }
-    double height() const
+    expression_ptr height() const
     {
         return height_;
     }
-    void set_height(double height) 
+    void set_height(expression_ptr height)
     {
         height_=height;
     }
@@ -115,7 +115,7 @@ struct MAPNIK_DECL building_symbolizer : public symbolizer_base
     }
 private:
     color fill_;
-    double height_;
+    expression_ptr height_;
     double opacity_;
 };  
 }

--- a/src/agg/process_building_symbolizer.cpp
+++ b/src/agg/process_building_symbolizer.cpp
@@ -25,6 +25,7 @@
 #include <mapnik/agg_renderer.hpp>
 #include <mapnik/agg_rasterizer.hpp>
 #include <mapnik/segment.hpp>
+#include <mapnik/expression_evaluator.hpp>
 
 // boost
 #include <boost/scoped_ptr.hpp>
@@ -66,7 +67,13 @@ void agg_renderer<T>::process(building_symbolizer const& sym,
     ras_ptr->reset();
     ras_ptr->gamma(agg::gamma_linear());
     
-    double height = sym.height() * scale_factor_;
+    double height = 0.0;
+    expression_ptr height_expr = sym.height();
+    if (height_expr)
+    {
+    	value_type result = boost::apply_visitor(evaluate<Feature,value_type>(feature), *height_expr);
+    	height = result.to_double() * scale_factor_;
+    }
     
     for (unsigned i=0;i<feature.num_geometries();++i)
     {

--- a/src/cairo_renderer.cpp
+++ b/src/cairo_renderer.cpp
@@ -779,7 +779,13 @@ void cairo_renderer_base::process(building_symbolizer const& sym,
     cairo_context context(context_);
 
     color const& fill = sym.get_fill();
-    double height = 0.7071 * sym.height(); // height in meters
+    double height = 0.0;
+	expression_ptr height_expr = sym.height();
+	if (height_expr)
+	{
+		value_type result = boost::apply_visitor(evaluate<Feature,value_type>(feature), *height_expr);
+		height = 0.7071 * result.to_double();
+	}
 
     for (unsigned i = 0; i < feature.num_geometries(); ++i)
     {

--- a/src/grid/process_building_symbolizer.cpp
+++ b/src/grid/process_building_symbolizer.cpp
@@ -28,6 +28,7 @@
 #include <mapnik/grid/grid_pixel.hpp>
 #include <mapnik/grid/grid.hpp>
 #include <mapnik/segment.hpp>
+#include <mapnik/expression_evaluator.hpp>
 
 // boost
 #include <boost/scoped_ptr.hpp>
@@ -59,7 +60,13 @@ void grid_renderer<T>::process(building_symbolizer const& sym,
 
     ras_ptr->reset();
 
-    double height = sym.height() * scale_factor_;
+    double height = 0.0;
+    expression_ptr height_expr = sym.height();
+    if (height_expr)
+    {
+        value_type result = boost::apply_visitor(evaluate<Feature,value_type>(feature), *height_expr);
+        height = result.to_double() * scale_factor_;
+    }
     
     for (unsigned i=0;i<feature.num_geometries();++i)
     {

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -1915,9 +1915,8 @@ void map_parser::parse_building_symbolizer( rule & rule, ptree const & sym )
         optional<double> opacity = get_opt_attr<double>(sym, "fill-opacity");
         if (opacity) building_sym.set_opacity(*opacity);
         // height
-        // TODO - expression
-        optional<double> height = get_opt_attr<double>(sym, "height");
-        if (height) building_sym.set_height(*height);
+        optional<std::string> height = get_opt_attr<std::string>(sym, "height");
+        if (height) building_sym.set_height(parse_expression(*height, "utf8"));
 
         parse_metawriter_in_symbolizer(building_sym, sym);
         rule.append(building_sym);


### PR DESCRIPTION
The enhancement to support height in building symbolizer to be expression from data source, can be useful for rendering buildings in 3d.
