### PR TITLE
fix compile json grammar with boost 1.49

### DIFF
--- a/include/mapnik/json/generic_json.hpp
+++ b/include/mapnik/json/generic_json.hpp
@@ -57,8 +57,7 @@ struct unicode_string : qi::grammar<Iterator, std::string()>
 
 struct push_utf8
 {
-    template <typename S, typename C>
-    struct result { typedef void type; };
+    typedef void result_type;
 
     void operator()(std::string& utf8, uchar code_point) const
     {
@@ -71,8 +70,7 @@ struct push_utf8
 
 struct push_esc
 {
-    template <typename S, typename C>
-    struct result { typedef void type; };
+    typedef void result_type;
 
     void operator()(std::string& utf8, uchar c) const
     {


### PR DESCRIPTION
I tried to compile Mapnik on Wheezy with Boost 1.49 and G++ 4.9 after longer time and ended up with following error.

```
src/json/mapnik_json_feature_grammar.cpp:28:31:   required from here
/usr/include/boost/utility/result_of.hpp:82:8: error: wrong number of template arguments (1, should be 2)
 struct result_of_nested_result : F::template result<FArgs>
        ^
In file included from include/mapnik/json/geometry_grammar.hpp:30:0,
                 from include/mapnik/json/feature_grammar.hpp:27,
                 from include/mapnik/json/feature_grammar_impl.hpp:25,
                 from src/json/mapnik_json_feature_grammar.cpp:24:
include/mapnik/json/generic_json.hpp:61:12: error: provided for ‘template<class S, class C> struct mapnik::json::push_utf8::result’
     struct result { typedef void type; };
            ^
...
```
I found by git bisect that the problem appeared in https://github.com/mapnik/mapnik/commit/89e516b49348775fca512718fb5afa16ecdbb122.

@artemp 
