### PR TITLE
fix labeling on polygons

### DIFF
--- a/include/mapnik/vertex_cache.hpp
+++ b/include/mapnik/vertex_cache.hpp
@@ -208,7 +208,7 @@ vertex_cache::vertex_cache(T & path)
             current_subpath_->add_segment(new_x, new_y, 0);
             first = false;
         }
-        if (agg::is_line_to(cmd))
+        else if (agg::is_line_to(cmd))
         {
             if (first)
             {
@@ -219,6 +219,14 @@ vertex_cache::vertex_cache(T & path)
             double dy = old_y - new_y;
             double segment_length = std::sqrt(dx*dx + dy*dy);
             current_subpath_->add_segment(new_x, new_y, segment_length);
+        }
+        else if (agg::is_closed(cmd) && !current_subpath_->vector.empty())
+        {
+            segment const & first_segment = current_subpath_->vector[0];
+            double dx = old_x - first_segment.pos.x;
+            double dy = old_y - first_segment.pos.y;
+            double segment_length = std::sqrt(dx*dx + dy*dy);
+            current_subpath_->add_segment(first_segment.pos.x, first_segment.pos.y, segment_length);
         }
         old_x = new_x;
         old_y = new_y;


### PR DESCRIPTION
Text with `placement="line"` works only on `line_string` now.

This one definitely deserves visual test. I would merge it once visual tests are working.