### PR TITLE
default to fast, simple, and correct (per ostringstream) to_string conversions

### DIFF
--- a/tests/cpp_tests/conversions_test.cpp
+++ b/tests/cpp_tests/conversions_test.cpp
@@ -1,4 +1,5 @@
 #include <boost/version.hpp>
+#include <mapnik/value_types.hpp>
 #include <mapnik/util/conversions.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <iostream>
@@ -69,16 +70,104 @@ int main( int, char*[] )
         BOOST_TEST_EQ( out,  "0.000123457" );
         out.clear();
     
-        to_string(out, double(1000000000000000));
-        BOOST_TEST_EQ( out,  "1000000000000000" );
+        to_string(out, double(0.0001));
+        BOOST_TEST_EQ( out,  "0.0001" );
         out.clear();
-    
+
+        to_string(out, double(0.00001));
+        BOOST_TEST_EQ( out,  "1e-05" );
+        out.clear();
+
+        to_string(out, double(0.000001));
+        BOOST_TEST_EQ( out,  "1e-06" );
+        out.clear();
+
+        to_string(out, double(0.0000001));
+        BOOST_TEST_EQ( out,  "1e-07" );
+        out.clear();
+
+        to_string(out, double(0.00000001));
+        BOOST_TEST_EQ( out,  "1e-08" );
+        out.clear();
+
+        to_string(out, double(0.000000001));
+        BOOST_TEST_EQ( out,  "1e-09" );
+        out.clear();
+
+        to_string(out, double(0.0000000001));
+        BOOST_TEST_EQ( out,  "1e-10" );
+        out.clear();
+
+        to_string(out, double(0.00000000001));
+        BOOST_TEST_EQ( out,  "1e-11" );
+        out.clear();
+
+        to_string(out, double(0.000000000001));
+        BOOST_TEST_EQ( out,  "1e-12" );
+        out.clear();
+
+        to_string(out, double(0.0000000000001));
+        BOOST_TEST_EQ( out,  "1e-13" );
+        out.clear();
+
+        to_string(out, double(0.00000000000001));
+        BOOST_TEST_EQ( out,  "1e-14" );
+        out.clear();
+
+        to_string(out, double(0.000000000000001));
+        BOOST_TEST_EQ( out,  "1e-15" );
+        out.clear();
+
+        to_string(out, double(100000));
+        BOOST_TEST_EQ( out,  "100000" );
+        out.clear();
+
+        to_string(out, double(1000000));
+        BOOST_TEST_EQ( out,  "1e+06" );
+        out.clear();
+
+        to_string(out, double(10000000));
+        BOOST_TEST_EQ( out,  "1e+07" );
+        out.clear();
+
+        to_string(out, double(100000000));
+        BOOST_TEST_EQ( out,  "1e+08" );
+        out.clear();
+
+        to_string(out, double(1000000000));
+        BOOST_TEST_EQ( out,  "1e+09" );
+        out.clear();
+
+        to_string(out, double(10000000000));
+        BOOST_TEST_EQ( out,  "1e+10" );
+        out.clear();
+
+        to_string(out, double(100000000000));
+        BOOST_TEST_EQ( out,  "1e+11" );
+        out.clear();
+
+        to_string(out, double(1000000000000));
+        BOOST_TEST_EQ( out,  "1e+12" );
+        out.clear();
+
+        to_string(out, double(10000000000000));
+        BOOST_TEST_EQ( out,  "1e+13" );
+        out.clear();
+
+        to_string(out, double(100000000000000));
+        BOOST_TEST_EQ( out,  "1e+14" );
+        out.clear();
+
+        to_string(out, double(1000000000000005));
+        BOOST_TEST_EQ( out,  "1e+15" );
+        out.clear();
+
         to_string(out, double(-1000000000000000));
-        BOOST_TEST_EQ( out,  "-1000000000000000" );
+        BOOST_TEST_EQ( out,  "-1e+15" );
         out.clear();
     
         to_string(out, double(100000000000000.1));
-        BOOST_TEST_EQ( out,  "100000000000000.1" );
+        BOOST_TEST_EQ( out,  "1e+14" );
         out.clear();
     
         to_string(out, double(1.00001));
@@ -86,7 +175,11 @@ int main( int, char*[] )
         out.clear();
     
         to_string(out, double(1234000000000000));
-        BOOST_TEST_EQ( out,  "1234000000000000" );
+        BOOST_TEST_EQ( out,  "1.234e+15" );
+        out.clear();
+
+        to_string(out, double(1e+16));
+        BOOST_TEST_EQ( out,  "1e+16" );
         out.clear();
     
         to_string(out, double(1.234e+16));
@@ -96,11 +189,58 @@ int main( int, char*[] )
         to_string(out, double(-1.234e+16));
         BOOST_TEST_EQ( out,  "-1.234e+16" );
         out.clear();
+        // https://github.com/mapbox/tilemill/issues/1456
+        to_string(out, double(8.3));
+        BOOST_TEST_EQ( out,  "8.3" );
+        out.clear();
     
-        // Test int
-    
-        to_string(out,   int(2));
+        // int
+        to_string(out, int(2));
         BOOST_TEST_EQ( out, "2" );
+        out.clear();
+
+        to_string(out, int(0));
+        BOOST_TEST_EQ( out, "0" );
+        out.clear();
+
+        to_string(out, int(-2));
+        BOOST_TEST_EQ( out, "-2" );
+        out.clear();
+
+        to_string(out, int(2147483647));
+        BOOST_TEST_EQ( out, "2147483647" );
+        out.clear();
+
+        to_string(out, int(-2147483648));
+        BOOST_TEST_EQ( out, "-2147483648" );
+        out.clear();
+
+        // unsigned
+        to_string(out, unsigned(4294967295));
+        BOOST_TEST_EQ( out, "4294967295" );
+        out.clear();
+
+#ifdef BIGINT
+        // long long
+        to_string(out,mapnik::value_integer(-0));
+        BOOST_TEST_EQ( out, "0" );
+        out.clear();
+
+        to_string(out,mapnik::value_integer(-2));
+        BOOST_TEST_EQ( out, "-2" );
+        out.clear();
+
+        to_string(out,mapnik::value_integer(9223372036854775807));
+        BOOST_TEST_EQ( out, "9223372036854775807" );
+        out.clear();
+#endif
+        // bool
+        to_string(out, true);
+        BOOST_TEST_EQ( out, "true" );
+        out.clear();
+
+        to_string(out, false);
+        BOOST_TEST_EQ( out, "false" );
         out.clear();
     }
     catch (std::exception const & ex)


### PR DESCRIPTION
I propose simply using `snprintf` for converting built in types to strings. The reasons are:

1) This enables us to avoid the mixed usage of lexical_cast and karma, both can be dropped from use in conversions.cpp

2) `snprintf` output can easily be made to match exactly the output of `ostringstream`, which I think is desirable (this patch does this and updates the expected values in the tests). The original reason we switched from `ostringstream` to karma was due to performance in a threaded context (not needing locale based output). But the unintended consequence is odd formatting results (compared to `ostringstream`) using karma and the overhead of trying to fix this.

3) the `snprintf` approach is overall faster than karma as well, especially on os x, though karma on ubuntu might be slightly faster in a threaded context. BTW, if we find we really need more speed, then we should take a look at using http://code.google.com/p/double-conversion/.

4) This fixes existing bug reports where `8.3` becomes `8.30000000001` in text labels, which is a karma bug: #1207

To back up my assertions I've done some benchmarking using `benchmark/run.cpp`. A simple test of conversion of `8.300000000000001` gives these results:
## std::ostringstream

1150 milliseconds (osx)
1430 milliseconds (ubuntu)
threaded -> 8100 milliseconds (ubuntu)
threaded -> 121210 milliseconds (osx)
## karma

1090 milliseconds (osx, boost-trunk)
1340 milliseconds (ubuntu, boost 1.49)
threaded -> 3170 milliseconds (osx boost-trunk)
threaded -> 1740 milliseconds (ubuntu, boost 1.49) **fastest**
## snprintf

820 milliseconds (osx) **fastest**
1040 milliseconds (ubuntu) **fastest**
threaded -> 2410 milliseconds (osx) **fastest**
threaded -> 3060 milliseconds (ubuntu)

Also, with the updated tests all tests pass when using `ostringstream` or the new `sprintf` methods, but these are the failures when karma is enabled (so places where our current karma impl still fails to match `ostreamstring`). Failures are the same for OS X and Ubuntu:

``` sh
tests/cpp_tests/conversions_test.cpp(70): test 'out == "0.000123457"' failed in function 'int main(int, char **)': '0.0001234567890123' != '0.000123457'
tests/cpp_tests/conversions_test.cpp(102): test 'out == "1e-11"' failed in function 'int main(int, char **)': '0.9999999999999998e-11' != '1e-11'
tests/cpp_tests/conversions_test.cpp(126): test 'out == "1e+06"' failed in function 'int main(int, char **)': '1000000' != '1e+06'
tests/cpp_tests/conversions_test.cpp(130): test 'out == "1e+07"' failed in function 'int main(int, char **)': '10000000' != '1e+07'
tests/cpp_tests/conversions_test.cpp(134): test 'out == "1e+08"' failed in function 'int main(int, char **)': '100000000' != '1e+08'
tests/cpp_tests/conversions_test.cpp(138): test 'out == "1e+09"' failed in function 'int main(int, char **)': '1000000000' != '1e+09'
tests/cpp_tests/conversions_test.cpp(142): test 'out == "1e+10"' failed in function 'int main(int, char **)': '10000000000' != '1e+10'
tests/cpp_tests/conversions_test.cpp(146): test 'out == "1e+11"' failed in function 'int main(int, char **)': '100000000000' != '1e+11'
tests/cpp_tests/conversions_test.cpp(150): test 'out == "1e+12"' failed in function 'int main(int, char **)': '1000000000000' != '1e+12'
tests/cpp_tests/conversions_test.cpp(154): test 'out == "1e+13"' failed in function 'int main(int, char **)': '10000000000000' != '1e+13'
tests/cpp_tests/conversions_test.cpp(158): test 'out == "1e+14"' failed in function 'int main(int, char **)': '100000000000000' != '1e+14'
tests/cpp_tests/conversions_test.cpp(162): test 'out == "1e+15"' failed in function 'int main(int, char **)': '1000000000000005' != '1e+15'
tests/cpp_tests/conversions_test.cpp(166): test 'out == "-1e+15"' failed in function 'int main(int, char **)': '-1000000000000000' != '-1e+15'
tests/cpp_tests/conversions_test.cpp(170): test 'out == "1e+14"' failed in function 'int main(int, char **)': '100000000000000.1' != '1e+14'
tests/cpp_tests/conversions_test.cpp(178): test 'out == "1.234e+15"' failed in function 'int main(int, char **)': '1234000000000000' != '1.234e+15'
tests/cpp_tests/conversions_test.cpp(194): test 'out == "8.3"' failed in function 'int main(int, char **)': '8.300000000000001' != '8.3'
```
