### PR TITLE
Add geometry_display_expression parameter

### DIFF
--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -78,6 +78,7 @@ public:
 
 private:
     std::string sql_bbox(box2d<double> const& env) const;
+    std::string substitute_tokens(std::string const& sql, double scale_denom, std::string const& box, double pixel_width, double pixel_height, bool &hasbbox) const;
     std::string populate_tokens(std::string const& sql, double scale_denom, box2d<double> const& env, double pixel_width, double pixel_height) const;
     std::string populate_tokens(std::string const& sql) const;
     boost::shared_ptr<IResultSet> get_resultset(boost::shared_ptr<Connection> &conn, std::string const& sql, CnxPool_ptr const& pool, processor_context_ptr ctx= processor_context_ptr()) const;
@@ -92,6 +93,7 @@ private:
     std::string schema_;
     std::string geometry_table_;
     const std::string geometry_field_;
+    const std::string geometry_display_expression_;
     std::string key_field_;
     mapnik::value_integer cursor_fetch_size_;
     mapnik::value_integer row_limit_;

--- a/tests/python_tests/postgis_test.py
+++ b/tests/python_tests/postgis_test.py
@@ -1011,6 +1011,17 @@ if 'postgis' in mapnik.DatasourceCache.plugin_names() \
         eq_(geoms[0].to_wkt(),'Polygon((0 0,1 1,2 2,0 0))')
         eq_(geoms[1].to_wkt(),'Polygon((0 0,1 1,2 2,0 0))')
 
+    def test_geometry_display_expression():
+        ds = mapnik.PostGIS(dbname=MAPNIK_TEST_DBNAME,
+                            table='(select ST_MakePoint(0,0) g) t',
+                            geometry_field='g',
+                            geometry_display_expression='st_translate(g,-1,1)')
+        eq_(len(ds.fields()),0)
+        fs = ds.featureset()
+        feat = fs.next()
+        geoms = feat.geometries()
+        eq_(len(geoms),1)
+        eq_(geoms[0].to_wkt(),'Point(-1 1)')
 
     atexit.register(postgis_takedown)
 


### PR DESCRIPTION
It can be used to run arbitrary functions to preprocess the geometry
to be rendered based on pixel resolution and/or bounding box.

Includes testcase
