### PR TITLE
Rename color-spin composite operation to colorize alpha

### DIFF
--- a/deps/agg/include/agg_pixfmt_rgba.h
+++ b/deps/agg/include/agg_pixfmt_rgba.h
@@ -1433,9 +1433,9 @@ namespace agg
         }
     };
 
-    // color spin
+    // colorize alpha values
     template <typename ColorT, typename Order>
-    struct comp_op_rgba_color_spin
+    struct comp_op_rgba_colorize_alpha
     {
         typedef ColorT color_type;
         typedef Order order_type;
@@ -1762,7 +1762,7 @@ namespace agg
         comp_op_rgba_saturation<ColorT,Order>::blend_pix,
         comp_op_rgba_color<ColorT,Order>::blend_pix,
         comp_op_rgba_value<ColorT,Order>::blend_pix,
-        comp_op_rgba_color_spin<ColorT,Order>::blend_pix,
+        comp_op_rgba_colorize_alpha<ColorT,Order>::blend_pix,
         0
     };
 
@@ -1804,7 +1804,7 @@ namespace agg
         comp_op_saturation,    //----comp_op_saturation
         comp_op_color,         //----comp_op_color
         comp_op_value,         //----comp_op_value
-        comp_op_color_spin,    //----comp_op_color_spin
+        comp_op_colorize_alpha,//----comp_op_colorize_alpha
         end_of_comp_op_e
     };
 

--- a/include/mapnik/image_compositing.hpp
+++ b/include/mapnik/image_compositing.hpp
@@ -75,7 +75,7 @@ enum composite_mode_e
     saturation,
     _color,
     _value,
-    color_spin
+    colorize_alpha
 };
 
 MAPNIK_DECL boost::optional<composite_mode_e> comp_op_from_string(std::string const& name);

--- a/src/cairo_renderer.cpp
+++ b/src/cairo_renderer.cpp
@@ -389,7 +389,7 @@ public:
         case saturation:
         case _color:
         case _value:
-        case color_spin:
+        case colorize_alpha:
             break;
         }
     }

--- a/src/image_compositing.cpp
+++ b/src/image_compositing.cpp
@@ -74,7 +74,7 @@ static const comp_op_lookup_type comp_lookup = boost::assign::list_of<comp_op_lo
     (saturation,"saturation")
     (_color,"color")
     (_value,"value")
-    (color_spin,"color-spin")
+    (colorize_alpha,"colorize-alpha")
     ;
 
 boost::optional<composite_mode_e> comp_op_from_string(std::string const& name)


### PR DESCRIPTION
to make it less confusing alongside actual color manipulation
modes.

Does what it says on the tin - simply renames the mode.
