### PR TITLE
prevent double-free in mapnik::projection

### DIFF
--- a/src/projection.cpp
+++ b/src/projection.cpp
@@ -108,7 +108,10 @@ void projection::init_proj4() const
         proj_ = pj_init_plus_ctx(proj_ctx_, params_.c_str());
         if (!proj_)
         {
-            if (proj_ctx_) pj_ctx_free(proj_ctx_);
+            if (proj_ctx_) {
+                pj_ctx_free(proj_ctx_);
+                proj_ctx_ = 0;
+            }
             throw proj_init_error(params_);
         }
 #else


### PR DESCRIPTION
A double-free can happen when init_proj4 is called outside of the
constructor (for projections with defer_proj_init=true) and when that
call fails. In this case proj_ctx_ is not set to NULL and then freed
again in the destructor. Set to null to avoid second pj_ctx_free call.

See #2170
This patch needs to be ported to 2.3.x and master as well.
