### PR TITLE
Hextree fix

### DIFF
--- a/include/mapnik/hextree.hpp
+++ b/include/mapnik/hextree.hpp
@@ -249,7 +249,9 @@ public:
         }
         if (colors_ == 1)
         {
-            return pal_remap_[has_holes_?1:0];
+            if (pal_remap_.size() > 1)
+                return pal_remap_[has_holes_?1:0];
+            else return 0;
         }
 
         rgba_hash_table::iterator it = color_hashmap_.find(val);
@@ -361,7 +363,7 @@ private:
 
     void print_tree(node *r, int d=0, int id=0) const
     {
-        for (int i=0; i<d; i++)
+        for (int i=0; i<d; ++i)
         {
             printf("\t");
         }
@@ -396,7 +398,7 @@ private:
     // clip extreme alfa values
     void create_palette_rek(std::vector<rgba> & palette, node * itr) const
     {
-        if (itr->count >= 3)
+        if (itr->count != 0)
         {
             unsigned count = itr->count;
             byte a = byte(itr->alphas/float(count));


### PR DESCRIPTION
Removing count  >= 3 condition and check accessing zero sized palette fixes the issue but introduce potential performance penalty (bigger sized palettes). 

FIXME: visual tests - we should disentangle rendering maps and image quantisations.
/cc @springmeyer 
