### PR TITLE
Cairo support in expr-v2 branch

### DIFF
--- a/include/mapnik/cairo_renderer.hpp
+++ b/include/mapnik/cairo_renderer.hpp
@@ -147,7 +147,6 @@ protected:
     std::shared_ptr<freetype_engine> font_engine_;
     face_manager<freetype_engine> font_manager_;
     cairo_face_manager face_manager_;
-    box2d<double> clip_extent_;
     std::shared_ptr<label_collision_detector4> detector_;
     box2d<double> query_extent_;
     void setup(Map const& m);

--- a/src/cairo_renderer.cpp
+++ b/src/cairo_renderer.cpp
@@ -133,9 +133,9 @@ cairo_renderer_base::cairo_renderer_base(Map const& m,
       font_engine_(std::make_shared<freetype_engine>()),
       font_manager_(*font_engine_),
       face_manager_(font_engine_),
-      clip_extent_(-m.buffer_size(), -m.buffer_size(),
-                   m.width() + m.buffer_size(), m.height() + m.buffer_size()),
-      detector_(std::make_shared<label_collision_detector4>(clip_extent_))
+      detector_(std::make_shared<label_collision_detector4>(
+                  box2d<double>(-m.buffer_size(), -m.buffer_size(),
+                                m.width() + m.buffer_size(), m.height() + m.buffer_size())))
 {
     setup(m);
 }
@@ -155,9 +155,9 @@ cairo_renderer_base::cairo_renderer_base(Map const& m,
       font_engine_(std::make_shared<freetype_engine>()),
       font_manager_(*font_engine_),
       face_manager_(font_engine_),
-      clip_extent_(-m.buffer_size(), -m.buffer_size(),
-                   m.width() + m.buffer_size(), m.height() + m.buffer_size()),
-      detector_(std::make_shared<label_collision_detector4>(clip_extent_))
+      detector_(std::make_shared<label_collision_detector4>(
+                  box2d<double>(-m.buffer_size(), -m.buffer_size(),
+                                m.width() + m.buffer_size(), m.height() + m.buffer_size())))
 {
     setup(m);
 }
@@ -177,8 +177,6 @@ cairo_renderer_base::cairo_renderer_base(Map const& m,
       font_engine_(std::make_shared<freetype_engine>()),
       font_manager_(*font_engine_),
       face_manager_(font_engine_),
-      clip_extent_(-m.buffer_size(), -m.buffer_size(),
-                   m.width() + m.buffer_size(), m.height() + m.buffer_size()),
       detector_(detector)
 {
     MAPNIK_LOG_DEBUG(cairo_renderer) << "cairo_renderer_base: Scale=" << m.scale();


### PR DESCRIPTION
Updated Cairo renderer files to compile, and run, with the latest `expr-v2` branch.

24 visual tests fail, of which 4 are specific to Cairo, 4 fail both for Cairo and AGG, and 16 are AGG-only. The "both" failures appear to be just due to character spacing, and are probably attributable to my use of HarfBuzz 0.9.19 (IIRC, the Travis CI version is 0.9.24). The Cairo-only failures are due to dash differences on some, but not all of the lines, and I haven't been able to track down where it's coming from, or whether it's due to changes in this PR or changes elsewhere in the `expr-v2` branch.

![reference](https://f.cloud.github.com/assets/271360/1646249/7f151ee0-5915-11e3-8b3d-c518459c7ea7.png)

(Reference above)

![actual](https://f.cloud.github.com/assets/271360/1646250/86600138-5915-11e3-8f75-e5adcc11822b.png)

(Actual above)

Full listing of failing visual tests:

```
1) 3 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-600-400-1.0-agg.png (actual)
        tests/visual_tests/images/marker-with-background-image-600-400-1.0-agg-reference.png (expected)
2) 5 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-600-400-2.0-agg.png (actual)
        tests/visual_tests/images/marker-with-background-image-600-400-2.0-agg-reference.png (expected)
3) 5 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-400-600-1.0-agg.png (actual)
        tests/visual_tests/images/marker-with-background-image-400-600-1.0-agg-reference.png (expected)
4) 4 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-400-600-2.0-agg.png (actual)
        tests/visual_tests/images/marker-with-background-image-400-600-2.0-agg-reference.png (expected)
5) 4 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-257-256-1.0-agg.png (actual)
        tests/visual_tests/images/marker-with-background-image-257-256-1.0-agg-reference.png (expected)
6) 12 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-600-400-1.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-600-400-1.0-agg-referen
ce.png (expected)
7) 21 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-600-400-2.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-600-400-2.0-agg-referen
ce.png (expected)
8) 9 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-400-600-1.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-400-600-1.0-agg-referen
ce.png (expected)
9) 14 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-400-600-2.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-400-600-2.0-agg-referen
ce.png (expected)
10) 11 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-257-256-1.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-257-256-1.0-agg-referen
ce.png (expected)
11) 2 different pixels:
        /tmp/mapnik-visual-images/marker-with-background-image-and-hsla-transform-257-256-2.0-agg.png (ac
tual)
        tests/visual_tests/images/marker-with-background-image-and-hsla-transform-257-256-2.0-agg-referen
ce.png (expected)
12) 3084 different pixels:
        /tmp/mapnik-visual-images/charspacing-200-400-2.0-agg.png (actual)
        tests/visual_tests/images/charspacing-200-400-2.0-agg-reference.png (expected)
13) 2018 different pixels:
        /tmp/mapnik-visual-images/charspacing-200-400-2.0-cairo.png (actual)
        tests/visual_tests/images/charspacing-200-400-2.0-cairo-reference.png (expected)
14) 29 different pixels:
        /tmp/mapnik-visual-images/lines-6-800-800-2.0-agg.png (actual)
        tests/visual_tests/images/lines-6-800-800-2.0-agg-reference.png (expected)
15) 26 different pixels:
        /tmp/mapnik-visual-images/lines-6-600-600-2.0-agg.png (actual)
        tests/visual_tests/images/lines-6-600-600-2.0-agg-reference.png (expected)
16) 11 different pixels:
        /tmp/mapnik-visual-images/lines-6-400-400-2.0-agg.png (actual)
        tests/visual_tests/images/lines-6-400-400-2.0-agg-reference.png (expected)
17) 6 different pixels:
        /tmp/mapnik-visual-images/lines-6-200-200-2.0-agg.png (actual)
        tests/visual_tests/images/lines-6-200-200-2.0-agg-reference.png (expected)
18) 850 different pixels:
        /tmp/mapnik-visual-images/road-casings-grouped-rendering-600-600-1.0-cairo.png (actual)
        tests/visual_tests/images/road-casings-grouped-rendering-600-600-1.0-cairo-reference.png (expected)
19) 1473 different pixels:
        /tmp/mapnik-visual-images/road-casings-grouped-rendering-600-600-2.0-cairo.png (actual)
        tests/visual_tests/images/road-casings-grouped-rendering-600-600-2.0-cairo-reference.png (expected)
20) 3 different pixels:
        /tmp/mapnik-visual-images/marker_line_placement_on_points-500-100-1.0-agg.png (actual)
        tests/visual_tests/images/marker_line_placement_on_points-500-100-1.0-agg-reference.png (expected)
21) 2673 different pixels:
        /tmp/mapnik-visual-images/charspacing-lines-300-300-2.0-agg.png (actual)
        tests/visual_tests/images/charspacing-lines-300-300-2.0-agg-reference.png (expected)
22) 1763 different pixels:
        /tmp/mapnik-visual-images/charspacing-lines-300-300-2.0-cairo.png (actual)
        tests/visual_tests/images/charspacing-lines-300-300-2.0-cairo-reference.png (expected)
23) 877 different pixels:
        /tmp/mapnik-visual-images/road-casings-non-grouped-rendering-600-600-1.0-cairo.png (actual)
        tests/visual_tests/images/road-casings-non-grouped-rendering-600-600-1.0-cairo-reference.png (expected)
24) 1625 different pixels:
        /tmp/mapnik-visual-images/road-casings-non-grouped-rendering-600-600-2.0-cairo.png (actual)
        tests/visual_tests/images/road-casings-non-grouped-rendering-600-600-2.0-cairo-reference.png (expected)
```
