### PR TITLE
Allow user to specify a python executable.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,8 +4,18 @@ Mapnik is cross platform and runs on Linux, Mac OSX, Solaris, *BSD, and Windows.
 
 To configure and build Mapnik do:
 
-    ./configure
-    make
+```bash
+    $ ./configure
+    $ make
+```
+
+To use a Python interpreter that is not named `python` for your build, do
+something like the following instead:
+
+```bash
+    $ PYTHON=python2 ./configure
+    $ make PYTHON=python2
+```
 
 NOTE: the above will not work on windows, rather see https://github.com/mapnik/mapnik/wiki/WindowsInstallation
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ endif
 
 OS:=$(shell uname -s)
 
+PYTHON = python
+
 ifeq ($(JOBS),)
 	JOBS:=1
 	ifeq ($(OS),Linux)
@@ -20,13 +22,13 @@ endif
 all: mapnik
 
 install:
-	python scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 install
+	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 install
 
 mapnik:
-	python scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
+	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
 
 clean:
-	@python scons/scons.py -j$(JOBS) -c --config=cache --implicit-cache --max-drift=1
+	@$(PYTHON) scons/scons.py -j$(JOBS) -c --config=cache --implicit-cache --max-drift=1
 	@if test -e ".sconsign.dblite"; then rm ".sconsign.dblite"; fi
 	@if test -e "config.log"; then rm  "config.log"; fi
 	@if test -e ".sconf_temp/"; then rm -r ".sconf_temp/"; fi
@@ -46,7 +48,7 @@ rebuild:
 	make uninstall && make clean && time make && make install
 
 uninstall:
-	@python scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 uninstall
+	@$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 uninstall
 
 test:
 	@ ./run_tests

--- a/configure
+++ b/configure
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-python scons/scons.py --implicit-deps-changed configure "$@"
+PYTHON=${PYTHON:-python}
+
+$PYTHON scons/scons.py --implicit-deps-changed configure "$@"

--- a/run_tests
+++ b/run_tests
@@ -2,8 +2,10 @@
 
 failures=0
 
+PYTHON=${PYTHON:-python}
+
 echo "*** Running visual tests..."
-python tests/visual_tests/test.py -q
+$PYTHON tests/visual_tests/test.py -q
 failures=$((failures+$?))
 
 echo "*** Running C++ tests..."
@@ -15,7 +17,7 @@ done
 echo
 
 echo "*** Running python tests..."
-python tests/run_tests.py -q
+$PYTHON tests/run_tests.py -q
 failures=$((failures+$?))
 
 exit $failures


### PR DESCRIPTION
Fall back on `python`. Unlike the solution in PR #2395 this puts all the responsibility for selecting the right python in the case that `python` is Python 3 on the user. I've followed the lead of the Python documentation Makefile. See:

http://hg.python.org/cpython/file/340d48347295/Doc/README.txt
http://hg.python.org/cpython/file/340d48347295/Doc/Makefile

Intent is that if your `python` is Python 2 everything works as before and that if your `python` is Python 3 but you have a `python2` you can specify that instead.

No changes have been made to the shebangs in the various Mapnik python scripts. But if they're run by the Makefile it'll all work out.
