### PR TITLE
Don't trim whitespace in the XML loaders.

### DIFF
--- a/include/mapnik/util/trim.hpp
+++ b/include/mapnik/util/trim.hpp
@@ -92,6 +92,13 @@ static inline void unquote(std::string & s)
     s.erase(std::find_if(s.rbegin(), s.rend(), not_quoted).base(), s.end());
 }
 
+// returns true if the string `s` consists entirely of whitespace
+// characters, as defined by the `not_whitespace` function. returns
+// false if any character is not whitespace.
+static inline bool is_whitespace(std::string const &s) {
+  return !std::any_of(s.begin(), s.end(), not_whitespace);
+}
+
 }} // end of namespace mapnik
 
 #endif // MAPNIK_TRIM_HPP

--- a/plugins/input/csv/csv_datasource.cpp
+++ b/plugins/input/csv/csv_datasource.cpp
@@ -108,6 +108,11 @@ csv_datasource::csv_datasource(parameters const& params)
     if (inline_string)
     {
         inline_string_ = *inline_string;
+        // trim inline strings, primarily to get rid of whitespace at
+        // the beginning left by the XML parser. see
+        // https://github.com/mapnik/mapnik/pull/2878#issuecomment-108728845
+        // for the discussion of this.
+        mapnik::util::trim(inline_string_);
     }
     else
     {

--- a/src/libxml2_loader.cpp
+++ b/src/libxml2_loader.cpp
@@ -26,7 +26,6 @@
 #include <mapnik/xml_loader.hpp>
 #include <mapnik/xml_node.hpp>
 #include <mapnik/config_error.hpp>
-#include <mapnik/util/trim.hpp>
 #include <mapnik/util/noncopyable.hpp>
 #include <mapnik/util/fs.hpp>
 
@@ -174,10 +173,9 @@ private:
             break;
             case XML_TEXT_NODE:
             {
-                std::string trimmed(reinterpret_cast<const char *>(cur_node->content));
-                mapnik::util::trim(trimmed);
-                if (trimmed.empty()) break; //Don't add empty text nodes
-                node.add_child(trimmed.c_str(), cur_node->line, true);
+                const char *content = reinterpret_cast<const char *>(cur_node->content);
+                if (*content == '\0') break; //Don't add empty text nodes
+                node.add_child(content, cur_node->line, true);
             }
             break;
             case XML_COMMENT_NODE:

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -1662,6 +1662,15 @@ void map_parser::find_unused_nodes_recursive(xml_node const& node, std::string &
         {
             if (node.is_text())
             {
+                // suppress warnings about whitespace text nodes, since
+                // whitespace text nodes are now left in the tree. see
+                // https://github.com/mapnik/mapnik/pull/2878#issuecomment-108728845
+                // for the discussion.
+                if (mapnik::util::is_whitespace(node.text()))
+                {
+                    return;
+                }
+
                 error_message += "\n* text '" + node.text();
             }
             else

--- a/src/rapidxml_loader.cpp
+++ b/src/rapidxml_loader.cpp
@@ -30,7 +30,6 @@
 #include <mapnik/xml_loader.hpp>
 #include <boost/property_tree/detail/xml_parser_read_rapidxml.hpp>
 #include <mapnik/xml_node.hpp>
-#include <mapnik/util/trim.hpp>
 #include <mapnik/util/noncopyable.hpp>
 #include <mapnik/util/utf_conv_win.hpp>
 
@@ -85,7 +84,7 @@ public:
             // Parse using appropriate flags
             // https://github.com/mapnik/mapnik/issues/1856
             // const int f_tws = rapidxml::parse_normalize_whitespace;
-            const int f_tws = rapidxml::parse_trim_whitespace | rapidxml::parse_validate_closing_tags;
+            const int f_tws = rapidxml::parse_validate_closing_tags;
             rapidxml::xml_document<> doc;
             doc.parse<f_tws>(&array.front());
 
@@ -138,11 +137,7 @@ private:
         {
             if (cur_node->value_size() > 0) // Don't add empty text nodes
             {
-                // parsed text values should have leading and trailing
-                // whitespace trimmed.
-                std::string trimmed = cur_node->value();
-                mapnik::util::trim(trimmed);
-                node.add_child(trimmed.c_str(), 0, true);
+                node.add_child(cur_node->value(), 0, true);
             }
         }
         break;

--- a/src/text/formatting/base.cpp
+++ b/src/text/formatting/base.cpp
@@ -26,6 +26,7 @@
 #include <mapnik/text/formatting/list.hpp>
 #include <mapnik/text/formatting/registry.hpp>
 #include <mapnik/xml_node.hpp>
+#include <mapnik/util/trim.hpp>
 
 namespace mapnik { namespace formatting {
 
@@ -36,6 +37,15 @@ node_ptr node::from_xml(xml_node const& xml, fontset_map const& fontsets)
     {
         if (node.name() == "Placement")
             continue;
+
+        // if this is a blank text node child, then ignore it. this is
+        // needed because the XML loader no longer trims and discards
+        // empty whitespace.
+        if (node.is_text() && mapnik::util::is_whitespace(node.text()))
+        {
+            continue;
+        }
+
         node_ptr n = registry::instance().from_xml(node,fontsets);
         if (n) list->push_back(n);
     }

--- a/test/unit/serialization/xml_parser_trim.cpp
+++ b/test/unit/serialization/xml_parser_trim.cpp
@@ -37,9 +37,9 @@ TEST_CASE("xml parser") {
     REQUIRE(datasource.has_child("Parameter"));
     mapnik::xml_node const &parameter = datasource.get_child("Parameter");
 
-    // parser should call mapnik::util::trim on the text content and
-    // this should result in an empty text string in the parameter.
-    REQUIRE(parameter.get_text() == "");
+    // parser should NOT call mapnik::util::trim on the text content and
+    // this should result in a text string consisting of a single space.
+    REQUIRE(parameter.get_text() == " ");
   }
 }
 


### PR DESCRIPTION
The libxml2 and ptree (a.k.a rapidxml) XML loaders were inconsistent in their handling of whitespace:

* Rapidxml trimmed some, but not did not process CDATA child
  nodes.
* Libxml2 trimmed all, due to manual application of the trim
  function.

As discussed in https://github.com/mapnik/mapnik/pull/2878#issuecomment-108728845
it would be preferable not to trim. However, simply disabling trimming breaks CSV reading in many places, as we have lots of test files like this:

```xml
    <Layer name="frame" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
        <StyleName>frame</StyleName>
        <Datasource>
            <Parameter name="type">csv</Parameter>
            <Parameter name="inline">
wkt|name
Polygon((-75.0 -75.0, -75.0 75.0, 35.0 75.0, 35.0 -75.0, -75.0 -75.0))|bounds
            </Parameter>
        </Datasource>
    </Layer>
```

This is due to turning off trimming _entirely_ - if we leave trimming on in rapidxml via `rapidxml::parse_trim_whitespace` (added in 95d5b73d) then we are only left with the case that rapidxml does not trim whitespace inside of a `<![CDATA[ ]]>' node, which breaks round-tripping the "empty_parameter2" test case. Libxml has no equivalent setting; whitespace trimming is either done all or nothing, manually and without regard to whether it came in a CDATA node or not.

However, failures are confined to the text node formatting and CSV plugin's inline functionality.

Therefore, if a manual call to trim is made for CSV inline handling and all-whitespace child nodes are dropped in the text node formatting, then all the tests pass (for me, let's see what Travis has to say...). Note that we still don't have full test coverage, so it's possible that other behaviour may have changed.
