### PR TITLE
fix multiple attach to the same sqlite database

### DIFF
--- a/plugins/input/sqlite/sqlite_datasource.cpp
+++ b/plugins/input/sqlite/sqlite_datasource.cpp
@@ -278,9 +278,11 @@ sqlite_datasource::sqlite_datasource(parameters const& params)
         mapnik::progress_timer __stats2__(std::clog, "sqlite_datasource::init(use_spatial_index)");
 #endif
 
+        bool index_db_attached = false;
         if (mapnik::util::exists(index_db))
         {
             dataset_->execute("attach database '" + index_db + "' as " + index_table_);
+            index_db_attached = true;
         }
         has_spatial_index_ = sqlite_utils::has_rtree(index_table_,dataset_);
 
@@ -304,7 +306,7 @@ sqlite_datasource::sqlite_datasource(parameters const& params)
                 {
                     //extent_initialized_ = true;
                     has_spatial_index_ = true;
-                    if (mapnik::util::exists(index_db))
+                    if (!index_db_attached && mapnik::util::exists(index_db))
                     {
                         dataset_->execute("attach database '" + index_db + "' as " + index_table_);
                     }


### PR DESCRIPTION
Fixes errors like "`RuntimeError: Sqlite Plugin: 'database is already in use`" from https://github.com/mapnik/mapnik/issues/1871.

All tests including https://github.com/mapnik/mapnik/pull/2461 passes on Debian Sid. Needs further digging on Debian Wheezy where I'm getting following error:

```
1) failure to run test: tests/visual_tests/images/text-data-binding-500-500-1.0
-agg-reference.png (RuntimeError('Sqlite Plugin: \'vtable constructor failed: i
dx_circular_layer_geom\' (/home/talaj/dev/mapnik_mapycz/tests/visual_tests/styl
es/../data/text-data-binding.sqlite)\nFull sql was: \'SELECT geom,id,[alignment
],[color1],[color2],[color3],[double],[placement],[text1],[text2] FROM circular
_layer WHERE id IN (SELECT pkid FROM "idx_circular_layer_geom" WHERE xmax>=-1 A
ND xmin<=1 AND ymax>=-1 AND ymin<=1)\'',))
```

Any idea why that could be?
