### PR TITLE
2.3.x: sqlite plugin - disable shared cache for sqlite prior to 3.7.15

### DIFF
--- a/plugins/input/sqlite/sqlite_connection.hpp
+++ b/plugins/input/sqlite/sqlite_connection.hpp
@@ -58,7 +58,12 @@ public:
         int mode = SQLITE_OPEN_READWRITE;
 #if SQLITE_VERSION_NUMBER >= 3006018
         // shared cache flag not available until >= 3.6.18
-        mode |= SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_SHAREDCACHE;
+        // Don't use shared cache in SQLite prior to 3.7.15.
+        // https://github.com/mapnik/mapnik/issues/2483
+        if (sqlite3_libversion_number() >= 3007015)
+        {
+            mode |= SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_SHAREDCACHE;
+        }
 #endif
         const int rc = sqlite3_open_v2 (file_.c_str(), &db_, mode, 0);
 #else


### PR DESCRIPTION
Apply https://github.com/mapnik/mapnik/pull/2528 on 2.3.x. Refs https://github.com/mapnik/mapnik/issues/2483.
