### PR TITLE
Disable missing geometry functions in older Boost versions.

### DIFF
--- a/bindings/python/mapnik_geometry.cpp
+++ b/bindings/python/mapnik_geometry.cpp
@@ -150,6 +150,9 @@ mapnik::box2d<double> geometry_envelope_impl(mapnik::geometry::geometry<double> 
     return mapnik::geometry::envelope(geom);
 }
 
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
+
 bool geometry_is_valid_impl(mapnik::geometry::geometry<double> const& geom)
 {
     return mapnik::geometry::is_valid(geom);
@@ -159,6 +162,8 @@ bool geometry_is_simple_impl(mapnik::geometry::geometry<double> const& geom)
 {
     return mapnik::geometry::is_simple(geom);
 }
+
+#endif // BOOST_VERSION >= 1.56
 
 bool geometry_is_empty_impl(mapnik::geometry::geometry<double> const& geom)
 {
@@ -221,8 +226,11 @@ void export_geometry()
                                                 "Constructs a new Point object\n"))
         .add_property("x", &point<double>::x, "X coordinate")
         .add_property("y", &point<double>::y, "Y coordinate")
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
         .def("is_valid", &geometry_is_valid_impl)
         .def("is_simple", &geometry_is_simple_impl)
+#endif // BOOST_VERSION >= 1.56
         .def("to_geojson",&to_geojson_impl)
         .def("to_wkb",&to_wkb_impl)
         .def("to_wkt",&to_wkt_impl)
@@ -231,8 +239,11 @@ void export_geometry()
     class_<line_string<double> >("LineString", init<>(
                       "Constructs a new LineString object\n"))
         .def("add_coord", &line_string<double>::add_coord, "Adds coord")
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
         .def("is_valid", &geometry_is_valid_impl)
         .def("is_simple", &geometry_is_simple_impl)
+#endif // BOOST_VERSION >= 1.56
         .def("to_geojson",&to_geojson_impl)
         .def("to_wkb",&to_wkb_impl)
         .def("to_wkt",&to_wkt_impl)
@@ -248,8 +259,11 @@ void export_geometry()
         .add_property("exterior_ring", &polygon<double>::exterior_ring , "Exterior ring")
         .def("add_hole", &polygon_add_hole_impl, "Add interior ring")
         .def("num_rings", polygon_set_exterior_impl, "Number of rings (at least 1)")
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
         .def("is_valid", &geometry_is_valid_impl)
         .def("is_simple", &geometry_is_simple_impl)
+#endif // BOOST_VERSION >= 1.56
         .def("to_geojson",&to_geojson_impl)
         .def("to_wkb",&to_wkb_impl)
         .def("to_wkt",&to_wkt_impl)
@@ -265,8 +279,11 @@ void export_geometry()
         .staticmethod("from_wkb")
         .def("__str__",&to_wkt_impl)
         .def("type",&geometry_type_impl)
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
         .def("is_valid", &geometry_is_valid_impl)
         .def("is_simple", &geometry_is_simple_impl)
+#endif // BOOST_VERSION >= 1.56
         .def("is_empty", &geometry_is_empty_impl)
         .def("correct", &geometry_correct_impl)
         .def("centroid",&geometry_centroid_impl)

--- a/include/mapnik/geometry_is_simple.hpp
+++ b/include/mapnik/geometry_is_simple.hpp
@@ -23,6 +23,9 @@
 #ifndef MAPNIK_GEOMETRY_IS_SIMPLE_HPP
 #define MAPNIK_GEOMETRY_IS_SIMPLE_HPP
 
+// only Boost >= 1.56 contains the is_simple function
+#if BOOST_VERSION >= 105600
+
 #include <mapnik/geometry.hpp>
 #include <mapnik/geometry_adapters.hpp>
 #include <boost/geometry/algorithms/is_simple.hpp>
@@ -99,4 +102,5 @@ inline bool is_simple(T const& geom)
 
 }}
 
+#endif // BOOST_VERSION >= 1.56
 #endif // MAPNIK_GEOMETRY_IS_SIMPLE_HPP

--- a/include/mapnik/geometry_is_valid.hpp
+++ b/include/mapnik/geometry_is_valid.hpp
@@ -23,6 +23,9 @@
 #ifndef MAPNIK_GEOMETRY_IS_VALID_HPP
 #define MAPNIK_GEOMETRY_IS_VALID_HPP
 
+// only Boost >= 1.56 contains the is_valid function
+#if BOOST_VERSION >= 105600
+
 #include <mapnik/geometry.hpp>
 #include <mapnik/geometry_adapters.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
@@ -103,4 +106,5 @@ inline bool is_valid(T const& geom)
 
 }}
 
+#endif // BOOST_VERSION >= 1.56
 #endif // MAPNIK_GEOMETRY_IS_VALID_HPP

--- a/tests/cpp_tests/wkb_formats_test.cpp
+++ b/tests/cpp_tests/wkb_formats_test.cpp
@@ -10,6 +10,14 @@
 #include <vector>
 #include <algorithm>
 
+namespace {
+void test_simple_and_valid(const mapnik::geometry::geometry<double> &geom) {
+// only Boost >= 1.56 has is_valid and is_simple
+#if BOOST_VERSION >= 105600
+    BOOST_TEST(mapnik::geometry::is_valid(geom) && mapnik::geometry::is_simple(geom));
+#endif
+}
+}
 
 int main(int argc, char** argv)
 {
@@ -74,13 +82,13 @@ int main(int argc, char** argv)
                                                                                mapnik::wkbSpatiaLite);
         // winding order is not correct per OGC so we'll fix it
         mapnik::geometry::correct(geom);
-        BOOST_TEST(mapnik::geometry::is_valid(geom) && mapnik::geometry::is_simple(geom));
+        test_simple_and_valid(geom);
 
         geom = mapnik::geometry_utils::from_wkb((const char*)sp_valid_blob,
                                                 sizeof(sp_valid_blob) / sizeof(sp_valid_blob[0]),
                                                 mapnik::wkbAuto);
         mapnik::geometry::correct(geom);
-        BOOST_TEST(mapnik::geometry::is_valid(geom) && mapnik::geometry::is_simple(geom));
+        test_simple_and_valid(geom);
 
         geom = mapnik::geometry_utils::from_wkb((const char*)sp_invalid_blob,
                                                 sizeof(sp_invalid_blob) / sizeof(sp_invalid_blob[0]),
@@ -92,13 +100,13 @@ int main(int argc, char** argv)
         geom = mapnik::geometry_utils::from_wkb((const char*)sq_valid_blob,
                                                 sizeof(sq_valid_blob) / sizeof(sq_valid_blob[0]),
                                                 mapnik::wkbGeneric);
-        BOOST_TEST(mapnik::geometry::is_valid(geom) && mapnik::geometry::is_simple(geom));
+        test_simple_and_valid(geom);
 
         geom = mapnik::geometry_utils::from_wkb( (const char*)sq_valid_blob,
                                                  sizeof(sq_valid_blob) / sizeof(sq_valid_blob[0]),
                                                  mapnik::wkbAuto);
 
-        BOOST_TEST(mapnik::geometry::is_valid(geom) && mapnik::geometry::is_simple(geom));
+        test_simple_and_valid(geom);
 
         geom = mapnik::geometry_utils::from_wkb((const char*)sq_invalid_blob,
                                                 sizeof(sq_invalid_blob) / sizeof(sq_invalid_blob[0]),

--- a/tests/cxx/geometry_is_valid.cpp
+++ b/tests/cxx/geometry_is_valid.cpp
@@ -6,6 +6,9 @@
 
 TEST_CASE("geometry is_valid") {
 
+// only Boost >= 1.56 has the is_valid function
+#if BOOST_VERSION >= 105600
+
 SECTION("point") {
     mapnik::geometry::point<double> pt(0,0);
     REQUIRE( mapnik::geometry::is_valid(pt) );
@@ -22,5 +25,7 @@ SECTION("line_string") {
     REQUIRE( mapnik::geometry::is_valid(line) );
 
 }
+
+#endif // BOOST_VERSION >= 1.56
 
 }


### PR DESCRIPTION
The functions `is_valid` and `is_simple` and their associated headers are only present in versions of Boost >= 1.56, and will cause compilation errors with previous versions of Boost. This masks them with preprocessor macros to allow the compilation to complete, at the cost of some (currently not widely used) functionality.

Refs #2769.