### PR TITLE
throw datasource_exception on GDAL RasterIO failures

### DIFF
--- a/tests/data/raster/missing_raster.vrt
+++ b/tests/data/raster/missing_raster.vrt
@@ -1,0 +1,45 @@
+<VRTDataset rasterXSize="2283" rasterYSize="1913">
+  <SRS>PROJCS[&quot;WGS 84 / UTM zone 30N&quot;,GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0],UNIT[&quot;degree&quot;,0.0174532925199433],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]],PROJECTION[&quot;Transverse_Mercator&quot;],PARAMETER[&quot;latitude_of_origin&quot;,0],PARAMETER[&quot;central_meridian&quot;,-3],PARAMETER[&quot;scale_factor&quot;,0.9996],PARAMETER[&quot;false_easting&quot;,500000],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;32630&quot;]]</SRS>
+  <GeoTransform> -1.4637000000000000e+04,  5.0000000000000000e+02,  0.0000000000000000e+00,  4.8596780000000000e+06,  0.0000000000000000e+00, -5.0000000000000000e+02</GeoTransform>
+  <VRTRasterBand dataType="Int16" band="1">
+    <NoDataValue>-9.99000000000000E+02</NoDataValue>
+    <HideNoDataValue>0</HideNoDataValue>
+    <ColorInterp>Palette</ColorInterp>  
+    <ColorTable>
+        <Entry c1="0" c2="0" c3="0" c4="0"/>
+        <Entry c1="0" c2="0" c3="255"/>
+        <Entry c1="0" c2="255" c3="0"/>
+        <Entry c1="255" c2="0" c3="0"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="128" c2="128" c3="128"/>
+        <Entry c1="0" c2="0" c3="255"/>
+        <Entry c1="0" c2="255" c3="0"/>
+        <Entry c1="255" c2="0" c3="0"/>
+    </ColorTable>
+    <ComplexSource>
+      <SourceFilename relativeToVRT="1">this_file_should_not_exist.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="2283" RasterYSize="1913" DataType="Int16" BlockXSize="256" BlockYSize="256" />
+      <SrcRect xOff="0" yOff="0" xSize="2283" ySize="1913" />
+      <DstRect xOff="0" yOff="0" xSize="2283" ySize="1913" />
+      <NODATA>-999</NODATA>
+    </ComplexSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/tests/python_tests/datasource_test.py
+++ b/tests/python_tests/datasource_test.py
@@ -13,6 +13,33 @@ def test_that_datasources_exist():
     if len(mapnik.DatasourceCache.plugin_names()) == 0:
         print '***NOTICE*** - no datasource plugins have been loaded'
 
+# adapted from raster_symboliser_test#test_dataraster_query_point
+def test_vrt_referring_to_missing_files():
+    srs = '+init=epsg:32630'
+    if 'gdal' in mapnik.DatasourceCache.plugin_names():
+        lyr = mapnik.Layer('dataraster')
+        lyr.datasource = mapnik.Gdal(
+            file = '../data/raster/missing_raster.vrt',
+            band = 1,
+            )
+        lyr.srs = srs
+        _map = mapnik.Map(256, 256, srs)
+        _map.layers.append(lyr)
+
+        # center of extent of raster
+        x, y = 556113.0,4381428.0 # center of extent of raster
+
+        _map.zoom_all()
+
+        # Should RuntimeError here
+        try:
+            _map.query_point(0, x, y).features
+        except RuntimeError, e:
+            eq_("this_file_should_not_exist.tif' does not exist in the file system" in str(e), True)
+        else:
+            assert False
+
+
 def test_field_listing():
     if 'shape' in mapnik.DatasourceCache.plugin_names():
         ds = mapnik.Shapefile(file='../data/shp/poly.shp')


### PR DESCRIPTION
Trying to read from a VRT that refers to a raster file that doesn't exist or cannot be read currently returns null data instead of throwing an exception.

Changes gdal_featureset to check return values from RasterIO and throw a datasource_exception if it fails.
