### PR TITLE
Remove all glyph_info rounding

### DIFF
--- a/include/mapnik/text/glyph_info.hpp
+++ b/include/mapnik/text/glyph_info.hpp
@@ -64,11 +64,11 @@ struct glyph_info
     pixel_position offset;
     char_properties_ptr format;
 
-    double ymin() const { return floor(unscaled_ymin * 64.0 * scale_multiplier); }
-    double ymax() const { return ceil(unscaled_ymax * 64.0 * scale_multiplier); }
+    double ymin() const { return unscaled_ymin * 64.0 * scale_multiplier; }
+    double ymax() const { return unscaled_ymax * 64.0 * scale_multiplier; }
     double height() const { return ymax() - ymin(); };
     double advance() const { return unscaled_advance * scale_multiplier; };
-    double line_height() const { return ceil(unscaled_line_height * scale_multiplier); };
+    double line_height() const { return unscaled_line_height * scale_multiplier; };
 };
 
 } //ns mapnik


### PR DESCRIPTION
Closes #2201 

Possible alternative to #2276, removes all rounding in `glyph_info.hpp` per https://github.com/mapnik/mapnik/pull/2272#issuecomment-46520908

/cc @springmeyer 
