### PR TITLE
Group symbolizer serialization

### DIFF
--- a/include/mapnik/symbolizer_utils.hpp
+++ b/include/mapnik/symbolizer_utils.hpp
@@ -101,6 +101,12 @@ struct symbolizer_traits<building_symbolizer>
 };
 
 template<>
+struct symbolizer_traits<group_symbolizer>
+{
+    static char const* name() { return "GroupSymbolizer";}
+};
+
+template<>
 struct symbolizer_traits<debug_symbolizer>
 {
     static char const* name() { return "DebugSymbolizer";}


### PR DESCRIPTION
This pull request addresses issue #2223.

XML serialization code was missing for some of components of group symbolizer. This was causing the save map test to fail. I have added the necessary functionality to fully serialize group symbolizer to xml.
