### PR TITLE
Handle nodata in greyscale, and wrap wide values ala GDAL

### DIFF
--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -298,6 +298,10 @@ void read_grayscale_band(mapnik::raster_ptr raster,
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
       val = reader();
+      // Apply harse type clipping rules ala GDAL
+      if ( val < 0 ) val = 0;
+      if ( val > 255 ) val = 255;
+      // Calculate pixel offset
       off = y * width * ps + x * ps;
       // Pixel space is RGBA, fill all w/ same value for Grey
       data[off+0] = val;


### PR DESCRIPTION
The issues described in #2661 are fixed here.

* The greyscale nodata handling is fixed by writing transparency into the output image where the nodata value appears.
* The wide value wrapping is handled the same brutal way GDAL handles it, by just clipping values that exceed the dynamic range (8 bits) of the output greyscale image. (Another approach would be to pre-scan the whole image to find the range and scale the results into the 8 bit space, but harmonizing with GDAL seemed simpler (also, pre-scanning could result in weird effects as different clipping bounds exposed different dynamic ranges for the data))