### PR TITLE
Limit size of raster buffer

### DIFF
--- a/src/agg/process_raster_symbolizer.cpp
+++ b/src/agg/process_raster_symbolizer.cpp
@@ -43,6 +43,8 @@
 #include "agg_rendering_buffer.h"
 #include "agg_pixfmt_rgba.h"
 
+#define MAX_SIZE 1024*1024
+
 
 namespace mapnik {
 
@@ -69,7 +71,9 @@ void agg_renderer<T>::process(raster_symbolizer const& sym,
         int end_y = static_cast<int>(std::floor(ext.maxy()+.5));
         int raster_width = end_x - start_x;
         int raster_height = end_y - start_y;
-        if (raster_width > 0 && raster_height > 0)
+        int raster_size = raster_width * raster_height;
+
+        if (raster_width > 0 && raster_height > 0  && raster_size > 0 && raster_size <= MAX_SIZE)
         {
             scaling_method_e scaling_method = sym.get_scaling_method();
             double filter_radius = sym.calculate_filter_factor();


### PR DESCRIPTION
Right now the pgraster_datasource can feed the raster symbolizer with
tiles that are first scaled up then cropped and that might result in the
symbolizer trying to allocate insane amounts of memory to just scale up
a few pixels.

This is also the source of some problems such as the bad_alloc when
raster_width * raster_height overflow and tries a mem alloc with a
negative value.