### PR TITLE
shape.input: keep shared ptr to mapped region

### DIFF
--- a/plugins/input/shape/dbfile.cpp
+++ b/plugins/input/shape/dbfile.cpp
@@ -62,7 +62,12 @@ dbf_file::dbf_file(std::string const& file_name)
     boost::optional<mapnik::mapped_region_ptr> memory = mapped_memory_cache::instance().find(file_name,true);
     if (memory)
     {
+        mapped_region_ = *memory;
         file_.buffer(static_cast<char*>((*memory)->get_address()),(*memory)->get_size());
+    }
+    else
+    {
+        throw std::runtime_error("could not create file mapping for "+file_name);
     }
 #endif
     if (file_)

--- a/plugins/input/shape/dbfile.hpp
+++ b/plugins/input/shape/dbfile.hpp
@@ -27,6 +27,7 @@
 #include <mapnik/feature.hpp>
 #include <mapnik/noncopyable.hpp>
 #include <mapnik/unicode.hpp>
+#include <mapnik/mapped_memory_cache.hpp>
 
 // boost
 #include <boost/interprocess/streams/bufferstream.hpp>
@@ -57,6 +58,7 @@ private:
     std::vector<field_descriptor> fields_;
 #ifdef SHAPE_MEMORY_MAPPED_FILE
     boost::interprocess::ibufferstream file_;
+    mapnik::mapped_region_ptr mapped_region_;
 #else
     std::ifstream file_;
 #endif

--- a/plugins/input/shape/shapefile.hpp
+++ b/plugins/input/shape/shapefile.hpp
@@ -138,6 +138,7 @@ public:
 #ifdef SHAPE_MEMORY_MAPPED_FILE
     typedef ibufferstream file_source_type;
     typedef shape_record<MappedRecordTag> record_type;
+    mapnik::mapped_region_ptr mapped_region_;
 #else
     typedef std::ifstream file_source_type;
     typedef shape_record<RecordTag> record_type;
@@ -162,7 +163,12 @@ public:
 
         if (memory)
         {
-            file_.buffer(static_cast<char*>((*memory)->get_address()), (*memory)->get_size());
+            mapped_region_ = *memory;
+            file_.buffer(static_cast<char*>((*memory)->get_address()),(*memory)->get_size());
+        }
+        else
+        {
+            throw std::runtime_error("could not create file mapping for "+file_name);
         }
 #endif
     }


### PR DESCRIPTION
Avoids a potential crash if a mapped region is deleted from the global cache but still in use by the shape.input.

Fixes #1877.
