### PR TITLE
Switch default compiler to cc/c++

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,8 +39,8 @@ severities = ['debug', 'warn', 'error', 'none']
 ICU_INCLUDES_DEFAULT='/usr/include'
 ICU_LIBS_DEFAULT='/usr/'
 
-DEFAULT_CC = "gcc"
-DEFAULT_CXX = "g++"
+DEFAULT_CC = "cc"
+DEFAULT_CXX = "c++"
 DEFAULT_CXX11_CXXFLAGS = " -std=c++11"
 DEFAULT_CXX11_LINKFLAGS = ""
 if sys.platform == 'darwin':


### PR DESCRIPTION
On Linux this will normally be gcc/g++ and remain equivalent. On FreeBSD these point to clang and gcc is not installed by default.

It might be possible to remove the OS X special casing below, but I don't have a machine suitable for testing.