### PR TITLE
Use sh instead of bash for configure

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PYTHON=${PYTHON:-python}
 


### PR DESCRIPTION
Not everywhere has bash installed or installs it to /bin/bash

Given that there's no bash-specific features in configure, it makes
sense to just use sh