### PR TITLE
Added support to pass datasource in params to OGR/GDAL plugins.

### DIFF
--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -105,7 +105,20 @@ gdal_datasource::gdal_datasource(parameters const& params)
     shared_dataset_ = *params.get<mapnik::boolean_type>("shared", false);
     band_ = *params.get<mapnik::value_integer>("band", -1);
 
-    GDALDataset *dataset = open_dataset();
+    // Initialize with pre-created datasource
+    // Datasource addressed is passed as base 10 string that is at least 64 bits (unsigned long long)
+    // For example: p["datasource"]= std::to_string((unsigned long long) GDALDataset*);
+    boost::optional<std::string> datasource = params.get<std::string>("datasource");
+
+    GDALDataset *dataset;
+    if(datasource)
+    {
+        dataset = (GDALDataset*) std::stoull(*datasource);
+    }
+    else
+    {
+        dataset = open_dataset();
+    }
 
     nbands_ = dataset->GetRasterCount();
     width_ = dataset->GetRasterXSize();


### PR DESCRIPTION
This allows users to pass the pointer value (or address of datasource) for both OGR and GDAL plugins. This is imperative for using datasources created using the Memory driver (these cannot be reopened: http://www.gdal.org/drv_memory.html: "There is no way to open an existing Memory datastore. It must be created with CreateDataSource() and populated and used from that handle. When the datastore is closed all contents are freed and destroyed."). Users can populate a datasource and pass it to Mapnik by converting it to a string, base ten (i.e. using std::to_string()). 
