### PR TITLE
Add a fix for compiling mapnik against boost 1.53.0.

### DIFF
--- a/include/mapnik/json/feature_collection_grammar.hpp
+++ b/include/mapnik/json/feature_collection_grammar.hpp
@@ -87,7 +87,7 @@ struct feature_collection_grammar :
             > lit(']')
             ;
         
-        feature = eps[_a = construct<mapnik::feature_ptr>(new_<mapnik::feature_impl>(ctx_,generate_id_()))]
+        feature = eps[_a = phoenix::construct<mapnik::feature_ptr>(new_<mapnik::feature_impl>(ctx_,generate_id_()))]
             >> feature_g(*_a)[push_back(_r1,_a)]
             ;
         


### PR DESCRIPTION
I had trouble compiling mapnik on RHEL 6 with boost 1.53.0. This patch fixed my particular problem, and it didn't break the compilation on clang either.

Qualify the call to phoenix::construct so that the compiler on RHEL6
(gcc (GCC) 4.4.6 20120305 (Red Hat 4.4.6-4)) doesn't complain. The
compiler complains that "boost::phoenix::tag::construct" is not a function.

I am willing to refine this patch until it fits your coding style.

---

FYI,  I tested with clang:
Apple LLVM version 4.2 (clang-425.0.27) (based on LLVM 3.2svn)
Target: x86_64-apple-darwin12.3.0
Thread model: posix
