### PR TITLE
Support boost::hash() for mapnik::value

### DIFF
--- a/include/mapnik/unicode.hpp
+++ b/include/mapnik/unicode.hpp
@@ -51,4 +51,10 @@ private:
 };
 }
 
+namespace icu_50 {
+inline std::size_t hash_value(const UnicodeString& val) {
+    return val.hashCode();
+}
+}
+
 #endif // MAPNIK_UNICODE_HPP

--- a/include/mapnik/value.hpp
+++ b/include/mapnik/value.hpp
@@ -36,6 +36,7 @@
 #include <boost/variant/variant.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/concept_check.hpp>
+#include <boost/functional/hash.hpp>
 
 // stl
 #include <iostream>
@@ -903,6 +904,10 @@ operator << (std::basic_ostream<charT,traits>& out,
 {
     out << v.to_string();
     return out;
+}
+
+inline std::size_t hash_value(const value& val) {
+    return hash_value(val.base());
 }
 
 } // namespace value_adl_barrier

--- a/include/mapnik/value_types.hpp
+++ b/include/mapnik/value_types.hpp
@@ -78,6 +78,10 @@ struct value_null
     }
 };
 
+inline std::size_t hash_value(const value_null& val) {
+    return 0;
+}
+
 inline std::ostream& operator<< (std::ostream & out,value_null const& v)
 {
     return out;


### PR DESCRIPTION
Allows using data structures that call `boost::hash()`, such as `boost::unordered_map`.
