### PR TITLE
fix rendering raster without scaling

### DIFF
--- a/src/agg/process_raster_symbolizer.cpp
+++ b/src/agg/process_raster_symbolizer.cpp
@@ -51,7 +51,7 @@ void agg_renderer<T0,T1>::process(raster_symbolizer const& sym,
 {
     render_raster_symbolizer(
         sym, feature, prj_trans, common_,
-        [&](image_rgba8 & target, composite_mode_e comp_op, double opacity,
+        [&](image_rgba8 const & target, composite_mode_e comp_op, double opacity,
             int start_x, int start_y) {
             composite(*current_buffer_, target,
                       comp_op, opacity, start_x, start_y);

--- a/src/cairo/process_raster_symbolizer.cpp
+++ b/src/cairo/process_raster_symbolizer.cpp
@@ -43,7 +43,7 @@ void cairo_renderer<T>::process(raster_symbolizer const& sym,
     cairo_save_restore guard(context_);
     render_raster_symbolizer(
         sym, feature, prj_trans, common_,
-        [&](image_rgba8 &target, composite_mode_e comp_op, double opacity,
+        [&](image_rgba8 const & target, composite_mode_e comp_op, double opacity,
             int start_x, int start_y) {
             context_.set_operator(comp_op);
             context_.add_image(start_x, start_y, target, opacity);


### PR DESCRIPTION
This patch fixes bug which causes raster not being rendered under specific circumstances:
* Raster resolution matches map resolution.
* Raster is rendered from (0, 0) positon.
* Raster is single-band type.

Test case is here https://github.com/mapnik/test-data-visual/pull/10.
[Here](https://github.com/mapnik/mapnik/blob/51172c8fdfdf6432a204758fc916dac228c7a2b6/include/mapnik/renderer_common/process_raster_symbolizer.hpp#L239-L242) is the place causing the problem.

I also cannot fully understand following condition:

```c++
if ( (std::fabs(image_ratio_x - 1.0) <= eps) &&
     (std::fabs(image_ratio_y - 1.0) <= eps) &&
     (std::abs(start_x) <= eps) &&
     (std::abs(start_y) <= eps) )
```
Isn't `(std::abs(start_x) <= eps) && (std::abs(start_y) <= eps)` superfluous here? This condition limits the optimization only to the first tile. Or do I miss something?
