### PR TITLE
No throw rendering

### DIFF
--- a/include/mapnik/symbolizer.hpp
+++ b/include/mapnik/symbolizer.hpp
@@ -292,7 +292,14 @@ struct evaluate_expression_wrapper<mapnik::color>
     {
         mapnik::value_type val = util::apply_visitor(mapnik::evaluate<T2,mapnik::value_type,T3>(feature,vars), expr);
         if (val.is_null()) return mapnik::color(0,0,0,0); // transparent
-        return mapnik::color(val.to_string());
+        try
+        {
+            return mapnik::color(val.to_string());
+        }
+        catch (std::exception const&)
+        {
+            return mapnik::color(0,0,0,0); // transparent
+        }
     }
 };
 

--- a/test/unit/font/fontset_runtime_test.cpp
+++ b/test/unit/font/fontset_runtime_test.cpp
@@ -24,9 +24,6 @@
 #include <algorithm>
 #include <mapnik/make_unique.hpp>
 
-// icu - for memory cleanup (to make valgrind happy)
-#include "unicode/uclean.h"
-
 TEST_CASE("fontset") {
 
 SECTION("error") {
@@ -80,6 +77,5 @@ SECTION("error") {
     } catch (std::exception const& ex) {
         REQUIRE(std::string(ex.what()) == std::string("Unable to find specified font face 'DejaVu Sans Book' in font set: 'fontset'"));
     }
-    u_cleanup();
 }
 }

--- a/test/unit/rendering/invalid_color.cpp
+++ b/test/unit/rendering/invalid_color.cpp
@@ -1,0 +1,55 @@
+#include "catch.hpp"
+
+#include <iostream>
+#include <mapnik/map.hpp>
+#include <mapnik/layer.hpp>
+#include <mapnik/feature_type_style.hpp>
+#include <mapnik/rule.hpp>
+#include <mapnik/symbolizer.hpp>
+#include <mapnik/unicode.hpp>
+#include <mapnik/memory_datasource.hpp>
+#include <mapnik/agg_renderer.hpp>
+
+#include <memory>
+
+using namespace mapnik;
+
+TEST_CASE("invalid color should not stop rendering") {
+
+    mapnik::Map m(256,256);
+    // add layer to map with one point
+    {
+        mapnik::context_ptr ctx = std::make_shared<mapnik::context_type>();
+        ctx->push("name");
+        mapnik::feature_ptr feature = std::make_shared<feature_impl>(ctx,1);
+        mapnik::transcoder tr("utf-8");
+        mapnik::value_unicode_string ustr = tr.transcode("hello world!");
+        feature->put("name",ustr);
+        mapnik::geometry::point<double> pt(128,128);
+        feature->set_geometry(std::move(pt));
+        mapnik::parameters params;
+        params["type"]="memory";
+        auto ds = std::make_shared<mapnik::memory_datasource>(params);
+        ds->push(feature);
+        mapnik::layer lyr("layer");
+        lyr.set_datasource(ds);
+        lyr.add_style("style");
+        m.add_layer(lyr);
+    }
+    // add style to map
+    {
+        mapnik::feature_type_style the_style;
+        mapnik::rule r;
+        mapnik::dot_symbolizer sym;
+        mapnik::put(sym, mapnik::keys::fill, parse_expression("2"));
+        r.append(std::move(sym));
+        the_style.add_rule(std::move(r));
+        m.insert_style("style", std::move(the_style) );        
+    }
+    m.zoom_to_box(mapnik::box2d<double>(-256,-256,
+                                        256,256));
+    mapnik::image_rgba8 buf(m.width(),m.height());
+    mapnik::agg_renderer<mapnik::image_rgba8> ren(m,buf);
+    ren.apply();
+
+}


### PR DESCRIPTION
There are very few to near zero situations where rendering should throw. Instead if something unexpected happens during rendering the problem item should be skipped or not rendered and rendering should continue.

One situation, that is newly a problem, is that after all properties moved to expressions they became much harder to validate at XML load (#2237).

This branch contains a reduced testcase for when an invalid color value is passed that may slip through XML loading and will throw during rendering (not ideal).
