### PR TITLE
visual tests: report total time spent by renderers

### DIFF
--- a/test/visual/report.hpp
+++ b/test/visual/report.hpp
@@ -55,7 +55,7 @@ protected:
 class console_short_report : public console_report
 {
 public:
-    console_short_report() : console_report(false)
+    console_short_report(bool _show_duration) : console_report(_show_duration)
     {
     }
 

--- a/test/visual/run.cpp
+++ b/test/visual/run.cpp
@@ -113,8 +113,7 @@ int main(int argc, char** argv)
                vm["iterations"].as<std::size_t>(),
                vm["jobs"].as<std::size_t>());
     bool show_duration = vm.count("duration");
-    bool verbose = vm.count("verbose") | show_duration;
-    report_type report(verbose ? report_type((console_report(show_duration))) : report_type((console_short_report())));
+    report_type report(vm.count("verbose") ? report_type((console_report(show_duration))) : report_type((console_short_report(show_duration))));
     result_list results;
 
     try


### PR DESCRIPTION
Refs https://github.com/mapnik/mapnik/pull/2954#issuecomment-119188382, https://github.com/mapnik/mapnik/issues/2946

Example:

```
 $ test/visual/run text-upright text-spacing -v -d
"text-upright-800-800-1.0" with agg... OK (26 milliseconds)
"text-upright-800-800-1.0" with cairo... OK (37 milliseconds)
"text-upright-800-800-1.0" with svg... OK (1 milliseconds)
"text-upright-800-800-1.0" with grid... OK (28 milliseconds)
"text-upright-800-800-2.0" with agg... OK (21 milliseconds)
"text-upright-800-800-2.0" with cairo... OK (29 milliseconds)
"text-upright-800-800-2.0" with svg... OK (0 milliseconds)
"text-upright-800-800-2.0" with grid... OK (19 milliseconds)
"text-spacing-512-512-1.0" with agg... OK (42 milliseconds)
"text-spacing-512-512-1.0" with cairo... OK (41 milliseconds)
"text-spacing-512-512-1.0" with svg... OK (0 milliseconds)
"text-spacing-512-512-1.0" with grid... OK (21 milliseconds)
"text-spacing-512-512-2.0" with agg... OK (39 milliseconds)
"text-spacing-512-512-2.0" with cairo... OK (43 milliseconds)
"text-spacing-512-512-2.0" with svg... OK (0 milliseconds)
"text-spacing-512-512-2.0" with grid... OK (22 milliseconds)

Visual rendering: 0 failed / 16 passed / 0 overwritten / 0 errors
agg:    130 milliseconds
cairo:  152 milliseconds
grid:   91 milliseconds
svg:    2 milliseconds
total:  377 milliseconds
```