### PR TITLE
Implement the python datasource in the python bindings

### DIFF
--- a/bindings/python/mapnik/__init__.py
+++ b/bindings/python/mapnik/__init__.py
@@ -605,17 +605,6 @@ def Osm(**keywords):
     keywords['type'] = 'osm'
     return CreateDatasource(keywords)
 
-def Python(**keywords):
-    """Create a Python Datasource.
-
-    >>> from mapnik import Python, PythonDatasource
-    >>> datasource = Python('PythonDataSource')
-    >>> lyr = Layer('Python datasource')
-    >>> lyr.datasource = datasource
-    """
-    keywords['type'] = 'python'
-    return CreateDatasource(keywords)
-
 class PythonDatasource(object):
     """A base class for a Python data source.
 

--- a/bindings/python/mapnik_datasource.cpp
+++ b/bindings/python/mapnik_datasource.cpp
@@ -209,7 +209,7 @@ void export_datasource()
         .def("num_features",&memory_datasource::size)
         ;
 
-    class_<mapnik::python_datasource, bases<datasource>, //boost::shared_ptr<mapnik::python_datasource>,
+    class_<mapnik::python_datasource, bases<datasource>,
         boost::noncopyable>("PythonDatasource",
             "This class represents a python datasource", no_init)
         ;

--- a/bindings/python/mapnik_datasource.cpp
+++ b/bindings/python/mapnik_datasource.cpp
@@ -38,6 +38,8 @@
 #include <mapnik/feature_layer_desc.hpp>
 #include <mapnik/memory_datasource.hpp>
 
+#include "python_datasource.hpp"
+
 
 using mapnik::datasource;
 using mapnik::memory_datasource;
@@ -152,7 +154,15 @@ boost::python::list field_types(boost::shared_ptr<mapnik::datasource> const& ds)
         }
     }
     return fld_types;
-}}
+}
+
+boost::shared_ptr<mapnik::datasource> create_python_datasource(boost::python::object ds)
+{
+    return mapnik::datasource_ptr(new mapnik::python_datasource(ds));
+}
+
+} // end anonymous namespace
+
 
 mapnik::parameters const& (mapnik::datasource::*params_const)() const =  &mapnik::datasource::params;
 
@@ -198,4 +208,12 @@ void export_datasource()
              ">>> ms.add_feature(Feature(1))\n")
         .def("num_features",&memory_datasource::size)
         ;
+
+    class_<mapnik::python_datasource, bases<datasource>, //boost::shared_ptr<mapnik::python_datasource>,
+        boost::noncopyable>("PythonDatasource",
+            "This class represents a python datasource", no_init)
+        ;
+        
+    def("Python", &create_python_datasource);
+
 }

--- a/bindings/python/mapnik_python.cpp
+++ b/bindings/python/mapnik_python.cpp
@@ -75,7 +75,6 @@ void export_view_transform();
 void export_raster_colorizer();
 void export_label_collision_detector();
 void export_logger();
-void export_python_datasource();
 
 #include <mapnik/version.hpp>
 #include <mapnik/value_error.hpp>
@@ -536,7 +535,6 @@ BOOST_PYTHON_MODULE(_mapnik)
     export_raster_colorizer();
     export_label_collision_detector();
     export_logger();
-		export_python_datasource();
 
     def("clear_cache", &clear_cache,
         "\n"

--- a/bindings/python/mapnik_python.cpp
+++ b/bindings/python/mapnik_python.cpp
@@ -75,6 +75,7 @@ void export_view_transform();
 void export_raster_colorizer();
 void export_label_collision_detector();
 void export_logger();
+void export_python_datasource();
 
 #include <mapnik/version.hpp>
 #include <mapnik/value_error.hpp>
@@ -535,6 +536,7 @@ BOOST_PYTHON_MODULE(_mapnik)
     export_raster_colorizer();
     export_label_collision_detector();
     export_logger();
+		export_python_datasource();
 
     def("clear_cache", &clear_cache,
         "\n"

--- a/bindings/python/python_datasource.cpp
+++ b/bindings/python/python_datasource.cpp
@@ -39,6 +39,29 @@ class ensure_gil
         PyGILState_STATE gil_state_;
 };
 
+std::string extractException()
+{
+  using namespace boost::python;
+
+  PyObject *exc,*val,*tb;
+  PyErr_Fetch(&exc,&val,&tb);
+  PyErr_NormalizeException(&exc,&val,&tb);
+  handle<> hexc(exc),hval(allow_null(val)),htb(allow_null(tb));
+  if(!hval)
+  {
+    return extract<std::string>(str(hexc));
+  }
+  else
+  {
+    object traceback(import("traceback"));
+    object format_exception(traceback.attr("format_exception"));
+    object formatted_list(format_exception(hexc,hval,htb));
+    object formatted(str("").join(formatted_list));
+    return extract<std::string>(formatted);
+  }
+}
+
+
 } // end anonymous namespace
 
 namespace mapnik {
@@ -70,7 +93,7 @@ datasource::datasource_t python_datasource::type() const
     }
     catch ( boost::python::error_already_set )
     {
-        //throw datasource_exception(extractException());
+         throw datasource_exception(extractException());
     }
 
 }
@@ -111,7 +134,7 @@ box2d<double> python_datasource::envelope() const
     }
     catch ( boost::python::error_already_set )
     {
-        //throw datasource_exception(extractException());
+        throw datasource_exception(extractException());
     }
     return box;
 }
@@ -139,7 +162,7 @@ boost::optional<datasource::geometry_t> python_datasource::get_geometry_type() c
     }
     catch ( boost::python::error_already_set )
     {
-        //throw datasource_exception(extractException());
+        throw datasource_exception(extractException());
     }
 }
 
@@ -164,7 +187,7 @@ featureset_ptr python_datasource::features(query const& q) const
     }
     catch ( boost::python::error_already_set )
     {
-        //throw datasource_exception(extractException());
+        throw datasource_exception(extractException());
     }
 }
 
@@ -185,7 +208,7 @@ featureset_ptr python_datasource::features_at_point(coord2d const& pt, double to
     }
     catch ( boost::python::error_already_set )
     {
-        //throw datasource_exception(extractException());
+        throw datasource_exception(extractException());
     }
 
 }
@@ -214,6 +237,7 @@ feature_ptr python_featureset::next()
 
     return *(begin_++);
 }
+
 
 } // end namespace mapnik
 

--- a/bindings/python/python_datasource.cpp
+++ b/bindings/python/python_datasource.cpp
@@ -240,22 +240,3 @@ feature_ptr python_featureset::next()
 
 
 } // end namespace mapnik
-
-namespace {
-boost::shared_ptr<mapnik::datasource> create_python_datasource(boost::python::object ds)
-{
-    return mapnik::datasource_ptr(new mapnik::python_datasource(ds));
-}
-
-} // end anonymous namespace
-
-void export_python_datasource()
-{
-    using namespace boost::python;
-
-    class_<mapnik::python_datasource,boost::shared_ptr<mapnik::python_datasource>,
-        boost::noncopyable>("PythonDatasource",
-            "This class represents a python datasource", no_init);
-		
-		def("Python", &create_python_datasource);
-}

--- a/bindings/python/python_datasource.cpp
+++ b/bindings/python/python_datasource.cpp
@@ -1,0 +1,237 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2006 Artem Pavlenko, Jean-Francois Doyon
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+// boost
+#include <boost/foreach.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
+
+#include "python_datasource.hpp"
+
+namespace {
+
+// Use RAII to acquire and release the GIL as needed.
+class ensure_gil
+{
+    public:
+        ensure_gil() : gil_state_(PyGILState_Ensure()) {}
+        ~ensure_gil() { PyGILState_Release( gil_state_ ); }
+    protected:
+        PyGILState_STATE gil_state_;
+};
+
+} // end anonymous namespace
+
+namespace mapnik {
+
+python_datasource::python_datasource(boost::python::object ds)
+  : datasource(parameters()),
+    desc_("python", "utf-8"),
+		datasource_(ds)
+{
+}
+
+python_datasource::~python_datasource() { }
+
+layer_descriptor python_datasource::get_descriptor() const
+{
+    return desc_;
+}
+
+datasource::datasource_t python_datasource::type() const
+{
+    typedef boost::optional<datasource::geometry_t> return_type;
+
+    try
+    {
+        ensure_gil lock;
+        boost::python::object data_type = datasource_.attr("data_type");
+        long data_type_integer = boost::python::extract<long>(data_type);
+        return datasource::datasource_t(data_type_integer);
+    }
+    catch ( boost::python::error_already_set )
+    {
+        //throw datasource_exception(extractException());
+    }
+
+}
+
+box2d<double> python_datasource::envelope() const
+{
+    box2d<double> box;
+    try
+    {
+        ensure_gil lock;
+        if (!PyObject_HasAttrString(datasource_.ptr(), "envelope"))
+        {
+            throw datasource_exception("Python: could not access envelope property");
+        }
+        else
+        {
+            boost::python::object py_envelope = datasource_.attr("envelope");
+            if (py_envelope.ptr() == boost::python::object().ptr())
+            {
+                throw datasource_exception("Python: could not access envelope property");
+            }
+            else
+            {
+                boost::python::extract<double> ex(py_envelope.attr("minx"));
+                if (!ex.check()) throw datasource_exception("Python: could not convert envelope.minx");
+                box.set_minx(ex());
+                boost::python::extract<double> ex1(py_envelope.attr("miny"));
+                if (!ex1.check()) throw datasource_exception("Python: could not convert envelope.miny");
+                box.set_miny(ex1());
+                boost::python::extract<double> ex2(py_envelope.attr("maxx"));
+                if (!ex2.check()) throw datasource_exception("Python: could not convert envelope.maxx");
+                box.set_maxx(ex2());
+                boost::python::extract<double> ex3(py_envelope.attr("maxy"));
+                if (!ex3.check()) throw datasource_exception("Python: could not convert envelope.maxy");
+                box.set_maxy(ex3());
+            }
+        }
+    }
+    catch ( boost::python::error_already_set )
+    {
+        //throw datasource_exception(extractException());
+    }
+    return box;
+}
+
+boost::optional<datasource::geometry_t> python_datasource::get_geometry_type() const
+{
+    typedef boost::optional<datasource::geometry_t> return_type;
+
+    try
+    {
+        ensure_gil lock;
+        // if the datasource object has no geometry_type attribute, return a 'none' value
+        if (!PyObject_HasAttrString(datasource_.ptr(), "geometry_type"))
+        {
+            return return_type();
+        }
+        boost::python::object py_geometry_type = datasource_.attr("geometry_type");
+        // if the attribute value is 'None', return a 'none' value
+        if (py_geometry_type.ptr() == boost::python::object().ptr())
+        {
+            return return_type();
+        }
+        long geom_type_integer = boost::python::extract<long>(py_geometry_type);
+        return datasource::geometry_t(geom_type_integer);
+    }
+    catch ( boost::python::error_already_set )
+    {
+        //throw datasource_exception(extractException());
+    }
+}
+
+featureset_ptr python_datasource::features(query const& q) const
+{
+    try
+    {
+        // if the query box intersects our world extent then query for features
+        if (envelope().intersects(q.get_bbox()))
+        {
+            ensure_gil lock;
+            boost::python::object features(datasource_.attr("features")(q));
+            // if 'None' was returned, return an empty feature set
+            if(features.ptr() == boost::python::object().ptr())
+            {
+                return featureset_ptr();
+            }
+            return boost::make_shared<python_featureset>(features);
+        }
+        // otherwise return an empty featureset pointer
+        return featureset_ptr();
+    }
+    catch ( boost::python::error_already_set )
+    {
+        //throw datasource_exception(extractException());
+    }
+}
+
+featureset_ptr python_datasource::features_at_point(coord2d const& pt, double tol) const
+{
+
+    try
+    {
+        ensure_gil lock;
+        boost::python::object features(datasource_.attr("features_at_point")(pt));
+        // if we returned none, return an empty set
+        if(features.ptr() == boost::python::object().ptr())
+        {
+            return featureset_ptr();
+        }
+        // otherwise, return a feature set which can iterate over the iterator
+        return boost::make_shared<python_featureset>(features);
+    }
+    catch ( boost::python::error_already_set )
+    {
+        //throw datasource_exception(extractException());
+    }
+
+}
+
+
+python_featureset::python_featureset(boost::python::object iterator)
+{
+    ensure_gil lock;
+    begin_ = boost::python::stl_input_iterator<feature_ptr>(iterator);
+}
+
+python_featureset::~python_featureset()
+{
+    ensure_gil lock;
+    begin_ = end_;
+}
+
+feature_ptr python_featureset::next()
+{
+    // checking to see if we've reached the end does not require the GIL.
+    if(begin_ == end_)
+        return feature_ptr();
+
+    // getting the next feature might call into the interpreter and so the GIL must be held.
+    ensure_gil lock;
+
+    return *(begin_++);
+}
+
+} // end namespace mapnik
+
+namespace {
+boost::shared_ptr<mapnik::datasource> create_python_datasource(boost::python::object ds)
+{
+    return mapnik::datasource_ptr(new mapnik::python_datasource(ds));
+}
+
+} // end anonymous namespace
+
+void export_python_datasource()
+{
+    using namespace boost::python;
+
+    class_<mapnik::python_datasource,boost::shared_ptr<mapnik::python_datasource>,
+        boost::noncopyable>("PythonDatasource",
+            "This class represents a python datasource", no_init);
+		
+		def("Python", &create_python_datasource);
+}

--- a/bindings/python/python_datasource.hpp
+++ b/bindings/python/python_datasource.hpp
@@ -1,0 +1,94 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2011 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+#ifndef MAPNIK_PYTHON_BINDING_DATASOURCE_INCLUDED
+#define MAPNIK_PYTHON_BINDING_DATASOURCE_INCLUDED
+
+// mapnik
+#include <mapnik/datasource.hpp>
+#include <mapnik/feature.hpp>
+
+// boost
+#include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
+
+namespace mapnik
+{
+
+class python_datasource : public datasource
+{
+public:
+    // constructor
+    // arguments must not change
+    python_datasource(boost::python::object ds);
+
+    // destructor
+    virtual ~python_datasource ();
+
+    // mandatory: type of the plugin, used to match at runtime
+    datasource::datasource_t type() const;
+
+    // mandatory: function to query features by box2d
+    // this is called when rendering, specifically in feature_style_processor.hpp
+    featureset_ptr features(query const& q) const;
+
+    // mandatory: function to query features by point (coord2d)
+    // not used by rendering, but available to calling applications
+    featureset_ptr features_at_point(coord2d const& pt, double tol = 0) const;
+
+    // mandatory: return the box2d of the datasource
+    // called during rendering to determine if the layer should be processed
+    box2d<double> envelope() const;
+
+    // mandatory: optionally return the overal geometry type of the datasource
+    boost::optional<datasource::geometry_t> get_geometry_type() const;
+
+    // mandatory: return the layer descriptor
+    layer_descriptor get_descriptor() const;
+
+private:
+    layer_descriptor desc_;
+    const std::string factory_;
+    std::map<std::string, std::string> kwargs_;
+    boost::python::object datasource_;
+};
+
+class python_featureset : public Featureset
+{
+public:
+    // this constructor can have any arguments you need
+    python_featureset(boost::python::object iterator);
+
+    // desctructor
+    virtual ~python_featureset();
+
+    // mandatory: you must expose a next() method, called when rendering
+    feature_ptr next();
+
+private:
+    typedef boost::python::stl_input_iterator<feature_ptr> feature_iter;
+
+    feature_iter begin_, end_;
+};
+
+} // end of namespace mapnik
+
+#endif // MAPNIK_PYTHON_BINDING_DATASOURCE_INCLUDED

--- a/tests/python_tests/python_datasource_test.py
+++ b/tests/python_tests/python_datasource_test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import math
+import mapnik
+import sys
+from utilities import execution_path, run_all
+from nose.tools import *
+
+def setup():
+    # All of the paths used are relative, if we run the tests
+    # from another directory we need to chdir()
+    os.chdir(execution_path('.'))
+
+class PointDatasource(mapnik.PythonDatasource):
+    def __init__(self):
+        super(PointDatasource, self).__init__(
+                geometry_type = mapnik.DataGeometryType.Point,
+                envelope = mapnik.Box2d(0,-10,100,110),
+                data_type = mapnik.DataType.Vector
+        )
+
+    def features(self, query):
+        return mapnik.PythonDatasource.wkt_features(
+            keys = ('label',),
+            features = (
+                ( 'POINT (5 6)', { 'label': 'foo-bar'} ),
+                ( 'POINT (60 50)', { 'label': 'buzz-quux'} ),
+            )
+        )
+
+class ConcentricCircles(object):
+    def __init__(self, centre, bounds, step=1):
+        self.centre = centre
+        self.bounds = bounds
+        self.step = step
+
+    class Iterator(object):
+        def __init__(self, container):
+            self.container = container
+
+            centre = self.container.centre
+            bounds = self.container.bounds
+            step = self.container.step
+
+            self.radius = step
+
+        def next(self):
+            points = []
+            for alpha in xrange(0, 361, 5):
+                x = math.sin(math.radians(alpha)) * self.radius + self.container.centre[0]
+                y = math.cos(math.radians(alpha)) * self.radius + self.container.centre[1]
+                points.append('%s %s' % (x,y))
+            circle = 'POLYGON ((' + ','.join(points) + '))'
+
+            # has the circle grown so large that the boundary is entirely within it?
+            tl = (self.container.bounds.maxx, self.container.bounds.maxy)
+            tr = (self.container.bounds.maxx, self.container.bounds.maxy)
+            bl = (self.container.bounds.minx, self.container.bounds.miny)
+            br = (self.container.bounds.minx, self.container.bounds.miny)
+            def within_circle(p):
+                delta_x = p[0] - self.container.centre[0]
+                delta_y = p[0] - self.container.centre[0]
+                return delta_x*delta_x + delta_y*delta_y < self.radius*self.radius
+
+            if all(within_circle(p) for p in (tl,tr,bl,br)):
+                raise StopIteration()
+
+            self.radius += self.container.step
+            return ( circle, { } )
+
+    def __iter__(self):
+        return ConcentricCircles.Iterator(self)
+
+class CirclesDatasource(mapnik.PythonDatasource):
+    def __init__(self, centre_x=-20, centre_y=0, step=10):
+        super(CirclesDatasource, self).__init__(
+                geometry_type = mapnik.DataGeometryType.Polygon,
+                envelope = mapnik.Box2d(-180, -90, 180, 90),
+                data_type = mapnik.DataType.Vector
+        )
+
+        self.centre_x = centre_x
+        self.centre_y = centre_y
+        self.step = step
+
+    def features(self, query):
+        centre = (self.centre_x, self.centre_y)
+
+        return mapnik.PythonDatasource.wkt_features(
+            keys = (),
+            features = ConcentricCircles(centre, query.bbox, self.step)
+        )
+
+def test_python_point_init():
+    ds = mapnik.Python(PointDatasource())
+    e = ds.envelope()
+
+    assert_almost_equal(e.minx, 0, places=7)
+    assert_almost_equal(e.miny, -10, places=7)
+    assert_almost_equal(e.maxx, 100, places=7)
+    assert_almost_equal(e.maxy, 110, places=7)
+
+def test_python_circle_init():
+    ds = mapnik.Python(CirclesDatasource())
+    e = ds.envelope()
+
+    assert_almost_equal(e.minx, -180, places=7)
+    assert_almost_equal(e.miny, -90, places=7)
+    assert_almost_equal(e.maxx, 180, places=7)
+    assert_almost_equal(e.maxy, 90, places=7)
+
+def test_python_circle_init_with_args():
+    ds = mapnik.Python(CirclesDatasource(centre_x=40, centre_y=7))
+    e = ds.envelope()
+
+    assert_almost_equal(e.minx, -180, places=7)
+    assert_almost_equal(e.miny, -90, places=7)
+    assert_almost_equal(e.maxx, 180, places=7)
+    assert_almost_equal(e.maxy, 90, places=7)
+
+def test_python_point_rendering():
+    m = mapnik.Map(512,512)
+    mapnik.load_map(m,'../data/python_plugin/python_point_datasource.xml')
+    m.zoom_all()
+    im = mapnik.Image(512,512)
+    mapnik.render(m,im)
+    actual = '/tmp/mapnik-python-point-render1.png'
+    expected = 'images/support/mapnik-python-point-render1.png'
+    im.save(actual)
+    expected_im = mapnik.Image.open(expected)
+    eq_(im.tostring(),expected_im.tostring(),
+            'failed comparing actual (%s) and expected (%s)' % (actual,'tests/python_tests/'+ expected))
+
+def test_python_circle_rendering():
+    m = mapnik.Map(512,512)
+    mapnik.load_map(m,'../data/python_plugin/python_circle_datasource.xml')
+    m.zoom_all()
+    im = mapnik.Image(512,512)
+    mapnik.render(m,im)
+    actual = '/tmp/mapnik-python-circle-render1.png'
+    expected = 'images/support/mapnik-python-circle-render1.png'
+    im.save(actual)
+    expected_im = mapnik.Image.open(expected)
+    eq_(im.tostring(),expected_im.tostring(),
+            'failed comparing actual (%s) and expected (%s)' % (actual,'tests/python_tests/'+ expected))
+
+if __name__ == "__main__":
+    setup()
+    run_all(eval(x) for x in dir() if x.startswith("test_"))


### PR DESCRIPTION
This is mostly copied from the python plugin. The benefit to this approach is that the datasource object can be constructed in the python script and passed into the mapnik api. So, for example, in the concentric-circles example at the bottom of https://github.com/mapnik/mapnik/wiki/Python-Plugin, you can do this instead:

```python
if __name__ == '__main__':
    m = mapnik.Map(640, 320)

    m.background = mapnik.Color('white')
    s = mapnik.Style()
    r = mapnik.Rule()
    r.symbols.append(mapnik.LineSymbolizer())
    s.rules.append(r)
    m.append_style('point_style',s)

    ######## This part is different
    layer = mapnik.Layer('python')
    datasource = CircleDatasource(centre_x=4, centre_y=50)
    layer.datasource = mapnik.Python(datasource)
    mapnik.render(m, mapnik.Image(512, 512))
    ...
    datasource.centre_x = 10
    mapnik.render(m, mapnik.Image(512, 512))
    ...
```

This means that later on you can change the values of centre_x and centre_y on the instance of CircleDatasource and they will be used the next time the map is rendered (this is useful in UIs with mapping widgets).
