### PR TITLE
Loosen simplification factor to 1/20 of pixel

### DIFF
--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -655,7 +655,10 @@ featureset_ptr postgis_datasource::features(const query& q) const
             s << "\"" << geometryColumn_ << "\"";
 
             if (simplify_geometries_) {
-              const double tolerance = std::min(px_gw, px_gh) / 2.0;
+              // 1/20 of pixel seems to be a good compromise to avoid
+              // drop of collapsed polygons.
+              // See https://github.com/mapnik/mapnik/issues/1639
+              const double tolerance = std::min(px_gw, px_gh) / 20.0;
               s << ", " << tolerance << ")";
             }
 


### PR DESCRIPTION
Reduce default simplification to 1/20 of pixel size.
See https://github.com/mapnik/mapnik/issues/1639
