### PR TITLE
visual tests: add time measurement

### DIFF
--- a/test/visual/config.hpp
+++ b/test/visual/config.hpp
@@ -26,6 +26,7 @@
 // stl
 #include <vector>
 #include <string>
+#include <chrono>
 
 // boost
 #include <boost/filesystem.hpp>
@@ -74,6 +75,7 @@ struct result
     boost::filesystem::path reference_image_path;
     std::string error_message;
     unsigned diff;
+    std::chrono::high_resolution_clock::duration duration;
 };
 
 using result_list = std::vector<result>;

--- a/test/visual/renderer.hpp
+++ b/test/visual/renderer.hpp
@@ -237,20 +237,18 @@ public:
     {
     }
 
-    result test(std::string const & name, mapnik::Map const & map, double scale_factor) const
+    image_type render(mapnik::Map const & map, double scale_factor) const
     {
-        image_type image(ren.render(map, scale_factor));
-        return report(image, name, { map.width(), map.height() }, { 1, 1 }, scale_factor);
+        return ren.render(map, scale_factor);
     }
 
-    result test_tiles(std::string const & name, mapnik::Map & map, map_size const & tiles, double scale_factor) const
+    image_type render(mapnik::Map & map, double scale_factor, map_size const & tiles) const
     {
-        image_type image(map.width(), map.height());
         mapnik::box2d<double> box = map.get_current_extent();
+        image_type image(map.width(), map.height());
         map.resize(image.width() / tiles.width, image.height() / tiles.height);
         double tile_box_width = box.width() / tiles.width;
         double tile_box_height = box.height() / tiles.height;
-
         for (std::size_t tile_y = 0; tile_y < tiles.height; tile_y++)
         {
             for (std::size_t tile_x = 0; tile_x < tiles.width; tile_x++)
@@ -265,7 +263,7 @@ public:
                 set_rectangle(tile, image, tile_x * tile.width(), (tiles.height - 1 - tile_y) * tile.height());
             }
         }
-        return report(image, name, { image.width(), image.height() }, tiles, scale_factor);
+        return image;
     }
 
     result report(image_type const & image,

--- a/test/visual/report.cpp
+++ b/test/visual/report.cpp
@@ -55,6 +55,11 @@ void console_report::report(result const & r)
             break;
     }
 
+    if (show_duration)
+    {
+        s << " (" << std::chrono::duration_cast<std::chrono::milliseconds>(r.duration).count() << " milliseconds)";
+    }
+
     s << std::endl;
 }
 

--- a/test/visual/report.hpp
+++ b/test/visual/report.hpp
@@ -36,7 +36,7 @@ namespace visual_tests
 class console_report
 {
 public:
-    console_report() : s(std::clog)
+    console_report(bool _show_duration) : s(std::clog), show_duration(_show_duration)
     {
     }
 
@@ -49,12 +49,13 @@ public:
 
 protected:
     std::ostream & s;
+    bool show_duration;
 };
 
 class console_short_report : public console_report
 {
 public:
-    console_short_report() : console_report()
+    console_short_report() : console_report(false)
     {
     }
 

--- a/test/visual/run.cpp
+++ b/test/visual/run.cpp
@@ -53,6 +53,8 @@ int main(int argc, char** argv)
         ("help,h", "produce usage message")
         ("verbose,v", "verbose output")
         ("overwrite,o", "overwrite reference image")
+        ("duration,d", "output rendering duration")
+        ("iterations,i", po::value<std::size_t>()->default_value(1), "number of iterations for benchmarking")
         ("jobs,j", po::value<std::size_t>()->default_value(1), "number of parallel threads")
         ("styles-dir", po::value<std::string>()->default_value("test/data-visual/styles"), "directory with styles")
         ("images-dir", po::value<std::string>()->default_value("test/data-visual/images"), "directory with reference images")
@@ -108,8 +110,11 @@ int main(int argc, char** argv)
                output_dir,
                vm["images-dir"].as<std::string>(),
                vm.count("overwrite"),
+               vm["iterations"].as<std::size_t>(),
                vm["jobs"].as<std::size_t>());
-    report_type report = vm.count("verbose") ? report_type((console_report())) : report_type((console_short_report()));
+    bool show_duration = vm.count("duration");
+    bool verbose = vm.count("verbose") | show_duration;
+    report_type report(verbose ? report_type((console_report(show_duration))) : report_type((console_short_report())));
     result_list results;
 
     try

--- a/test/visual/runner.hpp
+++ b/test/visual/runner.hpp
@@ -54,6 +54,7 @@ public:
            path_type const & output_dir,
            path_type const & reference_dir,
            bool overwrite,
+           std::size_t iterations,
            std::size_t jobs);
 
     result_list test_all(report_type & report) const;
@@ -70,6 +71,7 @@ private:
     const path_type output_dir_;
     const path_type reference_dir_;
     const std::size_t jobs_;
+    const std::size_t iterations_;
     const renderer_type renderers_[boost::mpl::size<renderer_type::types>::value];
 };
 


### PR DESCRIPTION
Refs https://github.com/mapnik/mapnik/issues/2946.

Introduces new command line arguments
*  `--duration` or  `-d` for reporting rendering time
* `--iterations` or `-i` for setting number of rendering iterations

Example:
```
 $ test/visual/run text-spacing -d -i 100
"text-spacing-512-512-1.0" with agg... OK (5902 milliseconds)
"text-spacing-512-512-1.0" with cairo... OK (6045 milliseconds)
"text-spacing-512-512-1.0" with svg... OK (582 milliseconds)
"text-spacing-512-512-1.0" with grid... OK (3389 milliseconds)
"text-spacing-512-512-2.0" with agg... OK (5440 milliseconds)
"text-spacing-512-512-2.0" with cairo... OK (6178 milliseconds)
"text-spacing-512-512-2.0" with svg... OK (572 milliseconds)
"text-spacing-512-512-2.0" with grid... OK (3974 milliseconds)

Visual rendering: 0 failed / 8 passed / 0 overwritten / 0 errors
```