### PR TITLE
Report proj4 string in extra metadata for ogr plugin - refs #2650

### DIFF
--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -32,6 +32,7 @@
 #include <mapnik/geom_util.hpp>
 #include <mapnik/timer.hpp>
 #include <mapnik/utils.hpp>
+#include <mapnik/util/trim.hpp>
 
 // boost
 #pragma GCC diagnostic push
@@ -365,6 +366,13 @@ void ogr_datasource::init(mapnik::parameters const& params)
             }
         }
     }
+    mapnik::parameters & extra_params = desc_.get_extra_parameters();
+    OGRSpatialReference * srs_ref = layer->GetSpatialRef();
+    char * srs_output = NULL;
+    if (srs_ref && srs_ref->exportToProj4( &srs_output ) == OGRERR_NONE ) {
+        extra_params["proj4"] = mapnik::util::trim_copy(srs_output);
+    }
+    CPLFree(srs_output);
 }
 
 const char * ogr_datasource::name()

--- a/tests/python_tests/ogr_test.py
+++ b/tests/python_tests/ogr_test.py
@@ -14,14 +14,15 @@ if 'ogr' in mapnik.DatasourceCache.plugin_names():
 
     # Shapefile initialization
     def test_shapefile_init():
-        s = mapnik.Ogr(file='../../demo/data/boundaries.shp',layer_by_index=0)
-
-        e = s.envelope()
-
+        ds = mapnik.Ogr(file='../../demo/data/boundaries.shp',layer_by_index=0)
+        e = ds.envelope()
         assert_almost_equal(e.minx, -11121.6896651, places=7)
         assert_almost_equal(e.miny, -724724.216526, places=6)
         assert_almost_equal(e.maxx, 2463000.67866, places=5)
         assert_almost_equal(e.maxy, 1649661.267, places=3)
+        meta = ds.describe()
+        eq_(meta['geometry_type'],mapnik.DataGeometryType.Polygon)
+        eq_('+proj=lcc' in meta['proj4'],True)
 
     # Shapefile properties
     def test_shapefile_properties():
@@ -35,6 +36,8 @@ if 'ogr' in mapnik.DatasourceCache.plugin_names():
         eq_(f['NAME_EN'], u'Quebec')
         eq_(f['Shape_Area'], 1512185733150.0)
         eq_(f['Shape_Leng'], 19218883.724300001)
+        meta = ds.describe()
+        eq_(meta['geometry_type'],mapnik.DataGeometryType.Polygon)
         # NOTE: encoding is latin1 but gdal >= 1.9 should now expose utf8 encoded features
         # See SHAPE_ENCODING for overriding: http://gdal.org/ogr/drv_shapefile.html
         # Failure for the NOM_FR field is expected for older gdal
@@ -68,6 +71,9 @@ if 'ogr' in mapnik.DatasourceCache.plugin_names():
         eq_(e.miny,-1)
         eq_(e.maxx,1)
         eq_(e.maxy,1)
+        meta = ds.describe()
+        eq_(meta['geometry_type'],mapnik.DataGeometryType.Polygon)
+        eq_('+proj=merc' in meta['proj4'],True)
 
     def test_ogr_reading_gpx_waypoint():
         ds = mapnik.Ogr(file='../data/gpx/empty.gpx',layer='waypoints')
@@ -76,6 +82,9 @@ if 'ogr' in mapnik.DatasourceCache.plugin_names():
         eq_(e.miny,48)
         eq_(e.maxx,-122)
         eq_(e.maxy,48)
+        meta = ds.describe()
+        eq_(meta['geometry_type'],mapnik.DataGeometryType.Point)
+        eq_('+proj=longlat' in meta['proj4'],True)
 
     def test_ogr_empty_data_should_not_throw():
         default_logging_severity = mapnik.logger.get_severity()
@@ -89,6 +98,9 @@ if 'ogr' in mapnik.DatasourceCache.plugin_names():
             eq_(e.maxx,0)
             eq_(e.maxy,0)
         mapnik.logger.set_severity(default_logging_severity)
+        meta = ds.describe()
+        eq_(meta['geometry_type'],mapnik.DataGeometryType.Point)
+        eq_('+proj=longlat' in meta['proj4'],True)
 
     # disabled because OGR prints an annoying error: ERROR 1: Invalid Point object. Missing 'coordinates' member.
     #def test_handling_of_null_features():


### PR DESCRIPTION
Calling applications should be able to ask mapnik plugins for extra metadata that is not expensive and easy to fetch for certain plugins. This is another small step like #2650, but for OGR to report what it knows about projections.