### PR TITLE
fix angle calculation

### DIFF
--- a/include/mapnik/text/vertex_cache.hpp
+++ b/include/mapnik/text/vertex_cache.hpp
@@ -138,6 +138,7 @@ private:
     void rewind_subpath();
     bool next_segment();
     bool previous_segment();
+    double current_segment_angle();
     // Position as calculated by last move/forward/next call.
     pixel_position current_position_;
     // First pixel of current segment.

--- a/src/text/vertex_cache.cpp
+++ b/src/text/vertex_cache.cpp
@@ -29,29 +29,40 @@
 namespace mapnik
 {
 
+double vertex_cache::current_segment_angle()
+{
+    return atan2(-(current_segment_->pos.y - segment_starting_point_.y),
+                   current_segment_->pos.x - segment_starting_point_.x);
+}
+
 double vertex_cache::angle(double width)
 {
- /* IMPORTANT NOTE: See note about coordinate systems in placement_finder::find_point_placement()
-  * for imformation about why the y axis is inverted! */
+    // IMPORTANT NOTE: See note about coordinate systems in placement_finder::find_point_placement()
+    // for imformation about why the y axis is inverted!
     double tmp = width + position_in_segment_;
     if ((tmp <= current_segment_->length) && (tmp >= 0))
     {
         //Only calculate angle on request as it is expensive
         if (!angle_valid_)
         {
-            angle_ = atan2(-(current_segment_->pos.y - segment_starting_point_.y),
-                           current_segment_->pos.x - segment_starting_point_.x);
+            angle_ = current_segment_angle();
         }
-        return width >= 0 ? angle_ : angle_ + M_PI;
     } else
     {
         scoped_state s(*this);
-        pixel_position const& old_pos = s.get_state().position();
-        move(width);
-        double angle = atan2(-(current_position_.y - old_pos.y),
-                             current_position_.x - old_pos.x);
-        return angle;
+        if (move(width))
+        {
+            pixel_position const& old_pos = s.get_state().position();
+            return atan2(-(current_position_.y - old_pos.y),
+                           current_position_.x - old_pos.x);
+        }
+        else
+        {
+            s.restore();
+            angle_ = current_segment_angle();
+        }
     }
+    return width >= 0 ? angle_ : angle_ + M_PI;
 }
 
 bool vertex_cache::next_subpath()


### PR DESCRIPTION
Fixes following bug I found while playing with text rendering.

Angle of the last character is not always correctly calculated. Here is example in [text-halign-800-800-2.0-agg-reference.png](https://github.com/mapnik/mapnik/blob/5688a938589db2d17e398a12cd7b25e6ce9d48c3/tests/visual_tests/images/text-halign-800-800-2.0-agg-reference.png) reference image:
![00](https://cloud.githubusercontent.com/assets/1950911/4061952/382a4250-2dfc-11e4-8ca8-dc6807badcc5.png)
After this fix:
![00_](https://cloud.githubusercontent.com/assets/1950911/4061953/38466110-2dfc-11e4-86cc-9b9b9717041c.png)

[lines-4-200-200-2.0-agg-reference.png](https://github.com/mapnik/mapnik/blob/5688a938589db2d17e398a12cd7b25e6ce9d48c3/tests/visual_tests/images/lines-4-200-200-2.0-agg-reference.png):
![lines-4-200-200-2 0-agg-reference](https://cloud.githubusercontent.com/assets/1950911/4062000/9e47131a-2dfc-11e4-88e4-f5361f19fd9f.png)
After:
![lines-4-200-200-2 0-agg](https://cloud.githubusercontent.com/assets/1950911/4062005/b32863e2-2dfc-11e4-91f8-94d98246376a.png)

[lines-3-800-800-1.0-agg-reference.png](https://github.com/mapnik/mapnik/blob/5688a938589db2d17e398a12cd7b25e6ce9d48c3/tests/visual_tests/images/lines-3-800-800-1.0-agg-reference.png):
![01](https://cloud.githubusercontent.com/assets/1950911/4062091/4edff19c-2dfd-11e4-8464-5ef87719c552.png)
After:
![01_](https://cloud.githubusercontent.com/assets/1950911/4062092/4ef87816-2dfd-11e4-8ba9-d7edd89ca35a.png)

[lines-5-800-800-1.0-agg-reference.png](https://github.com/mapnik/mapnik/blob/5688a938589db2d17e398a12cd7b25e6ce9d48c3/tests/visual_tests/images/lines-5-800-800-1.0-agg-reference.png):
![02](https://cloud.githubusercontent.com/assets/1950911/4062228/51e3612a-2dfe-11e4-82bf-e15d2987f6bc.png)
After:
![02_](https://cloud.githubusercontent.com/assets/1950911/4062229/51f9a746-2dfe-11e4-97d7-465ded2d7652.png)

New placement appeared in [collision-600-400-2.0-agg-reference.png](https://github.com/mapnik/mapnik/blob/5688a938589db2d17e398a12cd7b25e6ce9d48c3/tests/visual_tests/images/collision-600-400-2.0-agg-reference.png):
![03](https://cloud.githubusercontent.com/assets/1950911/4062367/4bf7e370-2dff-11e4-80cc-f1b4d4475f83.png)
After:
![03_](https://cloud.githubusercontent.com/assets/1950911/4062368/4bf87736-2dff-11e4-9f95-eac3881c2bf9.png)

It does not change any unrelated visual tests.
