### PR TITLE
Update Boost minimum version for `is_valid`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ Build system dependencies are:
 Mapnik Core depends on:
 
  * Boost
-    - >= 1.47 is required and >= 1.56 recommended
+    - >= 1.56 is required
     - These libraries are used:
       - filesystem
       - system

--- a/SConstruct
+++ b/SConstruct
@@ -63,7 +63,7 @@ SCONS_CONFIGURE_CACHE = 'config.cache'
 SCONF_TEMP_DIR = '.sconf_temp'
 # auto-search directories for boost libs/headers
 BOOST_SEARCH_PREFIXES = ['/usr/local','/opt/local','/sw','/usr',]
-BOOST_MIN_VERSION = '1.47'
+BOOST_MIN_VERSION = '1.56'
 #CAIRO_MIN_VERSION = '1.8.0'
 
 HARFBUZZ_MIN_VERSION = (0, 9, 34)


### PR DESCRIPTION
The minimum Boost version which contains the header `boost/geometry/algorithms/is_valid.hpp`, used in `include/mapnik/geometry_is_valid.hpp` appears to be 1.56. This updates the configure (SCons) script to require that as the minimum version and the install instructions.
