### PR TITLE
fix deprecation warning

### DIFF
--- a/include/mapnik/enumeration.hpp
+++ b/include/mapnik/enumeration.hpp
@@ -180,17 +180,22 @@ public:
     {
         // TODO: Enum value strings with underscore are deprecated in Mapnik 3.x
         // and support will be removed in Mapnik 4.x.
+        bool deprecated = false;
         std::string str_copy(str);
         if (str_copy.find('_') != std::string::npos)
         {
             std::replace(str_copy.begin(), str_copy.end(), '_', '-');
-            MAPNIK_LOG_ERROR(enumerations) << "enumeration value (" << str << ") using \"_\" is deprecated and will be removed in Mapnik 4.x, use '" << str_copy << "' instead";
+            deprecated = true;
         }
         for (unsigned i = 0; i < THE_MAX; ++i)
         {
             if (str_copy == our_strings_[i])
             {
                 value_ = static_cast<ENUM>(i);
+                if (deprecated)
+                {
+                    MAPNIK_LOG_ERROR(enumerations) << "enumeration value (" << str << ") using \"_\" is deprecated and will be removed in Mapnik 4.x, use '" << str_copy << "' instead";
+                }
                 return;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/mapnik/test-data-visual/issues/3#issuecomment-102178513.

`enumeration::from_string()` is being called while parsing xml, trying early evaluation [here](https://github.com/mapnik/mapnik/blob/822d3a5bce70d85857fb5a91a7f1056f0a2f4377/include/mapnik/text/properties_util.hpp#L111) and [here](https://github.com/mapnik/mapnik/blob/1cd5e69b3a740d37f4c713d27dfb24398c8423b9/include/mapnik/symbolizer.hpp#L163).

