### PR TITLE
Fix jpeg crash

### DIFF
--- a/src/jpeg_reader.cpp
+++ b/src/jpeg_reader.cpp
@@ -206,8 +206,11 @@ void jpeg_reader<T>::attach_stream (j_decompress_ptr cinfo, input_stream* in)
 }
 
 template <typename T>
-void jpeg_reader<T>::on_error(j_common_ptr /*cinfo*/)
+void jpeg_reader<T>::on_error(j_common_ptr cinfo)
 {
+    char buffer[JMSG_LENGTH_MAX];
+    (*cinfo->err->format_message)(cinfo, buffer);
+    throw image_reader_exception(std::string("JPEG Reader: libjpeg could not read image: ") + buffer);
 }
 
 template <typename T>

--- a/test/unit/imaging/image_io_test.cpp
+++ b/test/unit/imaging/image_io_test.cpp
@@ -39,7 +39,7 @@ SECTION("readers") {
         }
         catch (std::exception const& ex)
         {
-            REQUIRE( std::string(ex.what()) == std::string("JPEG Reader: libjpeg could not read image: Not a JPEG file: starts with 0x89") );
+            REQUIRE( std::string(ex.what()) == std::string("JPEG Reader: libjpeg could not read image: Not a JPEG file: starts with 0x89 0x50") );
         }
 #endif
 

--- a/test/unit/imaging/image_io_test.cpp
+++ b/test/unit/imaging/image_io_test.cpp
@@ -26,6 +26,21 @@ SECTION("readers") {
         type = mapnik::type_from_filename(should_throw);
         REQUIRE( type );
         REQUIRE_THROWS(std::unique_ptr<mapnik::image_reader> reader(mapnik::get_image_reader(should_throw,*type)));
+
+        // actually a png so jpeg reader should throw
+        should_throw = "./test/data/images/landusepattern.jpg";
+        REQUIRE( mapnik::util::exists( should_throw ) );
+        type = mapnik::type_from_filename(should_throw);
+        REQUIRE( type );
+        try
+        {
+            std::unique_ptr<mapnik::image_reader> reader(mapnik::get_image_reader(should_throw,*type));
+            REQUIRE(false);
+        }
+        catch (std::exception const& ex)
+        {
+            REQUIRE( std::string(ex.what()) == std::string("JPEG Reader: libjpeg could not read image: Not a JPEG file: starts with 0x89") );
+        }
 #endif
 
         REQUIRE_THROWS(mapnik::image_rgba8 im(-10,-10)); // should throw rather than overflow


### PR DESCRIPTION
Turns out (at least with libjpeg-turbo) the `on_error` may be called even if `on_error_message` is not called. This fixes the code so that an error is throw and we avoid proceeding to call `jpeg_read_header` which would then crash inside libjpeg-turbo.

Fixes #2903