### PR TITLE
Update grid renderer for `expr-v2` branch

### DIFF
--- a/src/cairo_context.cpp
+++ b/src/cairo_context.cpp
@@ -478,8 +478,6 @@ void cairo_context::add_text(glyph_positions_ptr path,
         if (glyph.format)
         {
             format = glyph.format;
-            // Settings have changed.
-            halo_radius = format->halo_radius * scale_factor;
         }
 
         face_set_ptr faces = font_manager.get_face_set(format->face_name, format->fontset);

--- a/src/grid/grid_renderer.cpp
+++ b/src/grid/grid_renderer.cpp
@@ -200,7 +200,8 @@ void grid_renderer<T>::render_marker(mapnik::feature_impl & feature, unsigned in
                                                    data,
                                                    SCALING_NEAR,
                                                    ratio,
-                                                   ratio);
+                                                   ratio,
+                                                   0.0, 0.0, 1.0); // TODO: is 1.0 a valid default here, and do we even care in grid_renderer what the image looks like?
             pixmap_.set_rectangle(feature.id(), target,
                                   boost::math::iround(pos.x - cx),
                                   boost::math::iround(pos.y - cy));

--- a/src/grid/process_building_symbolizer.cpp
+++ b/src/grid/process_building_symbolizer.cpp
@@ -28,7 +28,6 @@
 #include <mapnik/grid/grid.hpp>
 #include <mapnik/segment.hpp>
 #include <mapnik/expression_evaluator.hpp>
-#include <mapnik/building_symbolizer.hpp>
 #include <mapnik/expression.hpp>
 
 // boost
@@ -65,14 +64,7 @@ void grid_renderer<T>::process(building_symbolizer const& sym,
 
     ras_ptr->reset();
 
-    double height = 0.0;
-    expression_ptr height_expr = sym.height();
-    if (height_expr)
-    {
-        value_type result = boost::apply_visitor(evaluate<feature_impl,value_type>(feature), *height_expr);
-        height = result.to_double() * scale_factor_;
-    }
-
+    double height = get<value_double>(sym, keys::height,feature, 0.0);
     for (std::size_t i=0;i<feature.num_geometries();++i)
     {
         geometry_type & geom = feature.get_geometry(i);

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -26,7 +26,6 @@
 #include <mapnik/grid/grid_renderer.hpp>
 #include <mapnik/grid/grid_renderer_base.hpp>
 #include <mapnik/grid/grid.hpp>
-#include <mapnik/line_pattern_symbolizer.hpp>
 #include <mapnik/marker.hpp>
 #include <mapnik/marker_cache.hpp>
 #include <mapnik/vertex_converters.hpp>
@@ -49,7 +48,7 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
                                mapnik::feature_impl & feature,
                                proj_transform const& prj_trans)
 {
-    std::string filename = path_processor_type::evaluate( *sym.get_filename(), feature);
+    std::string filename = get<std::string>(sym, keys::file, feature);
 
     boost::optional<marker_ptr> mark = marker_cache::instance().find(filename,true);
     if (!mark) return;
@@ -62,6 +61,11 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
 
     boost::optional<image_ptr> pat = (*mark)->get_bitmap_data();
     if (!pat) return;
+
+    bool clip = get<value_bool>(sym, keys::clip, feature);
+    double offset = get<value_double>(sym, keys::offset, feature, 0.0);
+    double simplify_tolerance = get<value_double>(sym, keys::simplify_tolerance, feature, 0.0);
+    double smooth = get<value_double>(sym, keys::smooth, feature, false);
 
     typedef coord_transform<CoordTransform,geometry_type> path_type;
     typedef typename grid_renderer_base_type::pixfmt_type pixfmt_type;
@@ -83,35 +87,42 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     int stroke_width = (*pat)->width();
 
     agg::trans_affine tr;
-    evaluate_transform(tr, feature, sym.get_transform());
+    auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
+    if (transform) { evaluate_transform(tr, feature, *transform); }
 
     box2d<double> clipping_extent = query_extent_;
-    if (sym.clip())
+    if (clip)
     {
         double padding = (double)(query_extent_.width()/pixmap_.width());
         double half_stroke = stroke_width/2.0;
         if (half_stroke > 1)
             padding *= half_stroke;
-        if (std::fabs(sym.offset()) > 0)
-            padding *= std::fabs(sym.offset()) * 1.2;
+        if (std::fabs(offset) > 0)
+            padding *= std::fabs(offset) * 1.2;
         padding *= scale_factor_;
         clipping_extent.pad(padding);
     }
     
     // to avoid the complexity of using an agg pattern filter instead
     // we create a line_symbolizer in order to fake the pattern
-    stroke str;
-    str.set_width(stroke_width);
-    line_symbolizer line(str);
+    line_symbolizer line;
+    put<value_double>(line, keys::stroke_width, value_double(stroke_width));
+    // TODO: really should pass the offset to the fake line too, but
+    // this wasn't present in the previous version and makes the test
+    // fail - in this case, probably the test should be updated.
+    //put<value_double>(line, keys::offset, value_double(offset));
+    put<value_double>(line, keys::simplify_tolerance, value_double(simplify_tolerance));
+    put<value_double>(line, keys::smooth, value_double(smooth));
+
     vertex_converter<box2d<double>, grid_rasterizer, line_symbolizer,
                      CoordTransform, proj_transform, agg::trans_affine, conv_types>
         converter(clipping_extent,*ras_ptr,line,t_,prj_trans,tr,scale_factor_);
-    if (sym.clip()) converter.set<clip_line_tag>(); // optional clip (default: true)
+    if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
     converter.set<transform_tag>(); // always transform
-    if (std::fabs(sym.offset()) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
+    if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
     converter.set<affine_transform_tag>(); // optional affine transform
-    if (sym.simplify_tolerance() > 0.0) converter.set<simplify_tag>(); // optional simplify converter
-    if (sym.smooth() > 0.0) converter.set<smooth_tag>(); // optional smooth converter
+    if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
+    if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
     converter.set<stroke_tag>(); //always stroke
 
     for (geometry_type & geom : feature.paths())

--- a/src/grid/process_shield_symbolizer.cpp
+++ b/src/grid/process_shield_symbolizer.cpp
@@ -27,9 +27,9 @@
 #include <mapnik/grid/grid_renderer.hpp>
 #include <mapnik/grid/grid_renderer_base.hpp>
 #include <mapnik/grid/grid.hpp>
-#include <mapnik/symbolizer_helpers.hpp>
+#include <mapnik/text/symbolizer_helpers.hpp>
 #include <mapnik/pixel_position.hpp>
-#include <mapnik/font_util.hpp>
+#include <mapnik/text/renderer.hpp>
 
 // agg
 #include "agg_trans_affine.h"
@@ -41,8 +41,7 @@ void  grid_renderer<T>::process(shield_symbolizer const& sym,
                                 mapnik::feature_impl & feature,
                                 proj_transform const& prj_trans)
 {
-    shield_symbolizer_helper<face_manager<freetype_engine>,
-        label_collision_detector4> helper(
+    text_symbolizer_helper helper(
             sym, feature, prj_trans,
             width_, height_,
             scale_factor_,
@@ -50,41 +49,34 @@ void  grid_renderer<T>::process(shield_symbolizer const& sym,
             query_extent_);
     bool placement_found = false;
 
-    text_renderer<T> ren(pixmap_,
-                         font_manager_,
-                         sym.get_halo_rasterizer(),
-                         sym.comp_op(),
-                         scale_factor_);
+    composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, src_over);
+    double opacity = get<double>(sym,keys::opacity,feature, 1.0);
 
-    text_placement_info_ptr placement;
-    while (helper.next())
+    grid_text_renderer<T> ren(pixmap_,
+                              comp_op,
+                              scale_factor_);
+
+    placements_list const& placements = helper.get();
+    value_integer feature_id = feature.id();
+    
+    for (glyph_positions_ptr glyphs : placements)
     {
-        placement_found = true;
-        placements_type const& placements = helper.placements();
-        for (unsigned int ii = 0; ii < placements.size(); ++ii)
+        if (glyphs->marker())
         {
-            // get_marker_position returns (minx,miny) corner position,
-            // while (currently only) agg_renderer::render_marker newly
-            // expects center position;
-            // until all renderers and shield_symbolizer_helper are
-            // modified accordingly, we must adjust the position here
-            pixel_position pos = helper.get_marker_position(placements[ii]);
-            pos.x += 0.5 * helper.get_marker_width();
-            pos.y += 0.5 * helper.get_marker_height();
-            render_marker(feature,
+            render_marker(feature, 
                           pixmap_.get_resolution(),
-                          pos,
-                          helper.get_marker(),
-                          helper.get_image_transform(),
-                          sym.get_opacity(),
-                          sym.comp_op());
-
-            ren.prepare_glyphs(placements[ii]);
-            ren.render_id(feature.id(), placements[ii].center);
+                          glyphs->marker_pos(),
+                          *(glyphs->marker()->marker),
+                          glyphs->marker()->transform,
+                          opacity, comp_op);
         }
+        ren.render(*glyphs, feature_id);
+        placement_found = true;
     }
     if (placement_found)
+    {
         pixmap_.add_feature(feature);
+    }
 }
 
 template void grid_renderer<grid>::process(shield_symbolizer const&,

--- a/src/grid/process_text_symbolizer.cpp
+++ b/src/grid/process_text_symbolizer.cpp
@@ -23,8 +23,9 @@
 // mapnik
 #include <mapnik/feature.hpp>
 #include <mapnik/grid/grid_renderer.hpp>
-#include <mapnik/symbolizer_helpers.hpp>
-#include <mapnik/font_util.hpp>
+#include <mapnik/text/symbolizer_helpers.hpp>
+#include <mapnik/pixel_position.hpp>
+#include <mapnik/text/renderer.hpp>
 
 namespace mapnik {
 
@@ -33,8 +34,7 @@ void grid_renderer<T>::process(text_symbolizer const& sym,
                                mapnik::feature_impl & feature,
                                proj_transform const& prj_trans)
 {
-    text_symbolizer_helper<face_manager<freetype_engine>,
-        label_collision_detector4> helper(
+    text_symbolizer_helper helper(
             sym, feature, prj_trans,
             width_, height_,
             scale_factor_ * (1.0/pixmap_.get_resolution()),
@@ -42,23 +42,24 @@ void grid_renderer<T>::process(text_symbolizer const& sym,
             query_extent_);
     bool placement_found = false;
 
-    text_renderer<T> ren(pixmap_,
-                         font_manager_,
-                         sym.get_halo_rasterizer(),
-                         sym.comp_op(),
-                         scale_factor_);
+    composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, src_over);
 
-    while (helper.next()) {
+    grid_text_renderer<T> ren(pixmap_,
+                              comp_op,
+                              scale_factor_);
+
+    placements_list const& placements = helper.get();
+    value_integer feature_id = feature.id();
+
+    for (glyph_positions_ptr glyphs : placements)
+    {
+      ren.render(*glyphs, feature_id);
         placement_found = true;
-        placements_type const& placements = helper.placements();
-        for (unsigned int ii = 0; ii < placements.size(); ++ii)
-        {
-            ren.prepare_glyphs(placements[ii]);
-            ren.render_id(feature.id(), placements[ii].center);
-        }
     }
-    if (placement_found) pixmap_.add_feature(feature);
-
+    if (placement_found)
+    {
+        pixmap_.add_feature(feature);
+    }
 }
 
 template void grid_renderer<grid>::process(text_symbolizer const&,


### PR DESCRIPTION
All the grid visual tests pass.

One small issue is that in the grid line pattern symbolizer it constructs a 'fake' line symbolizer to re-use code (as the grid renderer cares nothing for patterns), but doesn't pass the offset parameter to it. The tests currently require this
behaviour, but they should probably be changed as it seems incorrect.
