### PR TITLE
Update memory requirements for g++ compiling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ For troubleshooting help see https://github.com/mapnik/mapnik/wiki/InstallationT
 Build system dependencies are:
 
  * C++ compiler (like g++ or clang++)
- * >= 2 GB RAM
+ * >= 2 GB RAM (> 5 GB for g++)
  * Python 2.4-2.7 
  * Scons (a copy is bundled)
 


### PR DESCRIPTION
Compiling with g++ fails with out of ram on Launchpad VMs with 4GB RAM + 1 GB swap
