### PR TITLE
Visual tests improvements, support for grid renderer

### DIFF
--- a/include/mapnik/grid/grid.hpp
+++ b/include/mapnik/grid/grid.hpp
@@ -152,8 +152,8 @@ public:
 
     inline mapnik::grid_view get_view(std::size_t x, std::size_t y, std::size_t w, std::size_t h)
     {
-        return mapnik::grid_view(x,y,w,h,
-                                 data_,key_,id_name_,names_,f_keys_,features_);
+        return mapnik::grid_view(x, y, w, h,
+                                 data_, key_, id_name_, names_, f_keys_, features_);
     }
 
 private:
@@ -166,11 +166,11 @@ private:
     hit_grid& operator=(const hit_grid&);
 
 public:
-    inline void setPixel(std::size_t x,std::size_t y,value_type feature_id)
+    inline void setPixel(std::size_t x, std::size_t y, value_type feature_id)
     {
-        if (checkBounds(x,y))
+        if (checkBounds(x, y))
         {
-            data_(x,y) = feature_id;
+            data_(x, y) = feature_id;
         }
     }
     inline std::size_t width() const
@@ -183,10 +183,10 @@ public:
         return height_;
     }
 
-    inline void set_rectangle(value_type id,image_rgba8 const& data,std::size_t x0,std::size_t y0)
+    inline void set_rectangle(value_type id, image_rgba8 const& data, std::size_t x0, std::size_t y0)
     {
-        box2d<int> ext0(0,0,width_,height_);
-        box2d<int> ext1(x0,y0,x0+data.width(),y0+data.height());
+        box2d<int> ext0(0, 0, width_, height_);
+        box2d<int> ext1(x0, y0, x0 + data.width(), y0 + data.height());
 
         if (ext0.intersects(ext1))
         {
@@ -194,11 +194,11 @@ public:
             for (std::size_t y = box.miny(); y < box.maxy(); ++y)
             {
                 value_type* row_to =  data_.get_row(y);
-                image_rgba8::pixel_type const * row_from = data.get_row(y-y0);
+                image_rgba8::pixel_type const * row_from = data.get_row(y - y0);
 
                 for (std::size_t x = box.minx(); x < box.maxx(); ++x)
                 {
-                    image_rgba8::pixel_type rgba = row_from[x-x0];
+                    image_rgba8::pixel_type rgba = row_from[x - x0];
                     unsigned a = (rgba >> 24) & 0xff;
                     // if the pixel is more than a tenth
                     // opaque then burn in the feature id

--- a/include/mapnik/grid/grid.hpp
+++ b/include/mapnik/grid/grid.hpp
@@ -57,8 +57,8 @@ public:
     static const value_type base_mask;
 
 private:
-    unsigned width_;
-    unsigned height_;
+    std::size_t width_;
+    std::size_t height_;
     std::string key_;
     data_type data_;
     std::string id_name_;
@@ -70,7 +70,7 @@ private:
 
 public:
 
-    hit_grid(int width, int height, std::string const& key);
+    hit_grid(std::size_t width, std::size_t height, std::string const& key);
 
     hit_grid(hit_grid<T> const& rhs);
 
@@ -145,12 +145,12 @@ public:
         return data_.data();
     }
 
-    inline value_type const * get_row(unsigned row) const
+    inline value_type const * get_row(std::size_t row) const
     {
         return data_.get_row(row);
     }
 
-    inline mapnik::grid_view get_view(unsigned x, unsigned y, unsigned w, unsigned h)
+    inline mapnik::grid_view get_view(std::size_t x, std::size_t y, std::size_t w, std::size_t h)
     {
         return mapnik::grid_view(x,y,w,h,
                                  data_,key_,id_name_,names_,f_keys_,features_);
@@ -158,7 +158,7 @@ public:
 
 private:
 
-    inline bool checkBounds(unsigned x, unsigned y) const
+    inline bool checkBounds(std::size_t x, std::size_t y) const
     {
         return (x < width_ && y < height_);
     }
@@ -166,24 +166,24 @@ private:
     hit_grid& operator=(const hit_grid&);
 
 public:
-    inline void setPixel(int x,int y,value_type feature_id)
+    inline void setPixel(std::size_t x,std::size_t y,value_type feature_id)
     {
         if (checkBounds(x,y))
         {
             data_(x,y) = feature_id;
         }
     }
-    inline unsigned width() const
+    inline std::size_t width() const
     {
         return width_;
     }
 
-    inline unsigned height() const
+    inline std::size_t height() const
     {
         return height_;
     }
 
-    inline void set_rectangle(value_type id,image_rgba8 const& data,int x0,int y0)
+    inline void set_rectangle(value_type id,image_rgba8 const& data,std::size_t x0,std::size_t y0)
     {
         box2d<int> ext0(0,0,width_,height_);
         box2d<int> ext1(x0,y0,x0+data.width(),y0+data.height());
@@ -191,14 +191,14 @@ public:
         if (ext0.intersects(ext1))
         {
             box2d<int> box = ext0.intersect(ext1);
-            for (int y = box.miny(); y < box.maxy(); ++y)
+            for (std::size_t y = box.miny(); y < box.maxy(); ++y)
             {
                 value_type* row_to =  data_.get_row(y);
-                unsigned int const * row_from = data.get_row(y-y0);
+                image_rgba8::pixel_type const * row_from = data.get_row(y-y0);
 
-                for (int x = box.minx(); x < box.maxx(); ++x)
+                for (std::size_t x = box.minx(); x < box.maxx(); ++x)
                 {
-                    unsigned rgba = row_from[x-x0];
+                    image_rgba8::pixel_type rgba = row_from[x-x0];
                     unsigned a = (rgba >> 24) & 0xff;
                     // if the pixel is more than a tenth
                     // opaque then burn in the feature id

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -37,7 +37,7 @@ template <typename T>
 const typename hit_grid<T>::value_type hit_grid<T>::base_mask = std::numeric_limits<typename T::type>::min();
 
 template <typename T>
-hit_grid<T>::hit_grid(int width, int height, std::string const& key)
+hit_grid<T>::hit_grid(std::size_t width, std::size_t height, std::string const& key)
     : width_(width),
       height_(height),
       key_(key),

--- a/test/visual/renderer.hpp
+++ b/test/visual/renderer.hpp
@@ -33,6 +33,7 @@
 // mapnik
 #include <mapnik/map.hpp>
 #include <mapnik/agg_renderer.hpp>
+#include <mapnik/grid/grid_renderer.hpp>
 #if defined(HAVE_CAIRO)
 #include <mapnik/cairo/cairo_renderer.hpp>
 #include <mapnik/cairo/cairo_image_util.hpp>
@@ -139,14 +140,49 @@ struct svg_renderer : renderer_base<std::string>
 };
 #endif
 
-struct grid_renderer : renderer_base<mapnik::image_gray8>
+struct grid_renderer : renderer_base<mapnik::image_rgba8>
 {
     static constexpr const char * name = "grid";
 
+    void convert(mapnik::grid::data_type const & grid, image_type & image) const
+    {
+        for (std::size_t y = 0; y < grid.height(); ++y)
+        {
+            mapnik::grid::value_type const * grid_row = grid.get_row(y);
+            image_type::pixel_type * image_row = image.get_row(y);
+            for (std::size_t x = 0; x < grid.width(); ++x)
+            {
+                mapnik::grid::value_type val = grid_row[x];
+
+                if (val == mapnik::grid::base_mask)
+                {
+                    image_row[x] = 0;
+                    continue;
+                }
+                if (val < 0)
+                {
+                    throw std::runtime_error("grid renderer: feature id is negative.");
+                }
+
+                val *= 100;
+
+                if (val > 0x00ffffff)
+                {
+                    throw std::runtime_error("grid renderer: feature id is too high.");
+                }
+
+                image_row[x] = val | 0xff000000;
+            }
+        }
+    }
+
     image_type render(mapnik::Map const & map, double scale_factor) const
     {
+        mapnik::grid grid(map.width(), map.height(), "__id__");
+        mapnik::grid_renderer<mapnik::grid> ren(map, grid, scale_factor);
+        ren.apply();
         image_type image(map.width(), map.height());
-        // TODO: Render grid here.
+        convert(grid.data(), image);
         return image;
     }
 };

--- a/test/visual/renderer.hpp
+++ b/test/visual/renderer.hpp
@@ -156,7 +156,7 @@ class renderer
 {
 public:
     renderer(boost::filesystem::path const & output_dir, boost::filesystem::path const & reference_dir, bool overwrite)
-        : output_dir(output_dir), reference_dir(reference_dir), overwrite(overwrite)
+        : ren(), output_dir(output_dir), reference_dir(reference_dir), overwrite(overwrite)
     {
     }
 
@@ -208,7 +208,7 @@ private:
         return s.str();
     }
 
-    Renderer ren;
+    const Renderer ren;
     boost::filesystem::path const & output_dir;
     boost::filesystem::path const & reference_dir;
     const bool overwrite;

--- a/test/visual/run.cpp
+++ b/test/visual/run.cpp
@@ -87,13 +87,21 @@ int main(int argc, char** argv)
     report_type report = vm.count("verbose") ? report_type((console_report())) : report_type((console_short_report()));
     result_list results;
 
-    if (vm.count("styles"))
+    try
     {
-        results = run.test(vm["styles"].as<std::vector<std::string>>(), report);
+        if (vm.count("styles"))
+        {
+            results = run.test(vm["styles"].as<std::vector<std::string>>(), report);
+        }
+        else
+        {
+            results = run.test_all(report);
+        }
     }
-    else
+    catch (std::exception & e)
     {
-        results = run.test_all(report);
+        std::cerr << "Error runnig tests: " << e.what() << std::endl;
+        return 1;
     }
 
     unsigned failed_count = mapnik::util::apply_visitor(summary_visitor(results), report);

--- a/test/visual/runner.cpp
+++ b/test/visual/runner.cpp
@@ -67,8 +67,8 @@ runner::runner(runner::path_type const & styles_dir,
 #if defined(SVG_RENDERER)
                   ,renderer<svg_renderer>(output_dir_, reference_dir_, overwrite)
 #endif
-                  /*,renderer<grid_renderer>(output_dir_, reference_dir_, overwrite)*/
-                 }
+                  ,renderer<grid_renderer>(output_dir_, reference_dir_, overwrite)
+                }
 {
 }
 

--- a/test/visual/runner.hpp
+++ b/test/visual/runner.hpp
@@ -42,7 +42,7 @@ class runner
 #if defined(SVG_RENDERER)
                                                 ,renderer<svg_renderer>
 #endif
-                                                /*renderer<grid_renderer>*/>;
+                                                ,renderer<grid_renderer>>;
     using path_type = boost::filesystem::path;
     using files_iterator = std::vector<path_type>::const_iterator;
 


### PR DESCRIPTION
Refs https://github.com/mapnik/mapnik/issues/2800.

I have used simplest conversion from grid to image, which came to my mind. There is limitation to maximum feature id, which has to be < 167772. That should be enough for test cases we have.

I will rebase once https://github.com/mapnik/mapnik/pull/2852 is merged.

Here are some samples:
![image-filters-multi-blur-512-512-1 0-grid](https://cloud.githubusercontent.com/assets/1950911/7798915/4a010b10-0300-11e5-9258-f48d9082c244.png)
![text-vertical-alignment-800-800-2 0-grid](https://cloud.githubusercontent.com/assets/1950911/7798914/4a0054a4-0300-11e5-907e-970a14394796.png)
![text-iconic-font-1000-1000-2 0-grid](https://cloud.githubusercontent.com/assets/1950911/7798913/49fca732-0300-11e5-917c-b5061bac15a7.png)
![road-casings-non-grouped-rendering-600-600-1 0-grid](https://cloud.githubusercontent.com/assets/1950911/7806076/b1649732-037c-11e5-92f4-fc4edab545a9.png)
