### PR TITLE
agg::conv_transform: changed transformer to non-const reference

### DIFF
--- a/deps/agg/include/agg_conv_transform.h
+++ b/deps/agg/include/agg_conv_transform.h
@@ -29,11 +29,8 @@ namespace agg
     template<class VertexSource, class Transformer=trans_affine> class conv_transform
     {
     public:
-        explicit conv_transform(VertexSource& source) :
-            m_source(&source), m_trans() {}
-        
-        conv_transform(VertexSource& source, const Transformer& tr) :
-            m_source(&source), m_trans(tr) {}
+        conv_transform(VertexSource& source, Transformer& tr) :
+            m_source(&source), m_trans(&tr) {}
     
         void attach(VertexSource& source) { m_source = &source; }
     
@@ -47,14 +44,14 @@ namespace agg
             unsigned cmd = m_source->vertex(x, y);
             if(is_vertex(cmd))
             {
-                m_trans.transform(x, y);
+                m_trans->transform(x, y);
             }
             return cmd;
         }
 
-        void transformer(const Transformer& tr)
+        void transformer(Transformer& tr)
         {
-            m_trans = tr;
+            m_trans = &tr;
         }
 
     private:
@@ -63,7 +60,7 @@ namespace agg
             operator = (const conv_transform<VertexSource>&);
 
         VertexSource*      m_source;
-        Transformer        m_trans;
+        const Transformer* m_trans;
     };
 
 

--- a/include/mapnik/vertex_converters.hpp
+++ b/include/mapnik/vertex_converters.hpp
@@ -190,16 +190,21 @@ template <typename T>
 struct converter_traits<T,mapnik::affine_transform_tag>
 {
     typedef T geometry_type;
-    typedef typename agg::conv_transform<geometry_type> conv_type;
+
+    struct conv_type : public agg::conv_transform<geometry_type>
+    {
+        agg::trans_affine trans_;
+
+        conv_type(geometry_type& geom)
+            : agg::conv_transform<geometry_type>(geom, trans_) {}
+    };
 
     template <typename Args>
     static void setup(geometry_type & geom, Args & args)
     {
         typename boost::mpl::at<Args,boost::mpl::int_<2> >::type sym = boost::fusion::at_c<2>(args);
-        agg::trans_affine tr;
         boost::array<double,6> const& m = sym.get_transform();
-        tr.load_from(&m[0]);
-        geom.transformer(tr);
+        geom.trans_.load_from(&m[0]);
     }
 };
 


### PR DESCRIPTION
replaces ba270e0
probably also makes ac9dc47 and b42e498 unnecessary
