### PR TITLE
Added combined placement option

### DIFF
--- a/include/mapnik/text/placements/base.hpp
+++ b/include/mapnik/text/placements/base.hpp
@@ -61,6 +61,9 @@ public:
 
     // Scale factor used by the renderer.
     double scale_factor;
+    
+    //reset the state for the placement
+    virtual void reset_state() = 0;
 
 };
 

--- a/include/mapnik/text/placements/combined.hpp
+++ b/include/mapnik/text/placements/combined.hpp
@@ -1,0 +1,69 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2015 Walid Ibrahim
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef TEXT_PLACEMENTS_COMBINED_HPP
+#define TEXT_PLACEMENTS_COMBINED_HPP
+
+#include <mapnik/text/placements/base.hpp>
+
+namespace mapnik {
+
+    class text_placements_info_combined;
+    class feature_impl;
+    struct attribute;
+    
+    class text_placements_combined: public text_placements
+    {
+        
+    public:
+        text_placements_combined(text_placements_ptr simple_placement, text_placements_ptr list_placement);
+        text_placement_info_ptr get_placement_info(double scale_factor, feature_impl const& feature, attributes const& vars) const;
+        virtual void add_expressions(expression_set & output) const;
+        static text_placements_ptr from_xml(xml_node const& xml, fontset_map const& fontsets, bool is_shield);
+        
+        text_placements_ptr get_simple_placement() { return simple_placement_; }
+        text_placements_ptr get_list_placement() { return list_placement_; }
+        
+    private:
+        text_placements_ptr simple_placement_;
+        text_placements_ptr list_placement_;
+        
+        friend class text_placements_info_combined;
+    };
+    
+    
+    class text_placement_info_combined: public text_placement_info
+    {
+        
+    public:
+        text_placement_info_combined(text_placements_combined const* parent, double scale_factor, text_placement_info_ptr simple_placement_info, text_placement_info_ptr list_placement_info);
+        bool next() const;
+        virtual void reset_state();
+    private:
+        text_placements_combined const* parent_;
+        text_placement_info_ptr simple_placement_info_;
+        text_placement_info_ptr list_placement_info_;
+    };
+    
+} //namespace
+
+#endif

--- a/include/mapnik/text/placements/dummy.hpp
+++ b/include/mapnik/text/placements/dummy.hpp
@@ -49,6 +49,7 @@ public:
         : text_placement_info(parent, scale_factor),
         state(0) {}
     bool next() const;
+    virtual void reset_state() { state = 0; }
 private:
     mutable unsigned state;
 };

--- a/include/mapnik/text/placements/list.hpp
+++ b/include/mapnik/text/placements/list.hpp
@@ -54,6 +54,7 @@ public:
         text_placement_info(parent, scale_factor),
         state(0), parent_(parent) {}
     bool next() const;
+    virtual void reset_state() { state = 0; }
 private:
     mutable unsigned state;
     text_placements_list const* parent_;

--- a/include/mapnik/text/placements/simple.hpp
+++ b/include/mapnik/text/placements/simple.hpp
@@ -60,6 +60,7 @@ public:
                                std::string const& evaluated_positions,
                                double scale_factor);
     bool next() const;
+    virtual void reset_state() {state = 0; position_state = 0;}
 protected:
     bool next_position_only() const;
     mutable unsigned state;

--- a/src/text/placements/combined.cpp
+++ b/src/text/placements/combined.cpp
@@ -1,0 +1,113 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2015 Walid Ibrahim
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+//mapnik
+#include <mapnik/text/placements/combined.hpp>
+#include <mapnik/xml_node.hpp>
+
+#include <mapnik/text/placements/list.hpp>
+#include <mapnik/text/placements/simple.hpp>
+
+namespace mapnik
+{
+
+//text_placements_combined class
+text_placements_combined::text_placements_combined(text_placements_ptr simple_placement, text_placements_ptr list_placement)
+: simple_placement_(simple_placement),
+  list_placement_(list_placement)
+{
+}
+
+text_placement_info_ptr text_placements_combined::get_placement_info(double scale_factor, feature_impl const& feature, attributes const& vars) const
+{
+    text_placement_info_ptr simple_placement_info = simple_placement_->get_placement_info(scale_factor, feature, vars);
+    
+    text_placement_info_ptr list_placement_info = list_placement_->get_placement_info(scale_factor, feature, vars);
+    
+    return std::make_shared<text_placement_info_combined>(this, scale_factor, simple_placement_info, list_placement_info);
+}
+    
+void text_placements_combined::add_expressions(expression_set & output) const
+{
+    simple_placement_->add_expressions(output);
+    list_placement_->add_expressions(output);
+}
+
+text_placements_ptr text_placements_combined::from_xml(xml_node const& xml, fontset_map const& fontsets, bool is_shield)
+{
+    text_placements_ptr simple_placement_ptr = text_placements_simple::from_xml(xml, fontsets, is_shield);
+    text_placements_ptr list_placement_ptr = text_placements_list::from_xml(xml, fontsets, is_shield);
+    if(simple_placement_ptr && list_placement_ptr)
+    {
+        return std::make_shared<text_placements_combined>(simple_placement_ptr, list_placement_ptr);
+    }
+    return text_placements_ptr();
+}
+    
+//text_placement_info_combined class
+    
+text_placement_info_combined::text_placement_info_combined(text_placements_combined const* parent, double scale_factor, text_placement_info_ptr simple_placement_info, text_placement_info_ptr list_placement_info)
+: text_placement_info(parent, scale_factor),
+  parent_(parent),
+  simple_placement_info_(simple_placement_info),
+  list_placement_info_(list_placement_info)
+{
+}
+    
+void text_placement_info_combined::reset_state()
+{
+    simple_placement_info_->reset_state();
+    list_placement_info_->reset_state();
+}
+    
+bool text_placement_info_combined::next() const
+{
+    //logic to get the next combined point placement
+    if(simple_placement_info_ && list_placement_info_)
+    {
+        if(simple_placement_info_->next())
+        {
+            properties.format_defaults.text_size = simple_placement_info_->properties.format_defaults.text_size;
+            properties.layout_defaults.dir = simple_placement_info_->properties.layout_defaults.dir;
+        }
+        else if(list_placement_info_->next())
+        {
+            //simple reset state
+            simple_placement_info_->reset_state();
+            simple_placement_info_->properties = list_placement_info_->properties;
+            properties = list_placement_info_->properties;
+            if(simple_placement_info_->next())
+            {
+                properties.format_defaults.text_size = simple_placement_info_->properties.format_defaults.text_size;
+                properties.layout_defaults.dir = simple_placement_info_->properties.layout_defaults.dir;
+            }
+        }
+        else
+        {
+            return false;
+        }
+         return true;
+    }
+    return false;
+}
+    
+}//namespace

--- a/src/text/placements/registry.cpp
+++ b/src/text/placements/registry.cpp
@@ -23,6 +23,7 @@
 #include <mapnik/text/placements/registry.hpp>
 #include <mapnik/text/placements/simple.hpp>
 #include <mapnik/text/placements/list.hpp>
+#include <mapnik/text/placements/combined.hpp>
 #include <mapnik/text/placements/dummy.hpp>
 #include <mapnik/config_error.hpp>
 
@@ -35,6 +36,7 @@ registry::registry()
 {
     register_name("simple", &text_placements_simple::from_xml);
     register_name("list", &text_placements_list::from_xml);
+    register_name("combined", &text_placements_combined::from_xml);
     register_name("dummy", &text_placements_list::from_xml);
 }
 


### PR DESCRIPTION
List and simple placements were already supported by Shield and Text Symbolizers, but we can only use one of them at a time.
In the proposed changes, I combined both placements options into a single "combined" placements, were the engine tries the simple placement algorithm as specified first and if no placement is found, then it check its list placement options and re-applies the simple placement again.

A possible test case would be

```xml
<Map srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
 <Style name="test_style">
        <Rule>
            <MarkersSymbolizer/>
            <TextSymbolizer face-name="DejaVu Sans Book" placement="point" dx="5" dy="-5" size="10" fill="green" justify-alignment="left" avoid-edges="true" adjust-edges="true" allow-overlap="false" clip="false" placement-type="combined" placements="N,NE,E,SE,S,SW,W,NW">[name]
                <Placement dx="10" dy="-10"  fill="blue"/>
                <Placement dx="10" dy="10"  fill="blue"/>
                <Placement dx="15" dy="-15"  fill="orange"/>
                <Placement dx="15" dy="15"  fill="orange"/>
                <Placement dx="20" dy="-20"  fill="yellow"/>
                <Placement dx="20" dy="20"  fill="yellow"/>
                <Placement dx="25" dy="-25"  fill="red"/>
                <Placement dx="25" dy="25"  fill="red"/>
                <Placement dx="35" dy="-35"  fill="purple"/>
                <Placement dx="35" dy="35"  fill="purple"/>
                <Placement dx="45" dy="-45"  fill="rgb(50,50,180)"/>
                <Placement dx="45" dy="45"  fill="rgb(50,50,180)"/>
            </TextSymbolizer>
        </Rule>
    </Style>
    
    <Layer name="test_layer" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
        <StyleName>test_style</StyleName>
        <Datasource>
            <Parameter name="type">csv</Parameter>
            <Parameter name="inline">
id|name|wkt
1|1st label|Point(-45 45)
2|2nd label|Point(-45 45)
3|3rd label|Point(-45 45)
4|4th label|Point(-45 45)
5|5th label|Point(-45 45)
6|6th label|Point(-45 45)
7|7th label|Point(-45 45)
8|8th label|Point(-45 45)
9|9th label|Point(-45 45)
10|10th label|Point(-45 45)
11|11th label|Point(-45 45)
12|12th label|Point(-45 45)
13|13th label|Point(-45 45)
14|14th label|Point(-45 45)
15|15th label|Point(-45 45)
16|16th label|Point(-45 45)
17|17th label|Point(-45 45)
18|18th label|Point(-45 45)
19|19th label|Point(-45 45)
20|20th label|Point(-45 45)
            </Parameter>
        </Datasource>
    </Layer>
</Map>
```

And the output is:

![1_1_2](https://cloud.githubusercontent.com/assets/4129570/6068685/1d0360ae-ad4c-11e4-9533-1ca85e83f4e6.png)

