### PR TITLE
fix make python for non-bash shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 install
 
 python:
-	if [[ ! -d ./bindings/python ]]; then git clone git@github.com:mapnik/python-mapnik.git --recursive ./bindings/python; else (cd bindings/python && git pull && git submodule update --init); fi;
+	if [ ! -d ./bindings/python ]; then git clone git@github.com:mapnik/python-mapnik.git --recursive ./bindings/python; else (cd bindings/python && git pull && git submodule update --init); fi;
 	make
 	python bindings/python/test/visual.py -q
 


### PR DESCRIPTION
Fixes `make python` on non-bash shells:

```
if [[ ! -d ./bindings/python ]]; then git clone git@github.com:mapnik/python-mapnik.git --recursive./bindings/python; else (cd bindings/python && git pull && gi
t submodule update --init); fi;
/bin/sh: 1: [[: not found
/bin/sh: 1: cd: can't cd to bindings/python
make: *** [python] Error 2
```