### PR TITLE
make stroke property on line_symbolizer a reference when accessed from python (not a copy)

### DIFF
--- a/bindings/python/mapnik_line_symbolizer.cpp
+++ b/bindings/python/mapnik_line_symbolizer.cpp
@@ -60,7 +60,7 @@ void export_line_symbolizer()
                       "Set/get the rasterization method of the line of the point")
         .add_property("stroke",make_function
                       (&line_symbolizer::get_stroke,
-                       return_value_policy<copy_const_reference>()),
+                       return_value_policy<reference_existing_object>()),
                       &line_symbolizer::set_stroke)
         .add_property("smooth",
                       &line_symbolizer::smooth,

--- a/tests/python_tests/object_test.py
+++ b/tests/python_tests/object_test.py
@@ -21,6 +21,15 @@ def test_line_symbolizer_init():
     s = mapnik.LineSymbolizer()
     eq_(s.rasterizer, mapnik.line_rasterizer.FULL)
 
+def test_line_symbolizer_stroke_reference():
+    l = mapnik.LineSymbolizer(mapnik.Color('green'),0.1)
+    l.stroke.add_dash(.1,.1)
+    l.stroke.add_dash(.1,.1)
+    eq_(l.stroke.get_dashes(), [(.1,.1),(.1,.1)])
+    eq_(l.stroke.color,mapnik.Color('green'))
+    eq_(l.stroke.opacity,1.0)
+    assert_almost_equal(l.stroke.width,0.1)
+
 # ShieldSymbolizer initialization
 def test_shieldsymbolizer_init():
     s = mapnik.ShieldSymbolizer(mapnik.Expression('[Field Name]'), 'DejaVu Sans Bold', 6, mapnik.Color('#000000'), mapnik.PathExpression('../data/images/dummy.png'))


### PR DESCRIPTION
This addresses http://groups.google.com/group/mapnik/browse_thread/thread/1cb39649d6b7baac.

@artemp - how does this look? Boost python will auto convert to shared_ptr under the hood, right?
