### PR TITLE
Add Ramer Douglas Peucker Algorithm to simplify_converter

### DIFF
--- a/include/mapnik/wkt/wkt_factory.hpp
+++ b/include/mapnik/wkt/wkt_factory.hpp
@@ -45,7 +45,7 @@ inline bool from_wkt(std::string const& wkt, mapnik::geometry_container & paths)
     return qi::phrase_parse(first, last, g, space, paths);
 }
 
-inline bool to_wkt(const mapnik::geometry_container& paths, std::string& wkt)
+inline bool to_wkt(mapnik::geometry_container const& paths, std::string& wkt)
 {
     using sink_type = std::back_insert_iterator<std::string>;
     static const mapnik::wkt::wkt_multi_generator<sink_type, mapnik::geometry_container> generator;

--- a/tests/cpp_tests/simplify_converters_test.cpp
+++ b/tests/cpp_tests/simplify_converters_test.cpp
@@ -17,7 +17,7 @@
 #include <stdexcept>
 
 // Convenience method for test cases
-void simplify(const std::string& wkt_in, double tolerance, const std::string& method, const std::string& expected)
+void simplify(std::string const& wkt_in, double tolerance, std::string const& method, std::string const& expected)
 {
     //grab the geom
     mapnik::geometry_container multi_input;
@@ -33,7 +33,7 @@ void simplify(const std::string& wkt_in, double tolerance, const std::string& me
     mapnik::geometry_type* output = new mapnik::geometry_type(multi_input.front().type());
     mapnik::CommandType cmd;
     double x, y;
-    while((cmd = (mapnik::CommandType)generalizer.vertex(&x, &y)) != mapnik::SEG_END)
+    while ((cmd = (mapnik::CommandType)generalizer.vertex(&x, &y)) != mapnik::SEG_END)
     {
         output->push_vertex(x, y, cmd);
     }


### PR DESCRIPTION
This PR is meant to do exactly what is mentioned in the title. Namely there was a placeholder in the code for the RDP algorithm which allowed you to ask for that strategy but would throw an "unimplemented" exception. Since this is one of the more popular strategies for simplification and mapquest's related project mapquest/avecado is making use of these simplify_converters for vector tiles we thought we would go ahead and add this one.

Since the algorithm is not an online algorithm the first call for a vertex will run the thing in its entirety (similar to visvalingam_whyatt). Instead of constructing a new list by the general divide and conquer recursive strategy we instead mark vertices which are simplified out as we encounter them this can save on (re)allocations. This method does not use convex hulls to achieve an nlogn worst case running time (though the average case is still nlogn the worst case is n^2). It is instead the more classical implementation using recursion and list traversal.
