### PR TITLE
fix labeling

### DIFF
--- a/include/mapnik/text/symbolizer_helpers.hpp
+++ b/include/mapnik/text/symbolizer_helpers.hpp
@@ -43,7 +43,7 @@ struct placement_finder_adapter
           points_on_line_(points_on_line) {}
 
     template <typename PathT>
-    void add_path(PathT & path)
+    void add_path(PathT & path) const
     {
         status_ = finder_.find_line_placements(path, points_on_line_);
     }

--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -335,7 +335,7 @@ bool text_symbolizer_helper::next_line_placement() const
         {
             auto const& line = util::get<geometry::line_string<double> const>(*geo_itr_);
             geometry::line_string_vertex_adapter<double> va(line);
-            //converter_.apply(va, adapter_);
+            converter_.apply(va, adapter_);
             if (adapter_.status())
             {
                 //Found a placement


### PR DESCRIPTION
c64dc3672a2bc8def5ddcf1c5d3fc612f63c46ab breaks all text rendering by commenting out [`converter_.apply(va, adapter_);`](https://github.com/mapnik/mapnik/blob/c64dc3672a2bc8def5ddcf1c5d3fc612f63c46ab/src/text/symbolizer_helpers.cpp#L338).

This probably happened due to missing visual tests in Mapnik core. I'm trying to deliver visual tests into the core ASAP. At least for agg and cairo.

I'm bit concerned about mixing `const` methods with `mutable` members in text rendering code. Everything looks immutable at first glance with `const` everywhere, but it really isn't. That apply for [`text_symbolizer_helper`](https://github.com/mapycz/mapnik/blob/master/include/mapnik/text/symbolizer_helpers.hpp), [`text_placement_info`](https://github.com/mapycz/mapnik/blob/master/include/mapnik/text/placements/base.hpp) (and all derived placement types).