### PR TITLE
Prevent potential for crashes at exit related to libgdal

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -80,7 +80,21 @@ PluginInfo::~PluginInfo()
     if (module_)
     {
 #ifdef MAPNIK_SUPPORTS_DLOPEN
-        if (module_->dl) dlclose(module_->dl),module_->dl=0;
+        /*
+          We do not call dlclose for plugins that link libgdal.
+          This is a terrible hack, but necessary to prevent crashes
+          at exit when gdal attempts to shutdown. The problem arises
+          when Mapnik is used with another library that uses thread-local
+          storage (like libuv). In this case GDAL also tries to cleanup thread
+          local storage and leaves things in a state that causes libuv to crash.
+          This is partially fixed by http://trac.osgeo.org/gdal/ticket/5509 but only
+          in the case that gdal is linked as a shared library. This workaround therefore
+          prevents crashes with gdal 1.11.x and gdal 2.x when using a static libgdal.
+        */
+        if (module_->dl && name_ != "gdal" && name_ != "ogr")
+        {
+            dlclose(module_->dl),module_->dl=0;
+        }
 #endif
         delete module_;
     }


### PR DESCRIPTION
This changes the plugin behavior to stop calling dlclose on plugins linking libgdal. This causes the libgdal global cleanup not to run and can prevent crashes. The backstory is at http://trac.osgeo.org/gdal/ticket/5509.

This is needed to be able to use node-mapnik with gdal 1.11.x. It is not needed to use node-mapnik with gdal 2.x (due to the fix applied to gdal master in http://trac.osgeo.org/gdal/ticket/5509) as long as libgdal is linked to gdal.input and ogr.input dynamically. So, once GDAL 2.0 is released we could consider removing this hack if, at that time, it seems reasonable to not need to link libgdal statically.

refs https://github.com/mapnik/node-mapnik/issues/251

Unbreaks builds of mapnik against mapnik-packaging after https://github.com/mapnik/mapnik-packaging/commit/e517f8c890831344021feacd369831712e4cc058
