### PR TITLE
visual tests: skip visual tests when test data are not present

### DIFF
--- a/test/run
+++ b/test/run
@@ -24,11 +24,15 @@ if [ -n "$(find test/standalone/ -maxdepth 1 -name '*-bin' -print -quit)" ]; the
     done
 fi
 
-run_substep "Running visual tests..."
-if [ -z "$JOBS" ]; then
-    JOBS=1
+if [ -d "test/data-visual/styles" ]; then
+    run_substep "Running visual tests..."
+    if [ -z "$JOBS" ]; then
+        JOBS=1
+    fi
+    ./test/visual/run -j $JOBS
+    failures=$((failures+$?))
+else
+    echo "Notice: Skipping visual tests, the visual tests data are not present under the standard directory \"test/data-visual\"."
 fi
-./test/visual/run -j $JOBS
-failures=$((failures+$?))
 
 exit $failures


### PR DESCRIPTION
Addresses https://github.com/mapnik/mapnik/issues/2841#issuecomment-104448028.

I was thinking about handling it somehow in the visual test runner itself, but I'm not convinced to do so as it looks better to handle it outside of the runner. On the other side I'm planning to improve visual tests reporting and I will probably handle missing styles directory more gracefully.

I hope this is sufficient for now.