### PR TITLE
Work in HSL so luma can be preserved

### DIFF
--- a/deps/agg/src/agg_pixfmt_rgba.cpp
+++ b/deps/agg/src/agg_pixfmt_rgba.cpp
@@ -1,6 +1,7 @@
 #include "agg_pixfmt_rgba.h"
 #include <boost/gil/gil_all.hpp>
 #include <boost/gil/extension/toolbox/hsv.hpp>
+#include <boost/gil/extension/toolbox/hsl.hpp>
 //#include <iostream>
 
 namespace agg
@@ -88,15 +89,16 @@ void comp_op_rgba_color<ColorT,Order>::blend_pix(value_type* p,
     {
         using namespace boost;
         using namespace gil;
-        using namespace hsv_color_space;
+        using namespace hsl_color_space;
         rgb8_pixel_t rgb_src(sr,sg,sb);
         rgb8_pixel_t rgb_dst(p[Order::R],p[Order::G],p[Order::B]);
-        hsv32f_pixel_t hsv_src,hsv_dst;
-        color_convert( rgb_src, hsv_src);
-        color_convert( rgb_dst, hsv_dst);
-        get_color(hsv_dst,hue_t()) = get_color(hsv_src,hue_t());
-        get_color(hsv_dst,saturation_t()) = get_color(hsv_src,saturation_t());
-        color_convert(hsv_dst, rgb_dst);
+        hsl32f_pixel_t hsl_src,hsl_dst;
+        color_convert( rgb_src, hsl_src);
+        color_convert( rgb_dst, hsl_dst);
+        get_color(hsl_dst,hue_t()) = get_color(hsl_src,hue_t());
+        get_color(hsl_dst,saturation_t()) = get_color(hsl_src,saturation_t());
+        get_color(hsl_dst,lightness_t()) = get_color(hsl_dst,lightness_t());
+        color_convert(hsl_dst, rgb_dst);
         p[Order::R] = get_color(rgb_dst,red_t());
         p[Order::G] = get_color(rgb_dst,green_t());
         p[Order::B] = get_color(rgb_dst,blue_t());


### PR DESCRIPTION
Let's try this again...

[`hsl-color`](https://github.com/mapnik/mapnik/blob/bfc6c61d62be5b4aa69a09e98a38a2466ebcae30/deps/agg/src/agg_pixfmt_rgba.cpp#L74-L105) doesn't appear to use the luma from the bottom layer.

"hsl-color" is [defined by Wikipedia as](http://en.wikipedia.org/wiki/Blend_modes#Hue.2C_saturation_and_luminosity):

> The Color blend mode preserves the luma of the bottom layer, while adopting the hue and chroma of the top layer."

Cairo defines it as:

> Blend mode function:
> 
> f(cA,cB) = set_lum(cA, lum(cB))
> 
> Creates a color with the hue and saturation of the source and the luminosity of the destination. This preserves the gray levels of the destination and is useful for coloring monochrome images or tinting color images."

This is what I'd expect (generated using Cairo via `node-canvas`):

![mapstack](https://cloud.githubusercontent.com/assets/45/3652132/a7451cd0-1134-11e4-93e5-f36c04c6162b.png)

However, this is what Mapnik creates:

![blend](https://cloud.githubusercontent.com/assets/45/3652135/addcd722-1134-11e4-9a0b-153fe6938317.png)
