### PR TITLE
Drop multi_pass iterator

### DIFF
--- a/plugins/input/geojson/geojson_datasource.hpp
+++ b/plugins/input/geojson/geojson_datasource.hpp
@@ -82,7 +82,7 @@ public:
     mapnik::layer_descriptor get_descriptor() const;
     boost::optional<mapnik::datasource::geometry_t> get_geometry_type() const;
     template <typename T>
-    void parse_geojson(T & stream);
+    void parse_geojson(T const& buffer);
 private:
     mapnik::datasource::datasource_t type_;
     std::map<std::string, mapnik::parameters> statistics_;


### PR DESCRIPTION
Because it is designed for when you need to handle large data incrementally. In our case we parse the entire geojson file so reading the entire file is desired for speed - closes #2397
