### PR TITLE
Fix pixel cast

### DIFF
--- a/include/mapnik/pixel_cast.hpp
+++ b/include/mapnik/pixel_cast.hpp
@@ -24,122 +24,139 @@
 #define MAPNIK_PIXEL_CAST_HPP
 
 #include <type_traits>
-#include <boost/numeric/conversion/bounds.hpp>
 
 namespace mapnik {
 
 namespace detail {
 
-    template<typename T, typename S, typename E = void>
-    struct numeric_compare;
+template<typename T, typename S, typename E = void>
+struct numeric_compare;
 
-    template<typename T, typename S>
-    struct numeric_compare_same_sign
-    {
-        using sizeup = typename std::conditional<sizeof(T) >= sizeof(S), T, S>::type;
+template<typename T, typename S>
+struct numeric_compare_same_sign
+{
+    using sizeup = typename std::conditional<sizeof(T) >= sizeof(S), T, S>::type;
 
-        static inline bool less(T t, S s) {
-            return static_cast<sizeup>(t) < static_cast<sizeup>(s);
-        }
-
-        static inline bool greater(T t, S s) {
-            return static_cast<sizeup>(t) > static_cast<sizeup>(s);
-        }
-    };
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
-            ((std::is_unsigned<T>::value && std::is_unsigned<S>::value)
-            || (std::is_signed<T>::value && std::is_signed<S>::value))>
-        ::type> : numeric_compare_same_sign<T,S>
-    {};
-
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
-                  std::is_integral<T>::value && std::is_signed<T>::value && std::is_unsigned<S>::value>::type>
-    {
-        static inline bool less(T t, S s) {
-            return (t < static_cast<T>(0)) ? true : static_cast<uint64_t>(t) < static_cast<uint64_t>(s);
-        }
-
-        static inline bool greater(T t, S s) {
-            return (t < static_cast<T>(0)) ? false : static_cast<uint64_t>(t) > static_cast<uint64_t>(s);
-        }
-    };
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
-                  std::is_integral<T>::value && std::is_unsigned<T>::value && std::is_signed<S>::value>::type>
-    {
-        static inline bool less(T t, S s) {
-            return (s < static_cast<S>(0)) ? false : static_cast<uint64_t>(t) < static_cast<uint64_t>(s);
-        }
-
-        static inline bool greater(T t, S s) {
-            return (s < static_cast<S>(0)) ? true : static_cast<uint64_t>(t) > static_cast<uint64_t>(s);
-        }
-    };
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<std::is_floating_point<T>::value && std::is_floating_point<S>::value>::type>
-    {
-        static inline bool less(T t, S s) {
-            return t < s;
-        }
-
-        static inline bool greater(T t, S s) {
-            return t > s;
-        }
-    };
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<std::is_floating_point<T>::value && std::is_integral<S>::value>::type>
-    {
-        static inline bool less(T t, S s) {
-            return less(static_cast<double>(t),static_cast<double>(s));
-        }
-
-        static inline bool greater(T t, S s) {
-            return greater(static_cast<double>(t),static_cast<double>(s));
-        }
-    };
-
-
-    template<typename T, typename S>
-    struct numeric_compare<T,S,typename std::enable_if<std::is_integral<T>::value && std::is_floating_point<S>::value>::type>
-    {
-        static inline bool less(T t, S s) {
-            return less(static_cast<double>(t),static_cast<double>(s));
-        }
-
-        static inline bool greater(T t, S s) {
-            return greater(static_cast<double>(t),static_cast<double>(s));
-        }
-    };
-
-    template<typename T, typename S>
-    inline bool less(T t, S s) {
-        return numeric_compare<T,S>::less(t,s);
+    static inline bool less(T t, S s) {
+        return static_cast<sizeup>(t) < static_cast<sizeup>(s);
     }
 
-    template<typename T, typename S>
-    inline bool greater(T t, S s) {
-        return numeric_compare<T,S>::greater(t,s);
+    static inline bool greater(T t, S s) {
+        return static_cast<sizeup>(t) > static_cast<sizeup>(s);
     }
+};
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
+                                                   ((std::is_unsigned<T>::value && std::is_unsigned<S>::value)
+                                                    || (std::is_signed<T>::value && std::is_signed<S>::value))>
+    ::type> : numeric_compare_same_sign<T,S>
+{};
+
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
+                                                   std::is_integral<T>::value && std::is_signed<T>::value && std::is_unsigned<S>::value>::type>
+{
+    static inline bool less(T t, S s) {
+        return (t < static_cast<T>(0)) ? true : static_cast<uint64_t>(t) < static_cast<uint64_t>(s);
+    }
+
+    static inline bool greater(T t, S s) {
+        return (t < static_cast<T>(0)) ? false : static_cast<uint64_t>(t) > static_cast<uint64_t>(s);
+    }
+};
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<!std::is_floating_point<T>::value && !std::is_floating_point<S>::value &&
+                                                   std::is_integral<T>::value && std::is_unsigned<T>::value && std::is_signed<S>::value>::type>
+{
+    static inline bool less(T t, S s) {
+        return (s < static_cast<S>(0)) ? false : static_cast<uint64_t>(t) < static_cast<uint64_t>(s);
+    }
+
+    static inline bool greater(T t, S s) {
+        return (s < static_cast<S>(0)) ? true : static_cast<uint64_t>(t) > static_cast<uint64_t>(s);
+    }
+};
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<std::is_floating_point<T>::value && std::is_floating_point<S>::value>::type>
+{
+    static inline bool less(T t, S s) {
+        return t < s;
+    }
+
+    static inline bool greater(T t, S s) {
+        return t > s;
+    }
+};
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<std::is_floating_point<T>::value && std::is_integral<S>::value>::type>
+{
+    static inline bool less(T t, S s) {
+        return less(static_cast<double>(t),static_cast<double>(s));
+    }
+
+    static inline bool greater(T t, S s) {
+        return greater(static_cast<double>(t),static_cast<double>(s));
+    }
+};
+
+
+template<typename T, typename S>
+struct numeric_compare<T,S,typename std::enable_if<std::is_integral<T>::value && std::is_floating_point<S>::value>::type>
+{
+    static inline bool less(T t, S s) {
+        return less(static_cast<double>(t),static_cast<double>(s));
+    }
+
+    static inline bool greater(T t, S s) {
+        return greater(static_cast<double>(t),static_cast<double>(s));
+    }
+};
+
+template<typename T, typename S>
+inline bool less(T t, S s) {
+    return numeric_compare<T,S>::less(t,s);
 }
+
+template<typename T, typename S>
+inline bool greater(T t, S s) {
+    return numeric_compare<T,S>::greater(t,s);
+}
+
+// floats
+template <typename T, typename Enable = void>
+struct bounds
+{
+    static constexpr T lowest() { return static_cast<T>(-std::numeric_limits<T>::max());}
+    static constexpr T highest() { return std::numeric_limits<T>::max();}
+};
+
+// integers
+template <typename T>
+struct bounds<T, typename std::enable_if<std::numeric_limits<T>::is_integer>::type >
+{
+    static constexpr T lowest() { return std::numeric_limits<T>::min();}
+    static constexpr T highest() { return std::numeric_limits<T>::max();}
+};
+
+} // ns detail
 
 
 template <typename T, typename S>
 inline T pixel_cast(S s)
 {
-    static T max_val = boost::numeric::bounds<T>::highest();
+    static constexpr auto max_val = detail::bounds<T>::highest();
+    static constexpr auto min_val = detail::bounds<T>::lowest();
+
     if (detail::greater(s,max_val))
     {
         return max_val;
     }
-    static T min_val = boost::numeric::bounds<T>::lowest();
-    if (detail::less(s,min_val))
+    else if (detail::less(s,min_val))
     {
         return min_val;
     }

--- a/test/unit/imaging/image_set_pixel.cpp
+++ b/test/unit/imaging/image_set_pixel.cpp
@@ -1,0 +1,28 @@
+#include "catch.hpp"
+
+// mapnik
+#include <mapnik/image_any.hpp>
+#include <mapnik/image_view_any.hpp>
+#include <mapnik/color.hpp>
+#include <mapnik/image_util.hpp>
+
+
+TEST_CASE("image set_pixel") {
+
+SECTION("test gray32") {
+    mapnik::image_gray32 im(256,256);
+    mapnik::set_pixel(im, 0, 0, -1);
+    auto pixel = mapnik::get_pixel<mapnik::image_gray32::pixel_type>(im, 0, 0);
+    INFO( pixel );
+    CHECK( pixel == 0 );
+}
+
+SECTION("test gray8s") {
+    mapnik::image_gray8s im(256,256);
+    mapnik::set_pixel(im, 0, 0, std::numeric_limits<mapnik::image_gray8s::pixel_type>::max()+1);
+    auto pixel = mapnik::get_pixel<mapnik::image_gray8s::pixel_type>(im, 0, 0);
+    INFO( pixel );
+    CHECK( (int)pixel == (int)std::numeric_limits<mapnik::image_gray8s::pixel_type>::max() );
+}
+
+}


### PR DESCRIPTION
My attempt to address https://github.com/mapnik/mapnik/issues/2893#issuecomment-111386739

/cc @artemp for review, fixups, merge?

BTW, I tried to use `constexpr boost::integer_traits<type>::const_max` but failed to get that working in a generic way because we also need to support doubles. But using something that can be `consexpr` should help performance.

Also, I did some benchmarking when testing this and could not pick up a difference between this implementation and `boost::numeric_cast` for the non-throwing case. But of course when things overflow and `numeric_cast` throws performance drops horrendously. So, my sense is we basically want all the numeric cast offers except the throw but I also can't see any better way to get that then this pixel_cast approach.