### PR TITLE
Pos counter in shapeindex not incremented for null geometry

### DIFF
--- a/utils/shapeindex/shapeindex.cpp
+++ b/utils/shapeindex/shapeindex.cpp
@@ -165,6 +165,9 @@ int main (int argc,char** argv)
             box2d<double> item_ext;
             if (shape_type==shape_io::shape_null)
             {
+                // still need to increment pos, or the pos counter
+                // won't indicate EOF until too late.
+                pos+=4+content_length;
                 continue;
             }
             else if (shape_type==shape_io::shape_point)


### PR DESCRIPTION
This leads to the termination check at the end of the file not triggering when EOF is reached. This then means that some records may be written with offset >= file_length, which can make Mapnik segfault later on.
