### PR TITLE
Avoid dereferencing a null error structure

### DIFF
--- a/src/libxml2_loader.cpp
+++ b/src/libxml2_loader.cpp
@@ -135,11 +135,15 @@ public:
             xmlError * error = xmlCtxtGetLastError( ctx_ );
             std::ostringstream os;
             os << "XML document not well formed";
+	    int line=0;
+	    std::string file;
             if (error)
             {
                 os << ": " << std::endl << error->message;
+		line = error->line;
+		file = error->file;
             }
-            throw config_error(os.str(), error->line, error->file);
+            throw config_error(os.str(), line, file);
         }
 
         int iXIncludeReturn = xmlXIncludeProcessFlags(doc, options_);


### PR DESCRIPTION
This should fix a segfault I was getting when I had a map.xml style that was an empty (zero byte) file.
