### PR TITLE
viewer: show more exception messages

### DIFF
--- a/demo/viewer/mapwidget.cpp
+++ b/demo/viewer/mapwidget.cpp
@@ -486,6 +486,10 @@ void render_agg(mapnik::Map const& map, double scaling_factor, QPixmap & pix)
     {
         std::cerr << ex.what() << std::endl;
     }
+    catch (const std::exception & ex)
+    {
+        std::cerr << "exception: " << ex.what() << std::endl;
+    }
     catch (...)
     {
         std::cerr << "Unknown exception caught!\n";
@@ -521,6 +525,10 @@ void render_grid(mapnik::Map const& map, double scaling_factor, QPixmap & pix)
     catch (mapnik::config_error & ex)
     {
         std::cerr << ex.what() << std::endl;
+    }
+    catch (const std::exception & ex)
+    {
+        std::cerr << "exception: " << ex.what() << std::endl;
     }
     catch (...)
     {


### PR DESCRIPTION
When trying to render the map widget in the viewer, we catch exceptions
and print out the message to stderr. The only exceptions that are printed
are mapnik::config_error messages. mapnik can throw more errors, so this
change makes it catch all std::exceptions.
