### PR TITLE
better handling of missing styles

### DIFF
--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -361,7 +361,7 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material 
         boost::optional<feature_type_style const&> style=m_.find_style(style_name);
         if (!style)
         {
-            MAPNIK_LOG_DEBUG(feature_style_processor)
+            MAPNIK_LOG_ERROR(feature_style_processor)
                 << "feature_style_processor: Style=" << style_name
                 << " required for layer=" << lay.name() << " does not exist.";
 

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -129,6 +129,7 @@ private:
     void find_unused_nodes_recursive(xml_node const& node, std::string & error_text);
     std::string ensure_relative_to_xml(boost::optional<std::string> const& opt_path);
     void ensure_exists(std::string const& file_path);
+    void check_styles(Map const & map) const throw (config_error);
     boost::optional<color> get_opt_color_attr(boost::property_tree::ptree const& node,
                                               std::string const& name);
 
@@ -328,6 +329,10 @@ void map_parser::parse_map(Map & map, xml_node const& node, std::string const& b
         throw config_error("Not a map file. Node 'Map' not found.");
     }
     find_unused_nodes(node);
+    if (strict_)
+    {
+        check_styles(map);
+    }
 }
 
 void map_parser::parse_map_include(Map & map, xml_node const& node)
@@ -1681,6 +1686,21 @@ void map_parser::find_unused_nodes_recursive(xml_node const& node, std::string &
         for (auto const& child_node : node)
         {
             find_unused_nodes_recursive(child_node, error_message);
+        }
+    }
+}
+
+void map_parser::check_styles(Map const & map) const throw (config_error)
+{
+    for (auto const & layer : map.layers())
+    {
+        for (auto const & style : layer.styles())
+        {
+            if (!map.find_style(style))
+            {
+                throw config_error("Unable to process some data while parsing '" + filename_ +
+                    "': Style '" + style + "' required for layer '" + layer.name() + "'.");
+            }
         }
     }
 }


### PR DESCRIPTION
Refs https://github.com/mapnik/mapnik/issues/2822.

* `MAPNIK_LOG_DEBUG` raised to `MAPNIK_LOG_ERROR` for the message during rendering.
* Throws during xml parsing when `strict = true`.