### PR TITLE
handle pj_transform HUGE_VAL results (aka inf)

### DIFF
--- a/src/proj_transform.cpp
+++ b/src/proj_transform.cpp
@@ -163,6 +163,13 @@ bool proj_transform::forward (double * x, double * y , double * z, int point_cou
         return false;
     }
 
+    for(int j=0; j<point_count; j++) {
+        if (x[j] == HUGE_VAL || y[j] == HUGE_VAL)
+        {
+            return false;
+        }
+    }
+
     if (is_dest_longlat_)
     {
         int i;
@@ -203,6 +210,13 @@ bool proj_transform::backward (double * x, double * y , double * z, int point_co
                       offset, x,y,z) != 0)
     {
         return false;
+    }
+
+    for(int j=0; j<point_count; j++) {
+        if (x[j] == HUGE_VAL || y[j] == HUGE_VAL)
+        {
+            return false;
+        }
     }
 
     if (is_source_longlat_)


### PR DESCRIPTION
 - turns out pj_transform will not always return an error for
   failed transforms and may instead just set values as HUGE_VAL
 - this commit handles this and calls it an error by returning false
   from forward/backward

Arguably if `point_count` > 1 some values might be correctly transformed
while others might be HUGE_VAL. For the purposes of Mapnik we will consider
any HUGE_VAL as an error because we have no way to handle partial failures.


>  * Revision 1.11  2004/01/24 09:37:19  warmerda
>  * pj_transform() will no longer return an error code if any of the points are
>   * transformable.  In this case the application is expected to check for
>   * HUGE_VAL to identify failed points.

from https://github.com/route-me/route-me/blob/master/Proj4/pj_transform.c#L85. NOTE: this specific note is not longer present in https://github.com/OSGeo/proj.4/blob/master/src/pj_transform.c or https://github.com/OSGeo/proj.4/blob/master/ChangeLog for some reason.