### PR TITLE
fix gcc compile

### DIFF
--- a/include/mapnik/json/feature_collection_grammar.hpp
+++ b/include/mapnik/json/feature_collection_grammar.hpp
@@ -77,7 +77,7 @@ struct feature_collection_grammar :
     qi::rule<Iterator, qi::locals<feature_ptr,int>, void(context_ptr const& ctx, std::size_t, FeatureCallback&), space_type> feature;
     qi::rule<Iterator, qi::locals<feature_ptr,int>, void(context_ptr const& ctx, std::size_t, FeatureCallback&), space_type> feature_from_geometry;
     // phoenix functions
-    phoenix::function<extract_geometry> extract_geometry;
+    phoenix::function<json::extract_geometry> extract_geometry;
     phoenix::function<apply_feature_callback> on_feature;
 };
 


### PR DESCRIPTION
Fixes following compilation error with GCC. Tested with GCC 4.9.2.

```
In file included from include/mapnik/json/feature_collection_grammar_impl.hpp:26:0,
                 from src/json/mapnik_json_feature_collection_grammar.cpp:24:
include/mapnik/json/feature_collection_grammar.hpp:80:41: error: declaration of ‘boost::phoenix::function<
mapnik::json::extract_geometry> mapnik::json::feature_collection_grammar<Iterator, FeatureType, FeatureCal
lback>::extract_geometry’ [-fpermissive]
     phoenix::function<extract_geometry> extract_geometry;
                                         ^
In file included from include/mapnik/json/feature_collection_grammar.hpp:29:0,
                 from include/mapnik/json/feature_collection_grammar_impl.hpp:26,
                 from src/json/mapnik_json_feature_collection_grammar.cpp:24:
include/mapnik/json/feature_grammar.hpp:82:8: error: changes meaning of ‘extract_geometry’ from ‘struct ma
pnik::json::extract_geometry’ [-fpermissive]
 struct extract_geometry
        ^
```