### PR TITLE
Link mapnik to dl on linux

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -118,6 +118,7 @@ else: # unix, non-macos
             mapnik_lib_link_flag += ' -Wl,-h,%s' %  mapnik_libname
     else: # Linux and others
         mapnik_lib_link_flag += ' -Wl,-rpath-link,. -Wl,-soname,%s' % mapnik_libname
+        lib_env['LIBS'].append('dl')
 
 source = Split(
     """


### PR DESCRIPTION
Linux/debian build complains about missing dl symbols otherwise.
