### PR TITLE
Ignore overviews with 0 scale in pgraster

### DIFF
--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -352,12 +352,22 @@ pgraster_datasource::pgraster_datasource(parameters const& params)
                 shared_ptr<ResultSet> rs = conn->executeQuery(s.str());
                 while (rs->next())
                 {
-                  overviews_.resize(overviews_.size()+1);
-                  pgraster_overview& ov = overviews_.back();
+                  pgraster_overview ov = pgraster_overview();
+
                   ov.schema = rs->getValue("sch"); 
                   ov.table = rs->getValue("tab");
                   ov.column = rs->getValue("col");
                   ov.scale = atof(rs->getValue("scl"));
+
+                  if(ov.scale == 0.0f)
+                  {
+                    MAPNIK_LOG_WARN(pgraster) << "pgraster_datasource: found invalid overview "
+                      << ov.schema << "." << ov.table << "." << ov.column << " with scale " << ov.scale;
+                    continue;
+                  }
+
+                  overviews_.push_back(ov);
+
                   MAPNIK_LOG_DEBUG(pgraster) << "pgraster_datasource: found overview " << ov.schema << "." << ov.table << "." << ov.column << " with scale " << ov.scale;
                 }
                 rs->close();


### PR DESCRIPTION
refs #2551

Postgis raster_columns view is returning NULL values for raster
overviews with large scale factors. That issue in postgis is described
in http://trac.osgeo.org/postgis/ticket/3006

This causes two main problems:
- The first overview with scale = NULL is wrongly chosen for rendering
  always
- The messed up scaling factor causes the render symbolizer to spent
  an insane amount of CPU and memory to render a messed up tiles.

The patch in postgis is expected to be released with the new version, a
few months from now.
