### PR TITLE
Ensure proper exit code on any test failure. See #1611

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,7 @@ uninstall:
 	python scons/scons.py --config=cache --implicit-cache --max-drift=1 uninstall
 
 test:
-	@echo "*** Running visual tests..."
-	@python tests/visual_tests/test.py -q || true
-	@echo "*** Running C++ tests..."
-	@for FILE in tests/cpp_tests/*-bin; do \
-		$${FILE}; \
-	done
-	@echo "*** Running python tests..."
-	@python tests/run_tests.py -q
+	./run_tests
 
 test-local:
 	@echo "*** Boostrapping local test environment..."

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+failures=0
+
+echo "*** Running visual tests..."
+python tests/visual_tests/test.py -q
+failures=$((failures+$?))
+
+echo "*** Running C++ tests..."
+for FILE in tests/cpp_tests/*-bin; do 
+	${FILE};
+  failures=$((failures+$?))
+done
+
+echo "*** Running python tests..."
+python tests/run_tests.py -q
+failures=$((failures+$?))
+
+exit $failures


### PR DESCRIPTION
Uses a shell script to run the tests.
