### PR TITLE
remove ltdl

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -68,7 +68,6 @@ pretty_dep_names = {
     'tiff':'TIFF C library | configure with TIFF_LIBS & TIFF_INCLUDES',
     'png':'PNG C library | configure with PNG_LIBS & PNG_INCLUDES',
     'icuuc':'ICU C++ library | configure with ICU_LIBS & ICU_INCLUDES or use ICU_LIB_NAME to specify custom lib name  | more info: http://site.icu-project.org/',
-    'ltdl':'GNU Libtool | more info: http://www.gnu.org/software/libtool',
     'z':'Z compression library | more info: http://www.zlib.net/',
     'm':'Basic math library, part of C++ stlib',
     'pkg-config':'pkg-config tool | more info: http://pkg-config.freedesktop.org',
@@ -309,8 +308,6 @@ opts.AddVariables(
     PathVariable('ICU_LIBS','Search path for ICU include files','/usr/' + LIBDIR_SCHEMA_DEFAULT, PathVariable.PathAccept),
     ('ICU_LIB_NAME', 'The library name for icu (such as icuuc, sicuuc, or icucore)', 'icuuc',
 PathVariable.PathAccept),
-    PathVariable('LTDL_INCLUDES', 'Search path for libltdl (part of libtool) include files', '/usr/include', PathVariable.PathAccept),
-    PathVariable('LTDL_LIBS','Search path for libltdl (ltdl.h) library files','/usr/' + LIBDIR_SCHEMA_DEFAULT, PathVariable.PathAccept),
     BoolVariable('PNG', 'Build Mapnik with PNG read and write support', 'True'),
     PathVariable('PNG_INCLUDES', 'Search path for libpng include files', '/usr/include', PathVariable.PathAccept),
     PathVariable('PNG_LIBS','Search path for libpng library files','/usr/' + LIBDIR_SCHEMA_DEFAULT, PathVariable.PathAccept),
@@ -1115,7 +1112,7 @@ if not preconfigured:
 
     # Adding the required prerequisite library directories to the include path for
     # compiling and the library path for linking, respectively.
-    for required in ('ICU', 'SQLITE', 'LTDL'):
+    for required in ('ICU', 'SQLITE'):
         inc_path = env['%s_INCLUDES' % required]
         lib_path = env['%s_LIBS' % required]
         env.AppendUnique(CPPPATH = os.path.realpath(inc_path))
@@ -1140,7 +1137,6 @@ if not preconfigured:
 
     LIBSHEADERS = [
         ['z', 'zlib.h', True,'C'],
-        ['ltdl', 'ltdl.h', True,'C'],
         [env['ICU_LIB_NAME'],'unicode/unistr.h',True,'C++'],
     ]
 

--- a/include/mapnik/datasource_cache.hpp
+++ b/include/mapnik/datasource_cache.hpp
@@ -35,8 +35,6 @@
 // stl
 #include <map>
 
-struct lt__handle;
-
 namespace mapnik {
 
 class PluginInfo;
@@ -57,7 +55,6 @@ private:
     ~datasource_cache();
     std::map<std::string,boost::shared_ptr<PluginInfo> > plugins_;
     bool registered_;
-    bool insert(std::string const& name,lt__handle * const module);
     std::vector<std::string> plugin_directories_;
 };
 }

--- a/include/mapnik/plugin.hpp
+++ b/include/mapnik/plugin.hpp
@@ -29,21 +29,29 @@
 // stl
 #include <string>
 
-// ltdl
-#include <ltdl.h>
-
 namespace mapnik
 {
+
+//  Opaque structure for handle
+typedef struct _mapnik_lib_t mapnik_lib_t;
+
 class PluginInfo : mapnik::noncopyable
 {
-private:
-    std::string name_;
-    lt_dlhandle module_;
 public:
-    PluginInfo (std::string const& name,const lt_dlhandle module);
+    typedef const char * name_func();
+    PluginInfo (std::string const& filename,
+                std::string const& library_name);
     ~PluginInfo();
     std::string const& name() const;
-    lt_dlhandle handle() const;
+    bool valid() const;
+    std::string get_error() const;
+    void * get_symbol(std::string const& sym_name) const;
+    static void init();
+    static void exit();
+private:
+    std::string filename_;
+    std::string name_;
+    mapnik_lib_t * module_;
 };
 }
 

--- a/src/build.py
+++ b/src/build.py
@@ -57,7 +57,7 @@ regex = 'boost_regex%s' % env['BOOST_APPEND']
 system = 'boost_system%s' % env['BOOST_APPEND']
 
 # clear out and re-set libs for this env
-lib_env['LIBS'] = ['freetype','ltdl','z',env['ICU_LIB_NAME'],filesystem,system,regex]
+lib_env['LIBS'] = ['freetype','z',env['ICU_LIB_NAME'],filesystem,system,regex]
 
 if env['PROJ']:
    lib_env['LIBS'].append('proj')


### PR DESCRIPTION
ltdl is used for dynamic loading of datasource plugins in Mapnik. But it can be hard to compile on windows and is unneeded on all other platforms. On Windows we can avoid it by calling Windows api's and on On OS X 10.8 apple stopped providing ltdl but dlopen/dlfcn.h is available and the recommended way: https://developer.apple.com/library/mac/#documentation/developertools/Reference/MachOReference/Reference/reference.html

I have also researched other toolkits and how they support dynamic loading in a cross platform way and tools like gdb, llvm, and node.js/libuv also take this approach of using windows apis directly and otherwise just dlopen.

One thing this patch does not do is leverage/report any errors from `dlopen`. Honestly I don't think this is critical. Ltdl provided an api to get errors but it was so buggy I ultimately disabled it. So, not accessing errors from dlopen/LoadLibrary does not regress any functionality at all. In the future we could consider adding this if it seems needed, but I think we should not mess with custom errors for now.
