### PR TITLE
Fix support for literals in postgis plugin

### DIFF
--- a/plugins/input/postgis/postgis_featureset.cpp
+++ b/plugins/input/postgis/postgis_featureset.cpp
@@ -174,6 +174,7 @@ feature_ptr postgis_featureset::next()
 
                     case 25:   //text
                     case 1043: //varchar
+                    case 705: //literal (unknown)
                     {
                         feature->put(name, tr_->transcode(buf));
                         break;


### PR DESCRIPTION
REF: #1626, #1464
