### PR TITLE
Stock markers support 

### DIFF
--- a/bindings/python/mapnik_markers_symbolizer.cpp
+++ b/bindings/python/mapnik_markers_symbolizer.cpp
@@ -97,7 +97,7 @@ void export_markers_symbolizer()
         ;
 
     class_<markers_symbolizer>("MarkersSymbolizer",
-                               init<>("Default Markers Symbolizer - blue arrow"))
+                               init<>("Default Markers Symbolizer - circle"))
         .def (init<mapnik::path_expression_ptr>("<path expression ptr>"))
         //.def_pickle(markers_symbolizer_pickle_suite())
         .add_property("filename",

--- a/include/mapnik/marker_cache.hpp
+++ b/include/mapnik/marker_cache.hpp
@@ -41,14 +41,21 @@ class marker;
 typedef boost::shared_ptr<marker> marker_ptr;
 
 
-struct MAPNIK_DECL marker_cache :
-        public singleton <marker_cache, CreateStatic>,
+class MAPNIK_DECL marker_cache :
+        public singleton <marker_cache, CreateUsingNew>,
         private boost::noncopyable
 {
-
-    friend class CreateStatic<marker_cache>;
-    static boost::unordered_map<std::string,marker_ptr> cache_;
-    static bool insert(std::string const& key, marker_ptr);
+    friend class CreateUsingNew<marker_cache>;
+private:
+    marker_cache();
+    ~marker_cache();
+    static bool insert_marker(std::string const& key, marker_ptr path);
+    static boost::unordered_map<std::string,marker_ptr> marker_cache_;
+    static bool insert_svg(std::string const& name, std::string const& svg_string);
+    static boost::unordered_map<std::string,std::string> svg_cache_;
+public:
+    static std::string known_svg_prefix_;
+    static bool is_uri(std::string const& path);
     static boost::optional<marker_ptr> find(std::string const& key, bool update_cache = false);
     static void clear();
 };

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -56,6 +56,7 @@
 #include <mapnik/config_error.hpp>
 #include <mapnik/util/dasharray_parser.hpp>
 #include <mapnik/util/conversions.hpp>
+#include <mapnik/marker_cache.hpp>
 
 // boost
 #include <boost/optional.hpp>
@@ -987,15 +988,35 @@ void map_parser::parse_markers_symbolizer(rule & rule, xml_node const& node)
             }
         }
 
-        path_expression_ptr expr(boost::make_shared<path_expression>());
+        optional<std::string> marker_type = node.get_opt_attr<std::string>("marker-type");
+        if (marker_type)
+        {
+            MAPNIK_LOG_ERROR(markers_symbolizer) << "'marker-type' is deprecated and will be removed in Mapnik 3.x, use file='shape://<type>' to specify known svg shapes";
+            // back compatibility with Mapnik 2.0.0
+            if (!marker_type->empty() && filename.empty())
+            {
+                if (*marker_type == "ellipse")
+                {
+                    filename = marker_cache::known_svg_prefix_ + "ellipse";
+                }
+                else if (*marker_type == "arrow")
+                {
+                    filename = marker_cache::known_svg_prefix_ + "arrow";
+                }
+            }
+        }
+
+        markers_symbolizer sym;
+
         if (!filename.empty())
         {
+            path_expression_ptr expr(boost::make_shared<path_expression>());
             if (!parse_path_from_string(expr, filename, node.get_tree().path_expr_grammar))
             {
                 throw mapnik::config_error("Failed to parse path_expression '" + filename + "'");
             }
+            sym.set_filename(expr);
         }
-        markers_symbolizer sym(expr);
 
         optional<float> opacity = node.get_opt_attr<float>("opacity");
         if (opacity) sym.set_opacity(*opacity);
@@ -1610,6 +1631,9 @@ void map_parser::ensure_font_face(std::string const& face_name)
 
 std::string map_parser::ensure_relative_to_xml(boost::optional<std::string> opt_path)
 {
+    if (marker_cache::is_uri(*opt_path))
+        return *opt_path;
+
     if (relative_to_xml_)
     {
         boost::filesystem::path xml_path = filename_;

--- a/src/markers_symbolizer.cpp
+++ b/src/markers_symbolizer.cpp
@@ -37,7 +37,7 @@ static const char * marker_placement_strings[] = {
 IMPLEMENT_ENUM( marker_placement_e, marker_placement_strings )
 
 markers_symbolizer::markers_symbolizer()
-    : symbolizer_with_image(path_expression_ptr(new path_expression)),
+    : symbolizer_with_image(parse_path("shape://ellipse")),
       symbolizer_base(),
       width_(),
       height_(),
@@ -45,7 +45,7 @@ markers_symbolizer::markers_symbolizer()
       allow_overlap_(false),
       spacing_(100.0),
       max_error_(0.2),
-      marker_p_(MARKER_LINE_PLACEMENT) {}
+      marker_p_(MARKER_POINT_PLACEMENT) {}
 
 markers_symbolizer::markers_symbolizer(path_expression_ptr const& filename)
     : symbolizer_with_image(filename),
@@ -56,7 +56,7 @@ markers_symbolizer::markers_symbolizer(path_expression_ptr const& filename)
       allow_overlap_(false),
       spacing_(100.0),
       max_error_(0.2),
-      marker_p_(MARKER_LINE_PLACEMENT) {}
+      marker_p_(MARKER_POINT_PLACEMENT) {}
 
 markers_symbolizer::markers_symbolizer(markers_symbolizer const& rhs)
     : symbolizer_with_image(rhs),


### PR DESCRIPTION
Implement built in support for ellipse and arrow markers, make markers_symbolizer default to POINT placement and ellipse drawing, add back compatibility for deprecated marker-type property - refs #1285 and #1304
