### PR TITLE
Add validation for polygon rings

### DIFF
--- a/include/mapnik/geometry_is_valid.hpp
+++ b/include/mapnik/geometry_is_valid.hpp
@@ -35,7 +35,6 @@
 #include <boost/geometry/algorithms/is_valid.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/area.hpp>
-#include <boost/geometry/algorithms/crosses.hpp>
 
 namespace mapnik { namespace geometry {
 

--- a/include/mapnik/geometry_is_valid.hpp
+++ b/include/mapnik/geometry_is_valid.hpp
@@ -30,7 +30,9 @@
 
 #include <mapnik/geometry.hpp>
 #include <mapnik/geometry_adapters.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
+#include <boost/geometry/algorithms/intersection.hpp>
 
 namespace mapnik { namespace geometry {
 
@@ -104,6 +106,61 @@ template <typename T>
 inline bool is_valid(T const& geom)
 {
     return detail::geometry_is_valid() (geom);
+}
+
+typedef boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian> Point;
+typedef boost::geometry::model::segment<Point> Segment;
+
+template <typename T>
+std::vector<Segment> make_segment_vector(linear_ring<T> ring)
+{
+
+    std::vector<Segment> result;
+
+    for (int i = 0; i < ring.size()-1; ++i)
+    {
+        Point a( ring.at(i).x, ring.at(i).y );
+        Point b( ring.at(i+1).x, ring.at(i+1).y );
+        Segment s(a, b);
+        result.push_back(std::move(s));
+    }
+    Point a( ring.back().x, ring.back().y );
+    Point b( ring.front().x, ring.front().y );
+    Segment s(a, b);
+    result.push_back(std::move(s));
+
+    return result;
+
+}
+
+template <typename T>
+inline bool is_valid_rings(polygon<T> const& poly)
+{
+    // First, test that at least one point from each interior ring is inside
+    // the exterior ring.  We just grab the first.  If this is satisfied,
+    // and the second test passes, then e
+    for (linear_ring<T> interior_ring : poly.interior_rings) {
+        if (!boost::geometry::within(interior_ring.front(), poly.exterior_ring)) {
+            return false;
+        }
+    }
+
+    std::vector<Segment> exterior_segments = make_segment_vector(poly.exterior_ring);
+    // Then, make sure there are no line intersections between the exterior ring
+    // and any of the interior rings
+    for (linear_ring<T> interior_ring : poly.interior_rings) {
+        std::vector<Segment> interior_segments = make_segment_vector(interior_ring);
+        for (Segment interior_segment : interior_segments) {
+            for (Segment exterior_segment : exterior_segments) {
+                if (boost::geometry::intersects(interior_segment, exterior_segment)) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+
 }
 
 }}

--- a/test/unit/geometry/geometry_is_valid.cpp
+++ b/test/unit/geometry/geometry_is_valid.cpp
@@ -20,7 +20,7 @@ SECTION("point") {
 
 SECTION("line_string") {
     mapnik::geometry::line_string<double> line;
-    line.add_coord(0,0);    
+    line.add_coord(0,0);  
     line.add_coord(1,1);
     REQUIRE( mapnik::geometry::is_valid(line) );
 
@@ -79,7 +79,9 @@ SECTION("polygon ring tests") {
     overlap_inner_2.add_coord(-9,9);
 
 
-    std::cout << "Test 1" << std::endl;
+    std::string validation_message;
+
+
     mapnik::geometry::polygon<double> correct;
     // add rings correctly and ensure we detect these as correct
     {
@@ -88,9 +90,8 @@ SECTION("polygon ring tests") {
         correct.set_exterior_ring(std::move(exterior2));
         correct.add_hole(std::move(hole2));
     }
-    REQUIRE( mapnik::geometry::is_valid_rings(correct) );
+    REQUIRE( mapnik::geometry::is_valid_rings(correct, validation_message) );
 
-    std::cout << "Test 2" << std::endl;
     mapnik::geometry::polygon<double> incorrect;
     // add rings incorrectly and ensure we detect these as incorrect
     {
@@ -99,9 +100,8 @@ SECTION("polygon ring tests") {
         incorrect.set_exterior_ring(std::move(hole2));
         incorrect.add_hole(std::move(exterior2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect, validation_message) );
 
-    std::cout << "Test 3" << std::endl;
     mapnik::geometry::polygon<double> incorrect2;
     // Rings added correctly, but interior is fully outside
     {
@@ -110,9 +110,8 @@ SECTION("polygon ring tests") {
         incorrect2.set_exterior_ring(std::move(exterior2));
         incorrect2.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect2) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect2, validation_message) );
 
-    std::cout << "Test 4" << std::endl;
     mapnik::geometry::polygon<double> incorrect3;
     // Rings added correctly, but interior overlaps exterior
     {
@@ -121,10 +120,9 @@ SECTION("polygon ring tests") {
         incorrect3.set_exterior_ring(std::move(exterior2));
         incorrect3.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect3) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect3, validation_message) );
 
 
-    std::cout << "Test 5" << std::endl;
     mapnik::geometry::polygon<double> incorrect4;
     // Two valid interior rings overlap
     {
@@ -135,57 +133,52 @@ SECTION("polygon ring tests") {
         incorrect4.add_hole(std::move(hole2));
         incorrect4.add_hole(std::move(hole3));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect4) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect4, validation_message) );
 
 
-    std::cout << "Test 6" << std::endl;
     mapnik::geometry::polygon<double> correct2;;
     // Only has exterior ring, should be valid
     {
         mapnik::geometry::linear_ring<double> exterior2(exterior);
         correct2.set_exterior_ring(std::move(exterior2));
     }
-    REQUIRE( mapnik::geometry::is_valid_rings(correct2) );
+    REQUIRE( mapnik::geometry::is_valid_rings(correct2, validation_message) );
 
 
-    std::cout << "Test 7" << std::endl;
     mapnik::geometry::polygon<double> correct3;;
     // Has no interior rings, has no exterior ring
     {
     }
-    REQUIRE( mapnik::geometry::is_valid_rings(correct3) );
+    REQUIRE( mapnik::geometry::is_valid_rings(correct3, validation_message) );
 
 
-    std::cout << "Test 8" << std::endl;
-    mapnik::geometry::polygon<double> correct4;
+    mapnik::geometry::polygon<double> notcorrect4;
     // Has exterior ring, and 1 empty interior ring
     {
         mapnik::geometry::linear_ring<double> exterior2(exterior);
         mapnik::geometry::linear_ring<double> empty_inner;
-        correct4.set_exterior_ring(std::move(exterior2));
-        correct4.add_hole(std::move(empty_inner));
+        notcorrect4.set_exterior_ring(std::move(exterior2));
+        notcorrect4.add_hole(std::move(empty_inner));
     }
-    REQUIRE( mapnik::geometry::is_valid_rings(correct4) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(notcorrect4, validation_message) );
 
 
-    std::cout << "Test 9" << std::endl;
-    mapnik::geometry::polygon<double> correct5;
+    mapnik::geometry::polygon<double> notcorrect5;
     // Has no exterior ring, and 1 empty interior ring
     {
         mapnik::geometry::linear_ring<double> empty_inner;
-        correct5.add_hole(std::move(empty_inner));
+        notcorrect5.add_hole(std::move(empty_inner));
     }
-    REQUIRE( mapnik::geometry::is_valid_rings(correct5) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(notcorrect5, validation_message) );
 
 
-    std::cout << "Test 10" << std::endl;
     mapnik::geometry::polygon<double> incorrect5;
     // Has no exterior, has one non-empty inner
     {
         mapnik::geometry::linear_ring<double> hole2(overlap_hole);
         incorrect5.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect5) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect5, validation_message) );
 
 
     mapnik::geometry::linear_ring<double> invalid_inner_winding;
@@ -195,7 +188,6 @@ SECTION("polygon ring tests") {
     invalid_inner_winding.add_coord(-4,9);
     invalid_inner_winding.add_coord(-9,9);
 
-    std::cout << "Test 11" << std::endl;
     mapnik::geometry::polygon<double> incorrect6;
     // Has an interior ring that's backwards
     {
@@ -204,18 +196,16 @@ SECTION("polygon ring tests") {
         incorrect6.set_exterior_ring(std::move(exterior2));
         incorrect6.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect6) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect6, validation_message) );
 
-    std::cout << "Test 12" << std::endl;
     mapnik::geometry::polygon<double> incorrect7;
-    // Has an exterior ring that's backwards
     {
         mapnik::geometry::linear_ring<double> exterior2(exterior_cw);
         mapnik::geometry::linear_ring<double> hole2(hole);;
         incorrect7.set_exterior_ring(std::move(exterior2));
         incorrect7.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect7) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect7, validation_message) );
 
 
     mapnik::geometry::linear_ring<double> nonsimple_hole;
@@ -225,16 +215,86 @@ SECTION("polygon ring tests") {
     nonsimple_hole.add_coord(-4,4);
     nonsimple_hole.add_coord(-2,2);
 
-    std::cout << "Test 13" << std::endl;
     mapnik::geometry::polygon<double> incorrect8;
-    // Has an exterior ring that's backwards
     {
         mapnik::geometry::linear_ring<double> exterior2(exterior);
         mapnik::geometry::linear_ring<double> hole2(nonsimple_hole);
         incorrect8.set_exterior_ring(std::move(exterior2));
         incorrect8.add_hole(std::move(hole2));
     }
-    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect8) );
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect8, validation_message) );
+
+
+    mapnik::geometry::linear_ring<double> exterior_repeated;
+    exterior_repeated.add_coord(0,0);
+    exterior_repeated.add_coord(0,10);
+    exterior_repeated.add_coord(-10,10);
+    exterior_repeated.add_coord(-10,0);
+    exterior_repeated.add_coord(-10,0);
+    exterior_repeated.add_coord(-10,0);
+    exterior_repeated.add_coord(0,0);
+
+    mapnik::geometry::linear_ring<double> hole_repeated;
+    hole_repeated.add_coord(-7,7);
+    hole_repeated.add_coord(-3,7);
+    hole_repeated.add_coord(-3,3);
+    hole_repeated.add_coord(-3,3);
+    hole_repeated.add_coord(-3,3);
+    hole_repeated.add_coord(-7,3);
+    hole_repeated.add_coord(-7,7);
+
+    mapnik::geometry::polygon<double> incorrect9;
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior_repeated);
+        mapnik::geometry::linear_ring<double> hole2(hole);
+        incorrect9.set_exterior_ring(std::move(exterior2));
+        incorrect9.add_hole(std::move(hole2));
+    }
+    // TODO: these tests maybe shouldn't pass because of the repeated points....
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect9, validation_message) );
+
+    mapnik::geometry::polygon<double> incorrect10;
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(hole_repeated);
+        incorrect10.set_exterior_ring(std::move(exterior2));
+        incorrect10.add_hole(std::move(hole2));
+    }
+    // TODO: these tests maybe shouldn't pass because of the repeated points....
+    //
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect10, validation_message) );
+
+
+
+
+    // Test that reverse coordinates work when y-axis is flipped
+    //
+    mapnik::geometry::linear_ring<double> backwards_exterior;
+    mapnik::geometry::linear_ring<double> backwards_inner;
+
+    backwards_exterior.add_coord(0,0);
+    backwards_exterior.add_coord(0,10);
+    backwards_exterior.add_coord(10,10);
+    backwards_exterior.add_coord(10,0);
+    backwards_exterior.add_coord(0,0);
+
+    backwards_inner.add_coord(8,8);
+    backwards_inner.add_coord(5,8);
+    backwards_inner.add_coord(5,5);
+    backwards_inner.add_coord(8,5);
+    backwards_inner.add_coord(8,8);
+
+    mapnik::geometry::polygon<double> correct6;
+    {
+        mapnik::geometry::linear_ring<double> exterior2(backwards_exterior);
+        mapnik::geometry::linear_ring<double> hole2(backwards_inner);
+        correct6.set_exterior_ring(std::move(exterior2));
+        correct6.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(correct6, validation_message) );
+    REQUIRE( mapnik::geometry::is_valid_rings(correct6, validation_message, mapnik::geometry::Y_AXIS_NORTH_NEGATIVE) );
+
+
 
 }
 

--- a/test/unit/geometry/geometry_is_valid.cpp
+++ b/test/unit/geometry/geometry_is_valid.cpp
@@ -26,19 +26,27 @@ SECTION("line_string") {
 
 }
 
-SECTION("polygon with incorrect storage of exterior and interior rings") {
+SECTION("polygon ring tests") {
 
     mapnik::geometry::linear_ring<double> exterior;
     exterior.add_coord(0,0);
-    exterior.add_coord(-10,0);
-    exterior.add_coord(-10,10);
     exterior.add_coord(0,10);
+    exterior.add_coord(-10,10);
+    exterior.add_coord(-10,0);
     exterior.add_coord(0,0);
+
+    mapnik::geometry::linear_ring<double> exterior_cw;
+    exterior_cw.add_coord(0,0);
+    exterior_cw.add_coord(-10,0);
+    exterior_cw.add_coord(-10,10);
+    exterior_cw.add_coord(0,10);
+    exterior_cw.add_coord(0,0);
+
     mapnik::geometry::linear_ring<double> hole;
     hole.add_coord(-7,7);
-    hole.add_coord(-7,3);
-    hole.add_coord(-3,3);
     hole.add_coord(-3,7);
+    hole.add_coord(-3,3);
+    hole.add_coord(-7,3);
     hole.add_coord(-7,7);
 
     mapnik::geometry::linear_ring<double> outside_hole;
@@ -50,11 +58,28 @@ SECTION("polygon with incorrect storage of exterior and interior rings") {
 
     mapnik::geometry::linear_ring<double> overlap_hole;
     overlap_hole.add_coord(-3,3);
-    overlap_hole.add_coord(3,3);
-    overlap_hole.add_coord(3,6);
     overlap_hole.add_coord(-3,6);
+    overlap_hole.add_coord(3,6);
+    overlap_hole.add_coord(3,3);
     overlap_hole.add_coord(-3,3);
 
+    mapnik::geometry::linear_ring<double> overlap_inner_1;
+    overlap_inner_1.add_coord(-1,1);
+    overlap_inner_1.add_coord(-6,1);
+    overlap_inner_1.add_coord(-6,6);
+    overlap_inner_1.add_coord(-1,6);
+    overlap_inner_1.add_coord(-1,1);
+
+
+    mapnik::geometry::linear_ring<double> overlap_inner_2;
+    overlap_inner_2.add_coord(-9,9);
+    overlap_inner_2.add_coord(-4,9);
+    overlap_inner_2.add_coord(-4,4);
+    overlap_inner_2.add_coord(-9,4);
+    overlap_inner_2.add_coord(-9,9);
+
+
+    std::cout << "Test 1" << std::endl;
     mapnik::geometry::polygon<double> correct;
     // add rings correctly and ensure we detect these as correct
     {
@@ -65,6 +90,7 @@ SECTION("polygon with incorrect storage of exterior and interior rings") {
     }
     REQUIRE( mapnik::geometry::is_valid_rings(correct) );
 
+    std::cout << "Test 2" << std::endl;
     mapnik::geometry::polygon<double> incorrect;
     // add rings incorrectly and ensure we detect these as incorrect
     {
@@ -75,6 +101,7 @@ SECTION("polygon with incorrect storage of exterior and interior rings") {
     }
     REQUIRE( !mapnik::geometry::is_valid_rings(incorrect) );
 
+    std::cout << "Test 3" << std::endl;
     mapnik::geometry::polygon<double> incorrect2;
     // Rings added correctly, but interior is fully outside
     {
@@ -85,6 +112,7 @@ SECTION("polygon with incorrect storage of exterior and interior rings") {
     }
     REQUIRE( !mapnik::geometry::is_valid_rings(incorrect2) );
 
+    std::cout << "Test 4" << std::endl;
     mapnik::geometry::polygon<double> incorrect3;
     // Rings added correctly, but interior overlaps exterior
     {
@@ -95,6 +123,118 @@ SECTION("polygon with incorrect storage of exterior and interior rings") {
     }
     REQUIRE( !mapnik::geometry::is_valid_rings(incorrect3) );
 
+
+    std::cout << "Test 5" << std::endl;
+    mapnik::geometry::polygon<double> incorrect4;
+    // Two valid interior rings overlap
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(overlap_inner_1);
+        mapnik::geometry::linear_ring<double> hole3(overlap_inner_2);
+        incorrect4.set_exterior_ring(std::move(exterior2));
+        incorrect4.add_hole(std::move(hole2));
+        incorrect4.add_hole(std::move(hole3));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect4) );
+
+
+    std::cout << "Test 6" << std::endl;
+    mapnik::geometry::polygon<double> correct2;;
+    // Only has exterior ring, should be valid
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        correct2.set_exterior_ring(std::move(exterior2));
+    }
+    REQUIRE( mapnik::geometry::is_valid_rings(correct2) );
+
+
+    std::cout << "Test 7" << std::endl;
+    mapnik::geometry::polygon<double> correct3;;
+    // Has no interior rings, has no exterior ring
+    {
+    }
+    REQUIRE( mapnik::geometry::is_valid_rings(correct3) );
+
+
+    std::cout << "Test 8" << std::endl;
+    mapnik::geometry::polygon<double> correct4;
+    // Has exterior ring, and 1 empty interior ring
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> empty_inner;
+        correct4.set_exterior_ring(std::move(exterior2));
+        correct4.add_hole(std::move(empty_inner));
+    }
+    REQUIRE( mapnik::geometry::is_valid_rings(correct4) );
+
+
+    std::cout << "Test 9" << std::endl;
+    mapnik::geometry::polygon<double> correct5;
+    // Has no exterior ring, and 1 empty interior ring
+    {
+        mapnik::geometry::linear_ring<double> empty_inner;
+        correct5.add_hole(std::move(empty_inner));
+    }
+    REQUIRE( mapnik::geometry::is_valid_rings(correct5) );
+
+
+    std::cout << "Test 10" << std::endl;
+    mapnik::geometry::polygon<double> incorrect5;
+    // Has no exterior, has one non-empty inner
+    {
+        mapnik::geometry::linear_ring<double> hole2(overlap_hole);
+        incorrect5.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect5) );
+
+
+    mapnik::geometry::linear_ring<double> invalid_inner_winding;
+    invalid_inner_winding.add_coord(-9,9);
+    invalid_inner_winding.add_coord(-9,4);
+    invalid_inner_winding.add_coord(-4,4);
+    invalid_inner_winding.add_coord(-4,9);
+    invalid_inner_winding.add_coord(-9,9);
+
+    std::cout << "Test 11" << std::endl;
+    mapnik::geometry::polygon<double> incorrect6;
+    // Has an interior ring that's backwards
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(invalid_inner_winding);;
+        incorrect6.set_exterior_ring(std::move(exterior2));
+        incorrect6.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect6) );
+
+    std::cout << "Test 12" << std::endl;
+    mapnik::geometry::polygon<double> incorrect7;
+    // Has an exterior ring that's backwards
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior_cw);
+        mapnik::geometry::linear_ring<double> hole2(hole);;
+        incorrect7.set_exterior_ring(std::move(exterior2));
+        incorrect7.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect7) );
+
+
+    mapnik::geometry::linear_ring<double> nonsimple_hole;
+    nonsimple_hole.add_coord(-2,2);
+    nonsimple_hole.add_coord(-4,2);
+    nonsimple_hole.add_coord(-2,4);
+    nonsimple_hole.add_coord(-4,4);
+    nonsimple_hole.add_coord(-2,2);
+
+    std::cout << "Test 13" << std::endl;
+    mapnik::geometry::polygon<double> incorrect8;
+    // Has an exterior ring that's backwards
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(nonsimple_hole);
+        incorrect8.set_exterior_ring(std::move(exterior2));
+        incorrect8.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect8) );
 
 }
 

--- a/test/unit/geometry/geometry_is_valid.cpp
+++ b/test/unit/geometry/geometry_is_valid.cpp
@@ -26,6 +26,78 @@ SECTION("line_string") {
 
 }
 
+SECTION("polygon with incorrect storage of exterior and interior rings") {
+
+    mapnik::geometry::linear_ring<double> exterior;
+    exterior.add_coord(0,0);
+    exterior.add_coord(-10,0);
+    exterior.add_coord(-10,10);
+    exterior.add_coord(0,10);
+    exterior.add_coord(0,0);
+    mapnik::geometry::linear_ring<double> hole;
+    hole.add_coord(-7,7);
+    hole.add_coord(-7,3);
+    hole.add_coord(-3,3);
+    hole.add_coord(-3,7);
+    hole.add_coord(-7,7);
+
+    mapnik::geometry::linear_ring<double> outside_hole;
+    outside_hole.add_coord(10,10);
+    outside_hole.add_coord(10,5);
+    outside_hole.add_coord(5,5);
+    outside_hole.add_coord(5,10);
+    outside_hole.add_coord(10,10);
+
+    mapnik::geometry::linear_ring<double> overlap_hole;
+    overlap_hole.add_coord(-3,3);
+    overlap_hole.add_coord(3,3);
+    overlap_hole.add_coord(3,6);
+    overlap_hole.add_coord(-3,6);
+    overlap_hole.add_coord(-3,3);
+
+    mapnik::geometry::polygon<double> correct;
+    // add rings correctly and ensure we detect these as correct
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(hole);
+        correct.set_exterior_ring(std::move(exterior2));
+        correct.add_hole(std::move(hole2));
+    }
+    REQUIRE( mapnik::geometry::is_valid_rings(correct) );
+
+    mapnik::geometry::polygon<double> incorrect;
+    // add rings incorrectly and ensure we detect these as incorrect
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(exterior2);
+        incorrect.set_exterior_ring(std::move(hole2));
+        incorrect.add_hole(std::move(exterior2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect) );
+
+    mapnik::geometry::polygon<double> incorrect2;
+    // Rings added correctly, but interior is fully outside
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(outside_hole);
+        incorrect2.set_exterior_ring(std::move(exterior2));
+        incorrect2.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect2) );
+
+    mapnik::geometry::polygon<double> incorrect3;
+    // Rings added correctly, but interior overlaps exterior
+    {
+        mapnik::geometry::linear_ring<double> exterior2(exterior);
+        mapnik::geometry::linear_ring<double> hole2(overlap_hole);
+        incorrect3.set_exterior_ring(std::move(exterior2));
+        incorrect3.add_hole(std::move(hole2));
+    }
+    REQUIRE( !mapnik::geometry::is_valid_rings(incorrect3) );
+
+
+}
+
 #endif // BOOST_VERSION >= 1.56
 
 }


### PR DESCRIPTION
This adds `mapnik::geometry::is_valid_rings()` which performs ring validation on `polygon` and `multi_polygon` objects.  This is to address #2746.  It performs the following checks:
- Exterior ring fully encloses interior rings
- Interior rings don't overlap
- Exterior ring wind CCW
- Interior rings wind CW
- No rings self-intersect (i.e. all rings are simple polygons)

Test coverage included in `test/unit/geometry/geometry_is_valid.cpp`
