### PR TITLE
add ogr plugin error handling to master/3.x

### DIFF
--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -261,7 +261,13 @@ void ogr_datasource::init(mapnik::parameters const& params)
     else
     {
         OGREnvelope envelope;
-        layer->GetExtent(&envelope);
+        OGRErr e = layer->GetExtent(&envelope);
+        if (e == OGRERR_FAILURE)
+        {
+            std::ostringstream s;
+            s << "OGR Plugin: Extent missing for layer '" << layer->GetName() << "'. Use <extent> paramater to define a custom extent value.";
+            throw datasource_exception(s.str());
+        }
         extent_.init(envelope.MinX, envelope.MinY, envelope.MaxX, envelope.MaxY);
     }
 


### PR DESCRIPTION
Adding ogr plugin extent error handling to master/3.x per the the discussion in https://github.com/mapnik/mapnik/pull/2352. 
