### PR TITLE
Add set_name method to font_set

### DIFF
--- a/include/mapnik/font_set.hpp
+++ b/include/mapnik/font_set.hpp
@@ -40,6 +40,7 @@ public:
     font_set(font_set const& rhs);
     font_set& operator=(font_set const& rhs);
     unsigned size() const;
+    void set_name(std::string const& name);
     std::string const& get_name() const;
     void add_face_name(std::string);
     std::vector<std::string> const& get_face_names() const;

--- a/src/font_set.cpp
+++ b/src/font_set.cpp
@@ -61,6 +61,11 @@ void font_set::add_face_name(std::string face_name)
     face_names_.push_back(face_name);
 }
 
+void font_set::set_name(std::string const& name)
+{
+    name_ = name;
+}
+
 std::string const& font_set::get_name() const
 {
     return name_;


### PR DESCRIPTION
Minor addition to the font_set class to make some code in the carto parser cleaner. See commit f68d7e4c0903615fbc89ce2c9cef39743d6f3eb9.
