### PR TITLE
Bring postgis simplification factor back to 1/20 of a pixel

### DIFF
--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -778,7 +778,7 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
           // 1/20 of pixel seems to be a good compromise to avoid
           // drop of collapsed polygons.
           // See https://github.com/mapnik/mapnik/issues/1639
-          const double tolerance = std::min(px_gw, px_gh) / 2.0;
+          const double tolerance = std::min(px_gw, px_gh) / 20.0;
           s << ", " << tolerance << ")";
         }
 


### PR DESCRIPTION
This was the value in 2.2.x and was accidentally changed as part
of a completely unrelated commit, see:
http://github.com/mapnik/mapnik/issues/1639#issuecomment-53388951
