### PR TITLE
viewer: add mouse wheel zooming

### DIFF
--- a/demo/viewer/mapwidget.cpp
+++ b/demo/viewer/mapwidget.cpp
@@ -289,6 +289,32 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* e)
    }
 }
 
+void MapWidget::wheelEvent(QWheelEvent* e)
+{
+   if (!map_)
+   {
+      return;
+   }
+
+   QPoint corner(map_->width(), map_->height());
+   QPoint zoomCoords;
+   double zoom;
+   if (e->delta() > 0)
+   {
+      zoom = 0.5;
+      QPoint center = corner / 2;
+      QPoint delta = e->pos() - center;
+      zoomCoords = zoom * delta + center;
+   }
+   else
+   {
+      zoom = 2.0;
+      zoomCoords = corner - e->pos();
+   }
+
+   map_->pan_and_zoom(zoomCoords.x(), zoomCoords.y(), zoom);
+   updateMap();
+}
 
 void MapWidget::keyPressEvent(QKeyEvent *e)
 {

--- a/demo/viewer/mapwidget.hpp
+++ b/demo/viewer/mapwidget.hpp
@@ -99,6 +99,7 @@ protected:
     void mousePressEvent(QMouseEvent* e);
     void mouseMoveEvent(QMouseEvent* e);
     void mouseReleaseEvent(QMouseEvent* e);
+    void wheelEvent(QWheelEvent* e);
     void keyPressEvent(QKeyEvent *e);
     void export_to_file(unsigned width,
                         unsigned height,


### PR DESCRIPTION
This change makes the viewer zoom in and out when using the scroll wheel.
The zoom tracks the position of the mouse pointer when zooming in so that
the map will be centered under the mouse after a zoom.
