### PR TITLE
Offset enabled for LinePatternSymbolizer

### DIFF
--- a/include/mapnik/line_pattern_symbolizer.hpp
+++ b/include/mapnik/line_pattern_symbolizer.hpp
@@ -34,6 +34,9 @@ struct MAPNIK_DECL line_pattern_symbolizer :
 {
     line_pattern_symbolizer(path_expression_ptr file);
     line_pattern_symbolizer(line_pattern_symbolizer const& rhs);
+    double offset_;
+    double offset() const;
+    void set_offset(double offset);
 };
 }
 

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -102,6 +102,8 @@ void  agg_renderer<T>::process(line_pattern_symbolizer const& sym,
         float half_stroke = (*mark)->width()/2.0;
         if (half_stroke > 1)
             padding *= half_stroke;
+        if (fabs(sym.offset()) > 0)
+            padding *= fabs(sym.offset()) * 1.2;
         double x0 = query_extent_.minx();
         double y0 = query_extent_.miny();
         double x1 = query_extent_.maxx();
@@ -109,13 +111,14 @@ void  agg_renderer<T>::process(line_pattern_symbolizer const& sym,
         clipping_extent.init(x0 - padding, y0 - padding, x1 + padding , y1 + padding);
     }
 
-    typedef boost::mpl::vector<clip_line_tag,transform_tag,smooth_tag> conv_types;
+    typedef boost::mpl::vector<clip_line_tag,transform_tag,offset_transform_tag,smooth_tag> conv_types;
     vertex_converter<box2d<double>, rasterizer_type, line_pattern_symbolizer,
                      CoordTransform, proj_transform, agg::trans_affine, conv_types>
         converter(clipping_extent,ras,sym,t_,prj_trans,tr,scale_factor_);
 
     if (sym.clip()) converter.set<clip_line_tag>(); //optional clip (default: true)
     converter.set<transform_tag>(); //always transform
+    if (fabs(sym.offset()) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
     if (sym.smooth() > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
     BOOST_FOREACH(geometry_type & geom, feature.paths())

--- a/src/line_pattern_symbolizer.cpp
+++ b/src/line_pattern_symbolizer.cpp
@@ -27,9 +27,19 @@ namespace mapnik
 {
 
 line_pattern_symbolizer::line_pattern_symbolizer(path_expression_ptr file)
-    : symbolizer_with_image(file), symbolizer_base() {}
+    : symbolizer_with_image(file), symbolizer_base(), offset_(0.0) {}
 
 line_pattern_symbolizer::line_pattern_symbolizer(line_pattern_symbolizer const& rhs)
-    : symbolizer_with_image(rhs), symbolizer_base(rhs) {}
+    : symbolizer_with_image(rhs), symbolizer_base(rhs), offset_(rhs.offset_) {}
+
+double line_pattern_symbolizer::offset() const
+{
+    return offset_;
+}
+
+void line_pattern_symbolizer::set_offset(double offset)
+{
+    offset_=offset;
+}
 
 }

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -1050,9 +1050,14 @@ void map_parser::parse_line_pattern_symbolizer(rule & rule, xml_node const & sym
             }
         }
 
+
         file = ensure_relative_to_xml(file);
         ensure_exists(file);
         line_pattern_symbolizer symbol( parse_path(file, sym.get_tree().path_expr_grammar) );
+
+        // offset value
+        optional<double> offset = sym.get_opt_attr<double>("offset");
+        if (offset) symbol.set_offset(*offset);
 
         parse_symbolizer_base(symbol, sym);
         rule.append(symbol);

--- a/src/save_map.cpp
+++ b/src/save_map.cpp
@@ -107,6 +107,11 @@ public:
             ptree::value_type("LinePatternSymbolizer",
                               ptree()))->second;
 
+        if (sym.offset() != 0.0 || explicit_defaults_ )
+        {
+            set_attr( sym_node, "offset", sym.offset() );
+        }
+
         add_image_attributes( sym_node, sym );
         serialize_symbolizer_base(sym_node, sym);
     }


### PR DESCRIPTION
Partial fix for #1241, which enables offsetting of  LinePatternSymbolizer.
