### PR TITLE
Added missing dependency to pg_config to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,9 @@ Optional dependencies:
  * Cairo >= 1.6.0 - Graphics library for output formats like PDF, PS, and SVG
     - pkg-config - Required for building with cairo support
     - pycairo - Python bindings for cairo
- * libpq - PostgreSQL libraries (For PostGIS plugin support)
+ * PostgreSQL (for PostGIS plugin support)
+    - libpq - PostreSQL libraries
+    - pg_config - PostgreSQL installation capabilities
  * libgdal - GDAL/OGR input (For gdal and ogr plugin support)
  * libsqlite3 - SQLite input (needs RTree support builtin) (sqlite plugin support)
  * libocci - Oracle input plugin support


### PR DESCRIPTION
According to the configure script mapnik has an optional dependency to pg_config provided by PostgreSQL. This dependency should be mentioned in INSTALL.md
