### PR TITLE
Double jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
   include:
     - os: osx
       compiler: clang
-      env: JOBS=6
+      env: JOBS=12
     - os: linux
       compiler: clang
-      env: JOBS=6
+      env: JOBS=12
     - os: linux
       compiler: gcc
-      env: JOBS=2
+      env: JOBS=6
 
 install:
  - if [[ $(uname -s) == 'Linux' ]]; then psql -U postgres -c 'create database template_postgis;' -U postgres; psql -U postgres -c 'create extension postgis;' -d template_postgis -U postgres; fi;

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ mapnik:
 		src/expression_grammar.os \
 		src/transform_expression_grammar.os \
 		src/image_filter_types.os \
-		src/renderer_common/process_group_symbolizer.cpp \
-		src/agg/process_markers_symbolizer.cpp \
-		src/agg/process_group_symbolizer.cpp \
-		src/grid/process_markers_symbolizer.cpp \
-		src/grid/process_group_symbolizer.cpp \
-		src/cairo/process_markers_symbolizer.cpp \
-		src/cairo/process_group_symbolizer.cpp \
+		src/renderer_common/process_group_symbolizer.os \
+		src/agg/process_markers_symbolizer.os \
+		src/agg/process_group_symbolizer.os \
+		src/grid/process_markers_symbolizer.os \
+		src/grid/process_group_symbolizer.os \
+		src/cairo/process_markers_symbolizer.os \
+		src/cairo/process_group_symbolizer.os \
 	# then install the rest with -j$(JOBS)
 	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ install:
 	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 install
 
 mapnik:
-	# we first build memory intensive files with -j1
-	$(PYTHON) scons/scons.py -j1 \
+	# we first build memory intensive files with -j2
+	$(PYTHON) scons/scons.py -j2 \
 		--config=cache --implicit-cache --max-drift=1 \
 		src/json/libmapnik-json.a \
 		src/wkt/libmapnik-wkt.a \
@@ -24,8 +24,11 @@ mapnik:
 		src/image_filter_types.os \
 		src/renderer_common/process_group_symbolizer.cpp \
 		src/agg/process_markers_symbolizer.cpp \
+		src/agg/process_group_symbolizer.cpp \
 		src/grid/process_markers_symbolizer.cpp \
-		src/cairo/process_markers_symbolizer.cpp
+		src/grid/process_group_symbolizer.cpp \
+		src/cairo/process_markers_symbolizer.cpp \
+		src/cairo/process_group_symbolizer.cpp \
 	# then install the rest with -j$(JOBS)
 	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
 


### PR DESCRIPTION
Now that we are running sudoless we can up the JOBS more since travis containers have "dedicated" 2 CPU and 4 GB Ram (http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/)