### PR TITLE
Fix compiler warning about uninitialised variable.

### DIFF
--- a/include/mapnik/renderer_common/process_point_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_point_symbolizer.hpp
@@ -41,15 +41,10 @@ void render_point_symbolizer(point_symbolizer const &sym,
                              F render_marker)
 {
     std::string filename = get<std::string>(sym, keys::file, feature, common.vars_);
-    boost::optional<mapnik::marker_ptr> marker;
-    if (!filename.empty())
-    {
-        marker = marker_cache::instance().find(filename, true);
-    }
-    else
-    {
-        marker.reset(std::make_shared<mapnik::marker>());
-    }
+    boost::optional<mapnik::marker_ptr> marker = filename.empty()
+       ? std::make_shared<mapnik::marker>()
+       : marker_cache::instance().find(filename, true);
+
     if (marker)
     {
         double opacity = get<double>(sym,keys::opacity,feature, common.vars_, 1.0);


### PR DESCRIPTION
Fixes, at least for me on GCC 4.8.2 on Ubuntu 14.04, the warning about `marker` being uninitialised. Hopefully fixes #2468.
