### PR TITLE
Fix debug build in 2.3.x

### DIFF
--- a/include/mapnik/png_io.hpp
+++ b/include/mapnik/png_io.hpp
@@ -684,7 +684,7 @@ void save_as_png8_hex(T1 & file,
     //transparency values per palette index
     std::vector<mapnik::rgba> pal;
     tree.create_palette(pal);
-    assert(int(pal.size()) <= colors);
+    assert(int(pal.size()) <= opts.colors);
     std::vector<mapnik::rgb> palette;
     std::vector<unsigned> alphaTable;
     for(unsigned i=0; i<pal.size(); i++)


### PR DESCRIPTION
Fixes

```
include/mapnik/png_io.hpp: In function ‘void mapnik::save_as_png8_hex(T1&, const T2&, const mapnik::png_options&)’:
include/mapnik/png_io.hpp:687: error: ‘colors’ was not declared in this scope
```

...which only occurs when configured with `DEBUG=true`.
