### PR TITLE
fix infinite loop

### DIFF
--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -342,9 +342,10 @@ bool text_symbolizer_helper::next_line_placement() const
                 geo_itr_ = geometries_to_process_.erase(geo_itr_);
                 return true;
             }
-            // No placement for this geometry. Keep it in geometries_to_process_ for next try.
-            ++geo_itr_;
         }
+
+        // No placement for this geometry. Keep it in geometries_to_process_ for next try.
+        ++geo_itr_;
     }
     return false;
 }


### PR DESCRIPTION
Mapnik end up in infinite loop when text `placement="line"` is used on other geometry than `line_string`.