### PR TITLE
Don't hard-code bash path in mapnik-config

### DIFF
--- a/utils/mapnik-config/build.py
+++ b/utils/mapnik-config/build.py
@@ -29,7 +29,7 @@ Import('env')
 
 config_env = env.Clone()
 
-config_variables = '''#!/bin/bash
+config_variables = '''#!/usr/bin/env bash
 
 ## variables
 


### PR DESCRIPTION
`[[` is a bashism, so this script needs bash, but shouldn't assume a location.