### PR TITLE
make mapnik-config able to report relative paths to share/ data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,11 @@ script:
    elif [[ ${MASON_PUBLISH == true]]; then
     export MASON_NAME=mapnik;
     export MASON_VERSION=latest;
-    export MASON_LIB_FILE=lib/libmapnik-wkt.a
+    export MASON_LIB_FILE=lib/libmapnik-wkt.a;
     source ./.mason.sh; 
     ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True;
    else
-    ./configure
+    ./configure;
    fi;
  - make
  - git clone --depth=1 https://github.com/mapnik/test-data test-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
     export MASON_VERSION=latest;
     export MASON_LIB_FILE=lib/libmapnik-wkt.a
     source ./.mason.sh; 
-    ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='';
+    ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True;
    else
     ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
  - source bootstrap.sh
  - if [[ ${COVERAGE} == true ]]; then 
     ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
-   elif [[ ${MASON_PUBLISH} == true]]; then
+   elif [[ ${MASON_PUBLISH} == true ]]; then
     export MASON_NAME=mapnik;
     export MASON_VERSION=latest;
     export MASON_LIB_FILE=lib/libmapnik-wkt.a;

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 git:
   depth: 2
 
+env:
+  global:
+   - secure: "N3a5nzzsgpuu45k8qWdYsHNxrSnqeAGLTOYpfYoAH7B94vuf7pa7XV1tQjXbxrnx2D6ryTdtUtyRKwy7zXbwXxGt4DpczWEo8f6DUd6+obAp3kdnXABg2Sj4oA7KMs0F0CmoADy0jdUZD5YyOJHu64LCIIgzEQ9q49PFMNbU3IE="
+   - secure: "iQYPNpMtejcgYeUkWZGIWz1msIco5qydJrhZTSCQOYahAQerdT7q5WZEpEo3G6IWOGgO1eo7GFuY8DvqQjw1+jC9b9mhkRNdo3LhGTKS9Gsbl5Q27k0rjlaFZmmQHrfPlQJwhfAIp+KLugHtQw5bCoLh+95E3j0F0DayF1tuJ3s="
 addons:
   postgresql: "9.4"
   apt:
@@ -44,14 +48,35 @@ install:
    else
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;
    fi;
+ - if [[ ${COVERAGE} == true ]]; then
+    PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls;
+   fi;
 
 script:
  - source bootstrap.sh
- - if [[ ${COVERAGE} == true ]]; then ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True; else ./configure; fi;
+ - if [[ ${COVERAGE} != true ]]; then 
+    export MASON_NAME=mapnik;
+    export MASON_VERSION=latest;
+    export MASON_LIB_FILE=lib/libmapnik-wkt.a
+    source ./.mason.sh; 
+    ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='';
+   else
+    ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
+   fi;
  - make
  - git clone --depth=1 https://github.com/mapnik/test-data test-data
  - git clone --depth=1 https://github.com/mapbox/mapnik-test-data tests/data/mapnik-test-data
  - make test
- - PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls
- - if [[ ${COVERAGE} == true ]]; then ./mason_packages/.link/bin/cpp-coveralls --build-root . --gcov-options '\-lp' --exclude mason_packages --exclude .sconf_temp --exclude benchmark --exclude deps --exclude scons --exclude test --exclude demo --exclude docs --exclude fonts --exclude utils > /dev/null; fi;
- - if [[ ${COVERAGE} != true ]]; then make bench; fi;
+ - if [[ ${COVERAGE} == true ]]; then 
+    ./mason_packages/.link/bin/cpp-coveralls --build-root . --gcov-options '\-lp' --exclude mason_packages --exclude .sconf_temp --exclude benchmark --exclude deps --exclude scons --exclude test --exclude demo --exclude docs --exclude fonts --exclude utils > /dev/null; 
+   fi;
+ - if [[ ${COVERAGE} != true ]]; then 
+    make bench; 
+   fi;
+
+after_success:
+ - if [[ ${COVERAGE} != true ]]; then
+    ./mason_latest.sh build;   
+    ./mason_latest.sh link;   
+    ./mason_latest.sh publish;   
+   fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,20 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: JOBS=8
+      env: JOBS=8 MASON_PUBLISH=true
     - os: linux
       compiler: gcc
       env: JOBS=6
+    - os: osx
+      compiler: clang
+      env: JOBS=8 MASON_PUBLISH=true
     - os: osx
       compiler: clang
       env: JOBS=8 COVERAGE=true
 
 before_install:
  - export COVERAGE=${COVERAGE:-false}
+ - export MASON_PUBLISH=${MASON_PUBLISH:-false}
 
 install:
  - if [[ $(uname -s) == 'Linux' ]]; then
@@ -54,14 +58,16 @@ install:
 
 script:
  - source bootstrap.sh
- - if [[ ${COVERAGE} != true ]]; then 
+ - if [[ ${COVERAGE} == true ]]; then 
+    ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
+   elif [[ ${MASON_PUBLISH == true]]; then
     export MASON_NAME=mapnik;
     export MASON_VERSION=latest;
     export MASON_LIB_FILE=lib/libmapnik-wkt.a
     source ./.mason.sh; 
     ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True;
    else
-    ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
+    ./configure
    fi;
  - make
  - git clone --depth=1 https://github.com/mapnik/test-data test-data
@@ -75,7 +81,7 @@ script:
    fi;
 
 after_success:
- - if [[ ${COVERAGE} != true ]]; then
+ - if [[ ${MASON_PUBLISH} == true ]]; then
     ./mason_latest.sh build;   
     ./mason_latest.sh link;   
     ./mason_latest.sh publish;   

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
 before_install:
  - export COVERAGE=${COVERAGE:-false}
  - export MASON_PUBLISH=${MASON_PUBLISH:-false}
+ - if [[ ${TRAVIS_BRANCH} != 'master' ]]; then export MASON_PUBLISH=false; fi;
 
 install:
  - if [[ $(uname -s) == 'Linux' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
     export MASON_NAME=mapnik;
     export MASON_VERSION=latest;
     export MASON_LIB_FILE=lib/libmapnik-wkt.a;
-    source ./.mason.sh; 
+    source ./.mason/mason.sh; 
     ./configure PREFIX=${MASON_PREFIX} PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True;
    else
     ./configure;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
  - source bootstrap.sh
  - if [[ ${COVERAGE} == true ]]; then 
     ./configure CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
-   elif [[ ${MASON_PUBLISH == true]]; then
+   elif [[ ${MASON_PUBLISH} == true]]; then
     export MASON_NAME=mapnik;
     export MASON_VERSION=latest;
     export MASON_LIB_FILE=lib/libmapnik-wkt.a;

--- a/SConstruct
+++ b/SConstruct
@@ -324,6 +324,7 @@ opts.AddVariables(
     ('PATH_REMOVE', 'A path prefix to exclude from all known command and compile paths (create multiple excludes separated by :)', ''),
     ('PATH_REPLACE', 'Two path prefixes (divided with a :) to search/replace from all known command and compile paths', ''),
     ('MAPNIK_NAME', 'Name of library', 'mapnik'),
+    BoolVariable('MAPNIK_BUNDLED_SHARE_DIRECTORY', 'For portable packaging: instruct mapnik-config to report relative paths to bundled GDAL_DATA, PROJ_LIB, and ICU_DATA','False'),
 
     # Boost variables
     # default is '/usr/include', see FindBoost method below
@@ -463,6 +464,7 @@ pickle_store = [# Scons internal variables
         'MAPNIK_INPUT_PLUGINS_DEST',
         'MAPNIK_FONTS',
         'MAPNIK_FONTS_DEST',
+        'MAPNIK_BUNDLED_SHARE_DIRECTORY',
         'MAPNIK_LIB_BASE',
         'MAPNIK_LIB_BASE_DEST',
         'EXTRA_FREETYPE_LIBS',

--- a/include/mapnik/renderer_common/apply_vertex_converter.hpp
+++ b/include/mapnik/renderer_common/apply_vertex_converter.hpp
@@ -25,17 +25,18 @@
 
 namespace mapnik { namespace detail {
 
-template <typename VertexConverter>
+template <typename VertexConverter, typename Processor>
 struct apply_vertex_converter
 {
-    apply_vertex_converter(VertexConverter & converter)
-        : converter_(converter) {}
+    apply_vertex_converter(VertexConverter & converter, Processor & proc)
+        : converter_(converter), proc_(proc) {}
     template <typename Adapter>
     void operator() (Adapter const& adapter) const
     {
-        converter_.apply(adapter);
+        converter_.apply(adapter, proc_);
     }
     VertexConverter & converter_;
+    Processor & proc_;
 };
 
 }}

--- a/include/mapnik/renderer_common/process_markers_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_markers_symbolizer.hpp
@@ -40,6 +40,14 @@ struct render_marker_symbolizer_visitor
     using raster_dispatch_type = RD;
     using buffer_type = typename std::tuple_element<0,ContextType>::type;
 
+    using vertex_converter_type = vertex_converter<clip_line_tag,
+                                                   clip_poly_tag,
+                                                   transform_tag,
+                                                   affine_transform_tag,
+                                                   simplify_tag,
+                                                   smooth_tag,
+                                                   offset_transform_tag>;
+
     render_marker_symbolizer_visitor(std::string const& filename,
                                      markers_symbolizer const& sym,
                                      mapnik::feature_impl & feature,
@@ -100,14 +108,7 @@ struct render_marker_symbolizer_visitor
                                                      snap_to_pixels,
                                                      renderer_context_);
 
-            using vertex_converter_type = vertex_converter<vector_dispatch_type,clip_line_tag,
-                                          clip_poly_tag,
-                                          transform_tag,
-                                          affine_transform_tag,
-                                          simplify_tag, smooth_tag,
-                                          offset_transform_tag>;
             vertex_converter_type converter(clip_box_,
-                                            rasterizer_dispatch,
                                             sym_,
                                             common_.t_,
                                             prj_trans_,
@@ -129,7 +130,7 @@ struct render_marker_symbolizer_visitor
             converter.template set<affine_transform_tag>(); // optional affine transform
             if (simplify_tolerance > 0.0) converter.template set<simplify_tag>(); // optional simplify converter
             if (smooth > 0.0) converter.template set<smooth_tag>(); // optional smooth converter
-            apply_markers_multi(feature_, common_.vars_, converter, sym_);
+            apply_markers_multi(feature_, common_.vars_, converter, rasterizer_dispatch, sym_);
         }
         else
         {
@@ -153,14 +154,7 @@ struct render_marker_symbolizer_visitor
                                                      snap_to_pixels,
                                                      renderer_context_);
 
-            using vertex_converter_type = vertex_converter<vector_dispatch_type,clip_line_tag,
-                                          clip_poly_tag,
-                                          transform_tag,
-                                          affine_transform_tag,
-                                          simplify_tag, smooth_tag,
-                                          offset_transform_tag>;
             vertex_converter_type converter(clip_box_,
-                                            rasterizer_dispatch,
                                             sym_,
                                             common_.t_,
                                             prj_trans_,
@@ -182,7 +176,7 @@ struct render_marker_symbolizer_visitor
             converter.template set<affine_transform_tag>(); // optional affine transform
             if (simplify_tolerance > 0.0) converter.template set<simplify_tag>(); // optional simplify converter
             if (smooth > 0.0) converter.template set<smooth_tag>(); // optional smooth converter
-            apply_markers_multi(feature_, common_.vars_, converter, sym_);
+            apply_markers_multi(feature_, common_.vars_, converter, rasterizer_dispatch,  sym_);
         }
     }
 
@@ -217,14 +211,8 @@ struct render_marker_symbolizer_visitor
                                                  common_.vars_,
                                                  renderer_context_);
 
-        using vertex_converter_type = vertex_converter<raster_dispatch_type,clip_line_tag,
-                                      clip_poly_tag,
-                                      transform_tag,
-                                      affine_transform_tag,
-                                      simplify_tag, smooth_tag,
-                                      offset_transform_tag>;
+
         vertex_converter_type converter(clip_box_,
-                                        rasterizer_dispatch,
                                         sym_,
                                         common_.t_,
                                         prj_trans_,
@@ -246,7 +234,7 @@ struct render_marker_symbolizer_visitor
         converter.template set<affine_transform_tag>(); // optional affine transform
         if (simplify_tolerance > 0.0) converter.template set<simplify_tag>(); // optional simplify converter
         if (smooth > 0.0) converter.template set<smooth_tag>(); // optional smooth converter
-        apply_markers_multi(feature_, common_.vars_, converter, sym_);
+        apply_markers_multi(feature_, common_.vars_, converter, rasterizer_dispatch, sym_);
     }
 
   private:
@@ -273,12 +261,12 @@ void render_markers_symbolizer(markers_symbolizer const& sym,
     {
         mapnik::marker const& mark = mapnik::marker_cache::instance().find(filename, true);
         render_marker_symbolizer_visitor<VD,RD,RendererType,ContextType> visitor(filename,
-                                         sym,
-                                         feature,
-                                         prj_trans,
-                                         common,
-                                         clip_box,
-                                         renderer_context);
+                                                                                 sym,
+                                                                                 feature,
+                                                                                 prj_trans,
+                                                                                 common,
+                                                                                 clip_box,
+                                                                                 renderer_context);
         util::apply_visitor(visitor, mark);
     }
 }

--- a/include/mapnik/renderer_common/process_polygon_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_polygon_symbolizer.hpp
@@ -51,7 +51,7 @@ void render_polygon_symbolizer(polygon_symbolizer const &sym,
     value_double smooth = get<value_double,keys::smooth>(sym, feature, common.vars_);
     value_double opacity = get<value_double,keys::fill_opacity>(sym, feature, common.vars_);
 
-    vertex_converter_type converter(clip_box, ras, sym, common.t_, prj_trans, tr,
+    vertex_converter_type converter(clip_box, sym, common.t_, prj_trans, tr,
                                     feature,common.vars_,common.scale_factor_);
 
     if (prj_trans.equal() && clip) converter.template set<clip_poly_tag>(); //optional clip (default: true)
@@ -60,9 +60,9 @@ void render_polygon_symbolizer(polygon_symbolizer const &sym,
     if (simplify_tolerance > 0.0) converter.template set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.template set<smooth_tag>(); // optional smooth converter
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer_type>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, ras);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
 
     color const& fill = get<mapnik::color, keys::fill>(sym, feature, common.vars_);

--- a/include/mapnik/text/symbolizer_helpers.hpp
+++ b/include/mapnik/text/symbolizer_helpers.hpp
@@ -56,7 +56,7 @@ struct placement_finder_adapter
 
 };
 
-using vertex_converter_type = vertex_converter<placement_finder_adapter<placement_finder>,clip_line_tag , transform_tag, affine_transform_tag, simplify_tag, smooth_tag>;
+using vertex_converter_type = vertex_converter<clip_line_tag , transform_tag, affine_transform_tag, simplify_tag, smooth_tag>;
 
 class base_symbolizer_helper
 {

--- a/include/mapnik/vertex_converters.hpp
+++ b/include/mapnik/vertex_converters.hpp
@@ -271,6 +271,11 @@ struct is_switchable<T,stroke_tag>
     static constexpr bool value = false;
 };
 
+template <typename T>
+struct is_switchable<T,offset_transform_tag>
+{
+    static constexpr bool value = false;
+};
 
 
 template <typename Dispatcher, typename... ConverterTypes>
@@ -377,11 +382,10 @@ struct arguments : util::noncopyable
 
 }
 
-template <typename Processor, typename... ConverterTypes >
+template <typename... ConverterTypes >
 struct vertex_converter : private util::noncopyable
 {
     using bbox_type = box2d<double>;
-    using processor_type = Processor;
     using symbolizer_type = symbolizer_base;
     using trans_type = view_transform;
     using proj_trans_type = proj_transform;
@@ -391,7 +395,6 @@ struct vertex_converter : private util::noncopyable
     using dispatcher_type = detail::dispatcher<args_type, sizeof...(ConverterTypes)>;
 
     vertex_converter(bbox_type const& bbox,
-                     processor_type & proc,
                      symbolizer_type const& sym,
                      trans_type const& tr,
                      proj_trans_type const& prj_trans,
@@ -399,13 +402,12 @@ struct vertex_converter : private util::noncopyable
                      feature_type const& feature,
                      attributes const& vars,
                      double scale_factor)
-        : disp_(bbox,sym,tr,prj_trans,affine_trans,feature,vars,scale_factor),
-          proc_(proc) {}
+        : disp_(bbox,sym,tr,prj_trans,affine_trans,feature,vars,scale_factor) {}
 
-    template <typename VertexAdapter>
-    void apply(VertexAdapter & geom)
+    template <typename VertexAdapter, typename Processor>
+    void apply(VertexAdapter & geom, Processor & proc)
     {
-        detail::converters_helper<dispatcher_type, ConverterTypes...>:: template forward<VertexAdapter, Processor>(disp_, geom, proc_);
+        detail::converters_helper<dispatcher_type, ConverterTypes...>:: template forward<VertexAdapter, Processor>(disp_, geom, proc);
     }
 
     template <typename Converter>
@@ -421,7 +423,6 @@ struct vertex_converter : private util::noncopyable
     }
 
     dispatcher_type disp_;
-    Processor & proc_;
 };
 
 }

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -12,6 +12,10 @@ function mason_load_source {
 
 function mason_compile {
     HERE=$(pwd)
+    make install
+    if [ $UNAME = 'Darwin' ]; then
+        install_name_tool -id @loader_path/libmapnik.dylib ${MASON_PREFIX}"/lib/libmapnik.dylib"     
+    fi
     python -c "data=open('$MASON_PREFIX/bin/mapnik-config','r').read();open('$MASON_PREFIX/bin/mapnik-config','w').write(data.replace('$HERE','.'))"
     mkdir -p ${MASON_PREFIX}/share/gdal
     mkdir -p ${MASON_PREFIX}/share/proj

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -31,6 +31,7 @@ function mason_ldflags {
 }
 
 function mason_clean {
+    echo "Done"
 }
 
 mason_run "$@"

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -14,8 +14,8 @@ function mason_compile {
     HERE=$(pwd)
     make install
     if [ $UNAME = 'Darwin' ]; then
-        install_name_tool -id @loader_path/libmapnik.dylib ${MASON_PREFIX}"/lib/libmapnik.dylib"     
-    fi
+        install_name_tool -id @loader_path/libmapnik.dylib ${MASON_PREFIX}"/lib/libmapnik.dylib";     
+    fi;
     python -c "data=open('$MASON_PREFIX/bin/mapnik-config','r').read();open('$MASON_PREFIX/bin/mapnik-config','w').write(data.replace('$HERE','.'))"
     mkdir -p ${MASON_PREFIX}/share/gdal
     mkdir -p ${MASON_PREFIX}/share/proj

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+MASON_NAME=mapnik
+MASON_VERSION=latest
+MASON_LIB_FILE=lib/libmapnik-wkt.a
+
+. ${MASON_DIR:-~/.mason}/mason.sh
+
+function mason_load_source {
+}
+
+function mason_compile {
+    HERE=$(pwd)
+    python -c "data=open('$MASON_PREFIX/bin/mapnik-config','r').read();open('$MASON_PREFIX/bin/mapnik-config','w').write(data.replace('$HERE','.'))"
+    mkdir -p ${MASON_PREFIX}/share/gdal
+    mkdir -p ${MASON_PREFIX}/share/proj
+    mkdir -p ${MASON_PREFIX}/share/icu
+    cp -r $GDAL_DATA/ ${MASON_PREFIX}/share/gdal/
+    cp -r $PROJ_LIB/ ${MASON_PREFIX}/share/proj/
+    cp -r $ICU_DATA/*dat ${MASON_PREFIX}/share/icu/
+    find ${MASON_PREFIX} -name "*.pyc" -exec rm {} \;
+}
+
+function mason_cflags {
+    ""
+}
+
+function mason_ldflags {
+    ""
+}
+
+function mason_clean {
+}
+
+mason_run "$@"

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -7,6 +7,7 @@ MASON_LIB_FILE=lib/libmapnik-wkt.a
 . ${MASON_DIR:-~/.mason}/mason.sh
 
 function mason_load_source {
+    export MASON_BUILD_PATH=$(pwd)
 }
 
 function mason_compile {

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -127,12 +127,12 @@ struct agg_renderer_process_visitor_l
             padding *= common_.scale_factor_;
             clip_box.pad(padding);
         }
-        using vertex_converter_type = vertex_converter<rasterizer_type, clip_line_tag, transform_tag,
+        using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,
                                                        affine_transform_tag,
                                                        simplify_tag,smooth_tag,
                                                        offset_transform_tag>;
 
-        vertex_converter_type converter(clip_box,ras,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
+        vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
         if (clip) converter.set<clip_line_tag>(); //optional clip (default: true)
         converter.set<transform_tag>(); //always transform
@@ -141,9 +141,9 @@ struct agg_renderer_process_visitor_l
         converter.set<affine_transform_tag>(); // optional affine transform
         if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer_type>;
         using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-        apply_vertex_converter_type apply(converter);
+        apply_vertex_converter_type apply(converter, ras);
         mapnik::util::apply_visitor(vertex_processor_type(apply),feature_.get_geometry());
     }
 
@@ -196,12 +196,12 @@ struct agg_renderer_process_visitor_l
             padding *= common_.scale_factor_;
             clip_box.pad(padding);
         }
-        using vertex_converter_type = vertex_converter<rasterizer_type, clip_line_tag, transform_tag,
+        using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,
                                                        affine_transform_tag,
                                                        simplify_tag,smooth_tag,
                                                        offset_transform_tag>;
 
-        vertex_converter_type converter(clip_box,ras,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
+        vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
         if (clip) converter.set<clip_line_tag>(); //optional clip (default: true)
         converter.set<transform_tag>(); //always transform
@@ -210,9 +210,9 @@ struct agg_renderer_process_visitor_l
         converter.set<affine_transform_tag>(); // optional affine transform
         if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer_type>;
         using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-        apply_vertex_converter_type apply(converter);
+        apply_vertex_converter_type apply(converter, ras);
         mapnik::util::apply_visitor(vertex_processor_type(apply),feature_.get_geometry());
     }
 

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -156,14 +156,13 @@ struct agg_renderer_process_visitor_p
         agg::trans_affine tr;
         auto transform = get_optional<transform_type>(sym_, keys::geometry_transform);
         if (transform) evaluate_transform(tr, feature_, common_.vars_, *transform, common_.scale_factor_);
-        using vertex_converter_type = vertex_converter<rasterizer,
-                                                       clip_poly_tag,
+        using vertex_converter_type = vertex_converter<clip_poly_tag,
                                                        transform_tag,
                                                        affine_transform_tag,
                                                        simplify_tag,
                                                        smooth_tag>;
 
-        vertex_converter_type converter(clip_box,*ras_ptr_,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
+        vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
 
         if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
@@ -172,9 +171,9 @@ struct agg_renderer_process_visitor_p
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
         if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer>;
         using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-        apply_vertex_converter_type apply(converter);
+        apply_vertex_converter_type apply(converter, *ras_ptr_);
         mapnik::util::apply_visitor(vertex_processor_type(apply),feature_.get_geometry());
         agg::scanline_u8 sl;
         ras_ptr_->filling_rule(agg::fill_even_odd);
@@ -257,14 +256,13 @@ struct agg_renderer_process_visitor_p
         agg::trans_affine tr;
         auto transform = get_optional<transform_type>(sym_, keys::geometry_transform);
         if (transform) evaluate_transform(tr, feature_, common_.vars_, *transform, common_.scale_factor_);
-        using vertex_converter_type = vertex_converter<rasterizer,
-                                                       clip_poly_tag,
+        using vertex_converter_type = vertex_converter<clip_poly_tag,
                                                        transform_tag,
                                                        affine_transform_tag,
                                                        simplify_tag,
                                                        smooth_tag>;
 
-        vertex_converter_type converter(clip_box,*ras_ptr_,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
+        vertex_converter_type converter(clip_box, sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
         if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
         converter.set<transform_tag>(); //always transform
@@ -272,9 +270,9 @@ struct agg_renderer_process_visitor_p
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
         if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+        using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer>;
         using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-        apply_vertex_converter_type apply(converter);
+        apply_vertex_converter_type apply(converter, *ras_ptr_);
         mapnik::util::apply_visitor(vertex_processor_type(apply),feature_.get_geometry());
         agg::scanline_u8 sl;
         ras_ptr_->filling_rule(agg::fill_even_odd);

--- a/src/agg/process_polygon_symbolizer.cpp
+++ b/src/agg/process_polygon_symbolizer.cpp
@@ -48,7 +48,7 @@ void agg_renderer<T0,T1>::process(polygon_symbolizer const& sym,
                               mapnik::feature_impl & feature,
                               proj_transform const& prj_trans)
 {
-    using vertex_converter_type = vertex_converter<rasterizer,clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
+    using vertex_converter_type = vertex_converter<clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
 
     ras_ptr->reset();
     double gamma = get<value_double>(sym, keys::gamma, feature, common_.vars_, 1.0);

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -143,13 +143,13 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
 
     using rasterizer_type = line_pattern_rasterizer<cairo_context>;
     rasterizer_type ras(context_, *pattern, width, height);
-    using vertex_converter_type = vertex_converter<rasterizer_type,clip_line_tag, transform_tag,
+    using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,
                                                    affine_transform_tag,
                                                    simplify_tag, smooth_tag,
                                                    offset_transform_tag,
                                                    dash_tag, stroke_tag>;
 
-    vertex_converter_type converter(clipping_extent, ras, sym, common_.t_, prj_trans, tr, feature, common_.vars_, common_.scale_factor_);
+    vertex_converter_type converter(clipping_extent,sym, common_.t_, prj_trans, tr, feature, common_.vars_, common_.scale_factor_);
 
     if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
     converter.set<transform_tag>(); // always transform
@@ -158,9 +158,9 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, rasterizer_type>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, ras);
     mapnik::util::apply_visitor(vertex_processor_type(apply), feature.get_geometry());
 }
 

--- a/src/cairo/process_line_symbolizer.cpp
+++ b/src/cairo/process_line_symbolizer.cpp
@@ -81,15 +81,14 @@ void cairo_renderer<T>::process(line_symbolizer const& sym,
         padding *= common_.scale_factor_;
         clipping_extent.pad(padding);
     }
-    using vertex_converter_type =  vertex_converter<cairo_context,
-                                                    clip_line_tag,
+    using vertex_converter_type =  vertex_converter<clip_line_tag,
                                                     transform_tag,
                                                     affine_transform_tag,
                                                     simplify_tag, smooth_tag,
                                                     offset_transform_tag,
                                                     dash_tag, stroke_tag>;
 
-    vertex_converter_type converter(clipping_extent,context_,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
+    vertex_converter_type converter(clipping_extent,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
 
     if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
     converter.set<transform_tag>(); // always transform
@@ -98,9 +97,9 @@ void cairo_renderer<T>::process(line_symbolizer const& sym,
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, cairo_context>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, context_);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
     // stroke
     context_.set_fill_rule(CAIRO_FILL_RULE_WINDING);

--- a/src/cairo/process_polygon_pattern_symbolizer.cpp
+++ b/src/cairo/process_polygon_pattern_symbolizer.cpp
@@ -124,23 +124,23 @@ void cairo_renderer<T>::process(polygon_pattern_symbolizer const& sym,
     agg::trans_affine tr;
     auto geom_transform = get_optional<transform_type>(sym, keys::geometry_transform);
     if (geom_transform) { evaluate_transform(tr, feature, common_.vars_, *geom_transform, common_.scale_factor_); }
-    using vertex_converter_type = vertex_converter<cairo_context,
+    using vertex_converter_type = vertex_converter<
                                                    clip_poly_tag,
                                                    transform_tag,
                                                    affine_transform_tag,
                                                    simplify_tag,
                                                    smooth_tag>;
 
-    vertex_converter_type converter(clip_box, context_,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
+    vertex_converter_type converter(clip_box,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
     if (prj_trans.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
     converter.set<transform_tag>(); //always transform
     converter.set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, cairo_context>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, context_);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
     // fill polygon
     context_.set_fill_rule(CAIRO_FILL_RULE_EVEN_ODD);

--- a/src/cairo/process_polygon_symbolizer.cpp
+++ b/src/cairo/process_polygon_symbolizer.cpp
@@ -38,7 +38,7 @@ void cairo_renderer<T>::process(polygon_symbolizer const& sym,
                                   mapnik::feature_impl & feature,
                                   proj_transform const& prj_trans)
 {
-    using vertex_converter_type = vertex_converter<cairo_context,clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
+    using vertex_converter_type = vertex_converter<clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
     cairo_save_restore guard(context_);
     composite_mode_e comp_op = get<composite_mode_e, keys::comp_op>(sym, feature, common_.vars_);
     context_.set_operator(comp_op);

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -115,11 +115,10 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     put<value_double>(line, keys::simplify_tolerance, value_double(simplify_tolerance));
     put<value_double>(line, keys::smooth, value_double(smooth));
 
-    using vertex_converter_type = vertex_converter<grid_rasterizer,
-                                                   clip_line_tag, transform_tag,
+    using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,
                                                    offset_transform_tag, affine_transform_tag,
                                                    simplify_tag, smooth_tag, stroke_tag>;
-    vertex_converter_type converter(clipping_extent,*ras_ptr,line,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
+    vertex_converter_type converter(clipping_extent,line,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
     if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
     converter.set<transform_tag>(); // always transform
     if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
@@ -127,9 +126,9 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
     converter.set<stroke_tag>(); //always stroke
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type,grid_rasterizer>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, *ras_ptr);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
 
     // render id

--- a/src/grid/process_line_symbolizer.cpp
+++ b/src/grid/process_line_symbolizer.cpp
@@ -89,11 +89,11 @@ void grid_renderer<T>::process(line_symbolizer const& sym,
         padding *= common_.scale_factor_;
         clipping_extent.pad(padding);
     }
-    using vertex_converter_type = vertex_converter<grid_rasterizer, clip_line_tag, transform_tag,
+    using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,
                                                    offset_transform_tag, affine_transform_tag,
                                                    simplify_tag, smooth_tag, dash_tag, stroke_tag>;
 
-    vertex_converter_type converter(clipping_extent,*ras_ptr,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
+    vertex_converter_type converter(clipping_extent,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
     if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
     converter.set<transform_tag>(); // always transform
     if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
@@ -103,9 +103,9 @@ void grid_renderer<T>::process(line_symbolizer const& sym,
     if (has_dash) converter.set<dash_tag>();
     converter.set<stroke_tag>(); //always stroke
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, grid_rasterizer>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, *ras_ptr);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
 
     // render id

--- a/src/grid/process_polygon_pattern_symbolizer.cpp
+++ b/src/grid/process_polygon_pattern_symbolizer.cpp
@@ -76,8 +76,8 @@ void grid_renderer<T>::process(polygon_pattern_symbolizer const& sym,
         evaluate_transform(tr, feature, common_.vars_, *transform, common_.scale_factor_);
     }
 
-    using vertex_converter_type = vertex_converter<grid_rasterizer, clip_poly_tag,transform_tag,affine_transform_tag,smooth_tag>;
-    vertex_converter_type converter(common_.query_extent_,*ras_ptr,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
+    using vertex_converter_type = vertex_converter<clip_poly_tag,transform_tag,affine_transform_tag,smooth_tag>;
+    vertex_converter_type converter(common_.query_extent_,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
 
     if (prj_trans.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
     converter.set<transform_tag>(); //always transform
@@ -85,9 +85,9 @@ void grid_renderer<T>::process(polygon_pattern_symbolizer const& sym,
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
     if (smooth > 0.0) converter.set<smooth_tag>(); // optional smooth converter
 
-    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type>;
+    using apply_vertex_converter_type = detail::apply_vertex_converter<vertex_converter_type, grid_rasterizer>;
     using vertex_processor_type = geometry::vertex_processor<apply_vertex_converter_type>;
-    apply_vertex_converter_type apply(converter);
+    apply_vertex_converter_type apply(converter, *ras_ptr);
     mapnik::util::apply_visitor(vertex_processor_type(apply),feature.get_geometry());
 
     using pixfmt_type = typename grid_renderer_base_type::pixfmt_type;

--- a/src/grid/process_polygon_symbolizer.cpp
+++ b/src/grid/process_polygon_symbolizer.cpp
@@ -53,7 +53,7 @@ void grid_renderer<T>::process(polygon_symbolizer const& sym,
     using renderer_type = agg::renderer_scanline_bin_solid<grid_renderer_base_type>;
     using pixfmt_type = typename grid_renderer_base_type::pixfmt_type;
     using color_type = typename grid_renderer_base_type::pixfmt_type::color_type;
-    using vertex_converter_type = vertex_converter<grid_rasterizer,clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
+    using vertex_converter_type = vertex_converter<clip_poly_tag,transform_tag,affine_transform_tag,simplify_tag,smooth_tag>;
 
     ras_ptr->reset();
 

--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -288,7 +288,7 @@ text_symbolizer_helper::text_symbolizer_helper(
     : base_symbolizer_helper(sym, feature, vars, prj_trans, width, height, scale_factor, t, query_extent),
       finder_(feature, vars, detector, dims_, *info_ptr_, font_manager, scale_factor),
     adapter_(finder_,false),
-    converter_(query_extent_, adapter_, sym_, t, prj_trans, affine_trans, feature, vars, scale_factor)
+    converter_(query_extent_, sym_, t, prj_trans, affine_trans, feature, vars, scale_factor)
 {
 
     // setup vertex converter
@@ -335,7 +335,7 @@ bool text_symbolizer_helper::next_line_placement() const
         {
             auto const& line = util::get<geometry::line_string<double> const>(*geo_itr_);
             geometry::line_string_vertex_adapter<double> va(line);
-            converter_.apply(va);
+            //converter_.apply(va, adapter_);
             if (adapter_.status())
             {
                 //Found a placement
@@ -385,7 +385,7 @@ text_symbolizer_helper::text_symbolizer_helper(
     : base_symbolizer_helper(sym, feature, vars, prj_trans, width, height, scale_factor, t, query_extent),
       finder_(feature, vars, detector, dims_, *info_ptr_, font_manager, scale_factor),
       adapter_(finder_,true),
-      converter_(query_extent_, adapter_, sym_, t, prj_trans, affine_trans, feature, vars, scale_factor)
+      converter_(query_extent_, sym_, t, prj_trans, affine_trans, feature, vars, scale_factor)
 {
    // setup vertex converter
     value_bool clip = mapnik::get<value_bool, keys::clip>(sym_, feature_, vars_);

--- a/utils/mapnik-config/build.py
+++ b/utils/mapnik-config/build.py
@@ -50,6 +50,9 @@ CONFIG_MAPNIK_INCLUDE="${CONFIG_PREFIX}/include -I${CONFIG_PREFIX}/include/mapni
 CONFIG_DEP_INCLUDES="%(dep_includes)s"
 CONFIG_CXXFLAGS="%(cxxflags)s"
 CONFIG_CXX='%(cxx)s'
+CONFIG_MAPNIK_GDAL_DATA='%(mapnik_bundled_gdal_data)s'
+CONFIG_MAPNIK_PROJ_LIB='%(mapnik_bundled_proj_data)s'
+CONFIG_MAPNIK_ICU_DATA='%(mapnik_bundled_icu_data)s'
 
 '''
 
@@ -107,6 +110,15 @@ if lib_root in inputpluginspath:
 
 lib_path = "${CONFIG_PREFIX}/" + config_env['LIBDIR_SCHEMA']
 
+mapnik_bundled_gdal_data = ''
+mapnik_bundled_proj_data = ''
+mapnik_bundled_icu_data = ''
+
+if config_env.get('MAPNIK_BUNDLED_SHARE_DIRECTORY'):
+    mapnik_bundled_gdal_data = 'lib/mapnik/share/gdal'
+    mapnik_bundled_proj_data = 'lib/mapnik/share/proj'
+    mapnik_bundled_icu_data = 'lib/mapnik/share/icu'
+
 configuration = {
     "git_revision": git_revision,
     "git_describe": git_describe,
@@ -121,7 +133,10 @@ configuration = {
     "input_plugins": inputpluginspath,
     "defines":defines,
     "cxxflags":cxxflags,
-    "cxx":env['CXX']
+    "cxx":env['CXX'],
+    "mapnik_bundled_gdal_data":mapnik_bundled_gdal_data,
+    "mapnik_bundled_proj_data":mapnik_bundled_proj_data,
+    "mapnik_bundled_icu_data":mapnik_bundled_icu_data,
 }
 
 ## if we are statically linking depedencies

--- a/utils/mapnik-config/mapnik-config.template.sh
+++ b/utils/mapnik-config/mapnik-config.template.sh
@@ -27,6 +27,9 @@ Known values for OPTION are:
   --cflags          all include paths, compiler flags, and pre-processor defines (for back-compatibility)
   --cxx             c++ compiler used to build mapnik (new in 2.2.0)
   --all-flags       all compile and link flags (new in 2.2.0)
+  --gdal-data       path to GDAL_DATA directory, if known (relevant only for packaged builds of Mapnik) (new in 3.0.0)
+  --proj-lib        path to PROJ_LIB directory, if known (relevant only for packaged builds of Mapnik) (new in 3.0.0)
+  --icu-data        path to ICU_DATA directory, if known (relevant only for packaged builds of Mapnik) (new in 3.0.0)
 EOF
 
     exit $1
@@ -126,6 +129,18 @@ while test $# -gt 0; do
 
     --all-flags)
       echo -I${CONFIG_MAPNIK_INCLUDE} ${CONFIG_DEP_INCLUDES} ${CONFIG_MAPNIK_DEFINES} ${CONFIG_CXXFLAGS} -L${CONFIG_MAPNIK_LIBPATH} -l${CONFIG_MAPNIK_LIBNAME} ${CONFIG_MAPNIK_LDFLAGS} ${CONFIG_DEP_LIBS}
+      ;;
+
+    --gdal-data)
+      if [[ ${CONFIG_MAPNIK_GDAL_DATA:-unset} != "unset" ]]; then echo ${CONFIG_PREFIX}/${CONFIG_MAPNIK_GDAL_DATA}; fi;
+      ;;
+
+    --proj-lib)
+      if [[ ${CONFIG_MAPNIK_PROJ_LIB:-unset} != "unset" ]]; then echo ${CONFIG_PREFIX}/${CONFIG_MAPNIK_PROJ_LIB}; fi;
+      ;;
+
+    --icu-data)
+      if [[ ${CONFIG_MAPNIK_ICU_DATA:-unset} != "unset" ]]; then echo ${CONFIG_PREFIX}/${CONFIG_MAPNIK_ICU_DATA}; fi;
       ;;
 
     *)


### PR DESCRIPTION
@flippmoke this addresses #2779 - let me know if this is works. The idea is that mapnik-core, when built to be packaged portably, would be built with `./configure MAPNIK_BUNDLED_SHARE_DIRECTORY=True` and then calls to `mapnik-config` would report the right paths dynamically.