### PR TITLE
Geometry Correct

### DIFF
--- a/include/mapnik/json/geometry_util.hpp
+++ b/include/mapnik/json/geometry_util.hpp
@@ -24,6 +24,7 @@
 #define MAPNIK_JSON_GEOMETRY_UTIL_HPP
 
 #include <mapnik/geometry.hpp>
+#include <mapnik/geometry_correct.hpp>
 
 namespace mapnik { namespace json {
 
@@ -100,6 +101,7 @@ struct create_polygon
             else poly.add_hole(std::move(ring));
         }
         geom_ = std::move(poly);
+        mapnik::geometry::correct(geom_);
     }
 
     template <typename T>
@@ -194,6 +196,7 @@ struct create_multipolygon
             multi_poly.emplace_back(std::move(poly));
         }
         geom_ = std::move(multi_poly);
+        mapnik::geometry::correct(geom_);
     }
 
     template <typename T>

--- a/plugins/input/csv/csv_datasource.cpp
+++ b/plugins/input/csv/csv_datasource.cpp
@@ -34,6 +34,7 @@
 #include <mapnik/feature_layer_desc.hpp>
 #include <mapnik/feature_factory.hpp>
 #include <mapnik/geometry.hpp>
+#include <mapnik/geometry_correct.hpp>
 #include <mapnik/memory_featureset.hpp>
 #include <mapnik/wkt/wkt_factory.hpp>
 #include <mapnik/json/geometry_parser.hpp>
@@ -543,6 +544,8 @@ void csv_datasource::parse_csv(T & stream,
                         mapnik::geometry::geometry<double> geom;
                         if (mapnik::from_wkt(value, geom))
                         {
+                            // correct orientations etc
+                            mapnik::geometry::correct(geom);
                             // set geometry
                             feature->set_geometry(std::move(geom));
                             parsed_wkt = true;

--- a/plugins/input/ogr/ogr_featureset.cpp
+++ b/plugins/input/ogr/ogr_featureset.cpp
@@ -31,6 +31,7 @@
 #include <mapnik/unicode.hpp>
 #include <mapnik/value_types.hpp>
 #include <mapnik/feature_factory.hpp>
+#include <mapnik/geometry_correct.hpp>
 
 // ogr
 #include "ogr_featureset.hpp"
@@ -100,7 +101,9 @@ feature_ptr ogr_featureset::next()
         OGRGeometry* geom = poFeature->GetGeometryRef();
         if (geom && ! geom->IsEmpty())
         {
-            feature->set_geometry(std::move(ogr_converter::convert_geometry(geom)));
+            auto geom_corrected = ogr_converter::convert_geometry(geom);
+            mapnik::geometry::correct(geom_corrected);
+            feature->set_geometry(std::move(geom_corrected));
         }
         else
         {

--- a/plugins/input/ogr/ogr_index_featureset.cpp
+++ b/plugins/input/ogr/ogr_index_featureset.cpp
@@ -30,6 +30,7 @@
 #include <mapnik/wkb.hpp>
 #include <mapnik/unicode.hpp>
 #include <mapnik/feature_factory.hpp>
+#include <mapnik/geometry_correct.hpp>
 
 // boost
 #ifdef SHAPE_MEMORY_MAPPED_FILE
@@ -121,7 +122,9 @@ feature_ptr ogr_index_featureset<filterT>::next()
             geom->getEnvelope(&feature_envelope_);
             if (!filter_.pass(mapnik::box2d<double>(feature_envelope_.MinX,feature_envelope_.MinY,
                                             feature_envelope_.MaxX,feature_envelope_.MaxY))) continue;
-            feature->set_geometry(std::move(ogr_converter::convert_geometry(geom)));
+            auto geom_corrected = ogr_converter::convert_geometry(geom);
+            mapnik::geometry::correct(geom_corrected);
+            feature->set_geometry(std::move(geom_corrected));
         }
         else
         {

--- a/plugins/input/osm/osm_featureset.cpp
+++ b/plugins/input/osm/osm_featureset.cpp
@@ -27,8 +27,7 @@
 #include <mapnik/feature_factory.hpp>
 #include <mapnik/debug.hpp>
 #include <mapnik/unicode.hpp>
-
-// boost
+#include <mapnik/geometry_correct.hpp>
 
 #include "osm_featureset.hpp"
 
@@ -91,6 +90,7 @@ feature_ptr osm_featureset<filterT>::next()
             }
             mapnik::geometry::polygon<double> geom;
             geom.set_exterior_ring(std::move(ring));
+            mapnik::geometry::correct(geom);
             feature->set_geometry(std::move(geom));
         }
         else

--- a/plugins/input/shape/shape_io.cpp
+++ b/plugins/input/shape/shape_io.cpp
@@ -27,6 +27,7 @@
 #include <mapnik/make_unique.hpp>
 #include <mapnik/datasource.hpp>
 #include <mapnik/util/is_clockwise.hpp>
+#include <mapnik/geometry_correct.hpp>
 
 using mapnik::datasource_exception;
 const std::string shape_io::SHP = ".shp";
@@ -195,5 +196,6 @@ mapnik::geometry::geometry<double> shape_io::read_polygon(shape_file::record_typ
     } else {
         geom = std::move(poly);
     }
+    mapnik::geometry::correct(geom);
     return geom;
 }

--- a/plugins/input/topojson/topojson_featureset.cpp
+++ b/plugins/input/topojson/topojson_featureset.cpp
@@ -26,6 +26,8 @@
 #include <mapnik/json/topology.hpp>
 #include <mapnik/util/variant.hpp>
 #include <mapnik/geometry_adapters.hpp>
+#include <mapnik/geometry_correct.hpp>
+
 // stl
 #include <string>
 #include <vector>
@@ -263,6 +265,7 @@ struct feature_generator
             }
             if (hit)
             {
+                mapnik::geometry::correct(polygon);
                 feature->set_geometry(std::move(polygon));
                 assign_properties(*feature, poly, tr_);                
             }
@@ -345,6 +348,7 @@ struct feature_generator
             }
             if (hit)
             {
+                mapnik::geometry::correct(multi_polygon);
                 feature->set_geometry(std::move(multi_polygon));
                 assign_properties(*feature, multi_poly, tr_);                
             }

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -27,6 +27,7 @@
 #include <mapnik/wkb.hpp>
 #include <mapnik/feature.hpp>
 #include <mapnik/util/noncopyable.hpp>
+#include <mapnik/geometry_correct.hpp>
 
 namespace mapnik
 {
@@ -409,6 +410,8 @@ mapnik::geometry::geometry<double> geometry_utils::from_wkb(const char* wkb,
 {
     wkb_reader reader(wkb, size, format);
     mapnik::geometry::geometry<double> geom(reader.read());
+    // note: this will only be applied to polygons
+    mapnik::geometry::correct(geom);
     return geom;
 }
 


### PR DESCRIPTION
Calls `mapnik::geometry::correct` on all polygons right after they are created. Closes #2834