### PR TITLE
Allow mapnik-json and mapnik-wkt to be built as shared libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ python:
 	make
 	python bindings/python/test/visual.py -q
 
-src/json/libmapnik-json.a:
+src/json/libmapnik-json.so:
 	# we first build memory intensive files with -j1
 	$(PYTHON) scons/scons.py -j1 \
 		--config=cache --implicit-cache --max-drift=1 \
 		src/renderer_common/process_group_symbolizer.os \
-		src/json/libmapnik-json.a \
-		src/wkt/libmapnik-wkt.a \
+		src/json/libmapnik-json.so \
+		src/wkt/libmapnik-wkt.so \
 		src/css_color_grammar.os \
 		src/expression_grammar.os \
 		src/transform_expression_grammar.os \
@@ -35,7 +35,7 @@ src/json/libmapnik-json.a:
 		src/cairo/process_markers_symbolizer.os \
 		src/cairo/process_group_symbolizer.os \
 
-mapnik: src/json/libmapnik-json.a
+mapnik: src/json/libmapnik-json.so
 	# then install the rest with -j$(JOBS)
 	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
 

--- a/SConstruct
+++ b/SConstruct
@@ -431,6 +431,8 @@ pickle_store = [# Scons internal variables
         'CUSTOM_CXXFLAGS', # user submitted
         'CUSTOM_CFLAGS', # user submitted
         'MAPNIK_LIB_NAME',
+        'MAPNIK_JSON_LIB_NAME',
+        'MAPNIK_WKT_LIB_NAME',
         'LINK',
         'RUNTIME_LINK',
         # Mapnik's SConstruct build variables
@@ -1186,6 +1188,16 @@ if not preconfigured:
        env['MAPNIK_LIB_NAME'] = '${LIBPREFIX}${MAPNIK_NAME}${LIBSUFFIX}'
     else:
        env['MAPNIK_LIB_NAME'] = '${SHLIBPREFIX}${MAPNIK_NAME}${SHLIBSUFFIX}'
+
+    if env['LINKING'] == 'static':
+       env['MAPNIK_JSON_LIB_NAME'] = '${LIBPREFIX}${MAPNIK_NAME}-json${LIBSUFFIX}'
+    else:
+       env['MAPNIK_JSON_LIB_NAME'] = '${SHLIBPREFIX}${MAPNIK_NAME}-json${SHLIBSUFFIX}'
+
+    if env['LINKING'] == 'static':
+       env['MAPNIK_WKT_LIB_NAME'] = '${LIBPREFIX}${MAPNIK_NAME}-wkt${LIBSUFFIX}'
+    else:
+       env['MAPNIK_WKT_LIB_NAME'] = '${SHLIBPREFIX}${MAPNIK_NAME}-wkt${SHLIBSUFFIX}'
 
     if env['PKG_CONFIG_PATH']:
         env['ENV']['PKG_CONFIG_PATH'] = fix_path(env['PKG_CONFIG_PATH'])

--- a/benchmark/build.py
+++ b/benchmark/build.py
@@ -8,7 +8,7 @@ test_env = env.Clone()
 
 test_env['LIBS'] = [env['MAPNIK_NAME']]
 test_env.AppendUnique(LIBS=copy(env['LIBMAPNIK_LIBS']))
-test_env.AppendUnique(LIBS='mapnik-wkt')
+test_env.AppendUnique(LIBS=('%s-wkt' % env['MAPNIK_NAME']))
 if env['PLATFORM'] == 'Linux':
     test_env.AppendUnique(LIBS='dl')
     test_env.AppendUnique(LIBS='rt')

--- a/mason_latest.sh
+++ b/mason_latest.sh
@@ -2,7 +2,7 @@
 
 MASON_NAME=mapnik
 MASON_VERSION=latest
-MASON_LIB_FILE=lib/libmapnik-wkt.a
+MASON_LIB_FILE=lib/libmapnik-wkt.so
 
 . ${MASON_DIR:-~/.mason}/mason.sh
 

--- a/plugins/input/csv/build.py
+++ b/plugins/input/csv/build.py
@@ -37,8 +37,8 @@ plugin_sources = Split(
 libraries = []
 libraries.append('boost_system%s' % env['BOOST_APPEND'])
 libraries.append(env['ICU_LIB_NAME'])
-libraries.append('mapnik-json')
-libraries.append('mapnik-wkt')
+libraries.append('%s-json' % env['MAPNIK_NAME'])
+libraries.append('%s-wkt' % env['MAPNIK_NAME'])
 
 if env['PLUGIN_LINKING'] == 'shared':
     libraries.append(env['MAPNIK_NAME'])
@@ -51,8 +51,8 @@ if env['PLUGIN_LINKING'] == 'shared':
 
     # if the plugin links to libmapnik ensure it is built first
     Depends(TARGET, env.subst('../../../src/%s' % env['MAPNIK_LIB_NAME']))
-    Depends(TARGET, env.subst('../../../src/json/libmapnik-json${LIBSUFFIX}'))
-    Depends(TARGET, env.subst('../../../src/wkt/libmapnik-wkt${LIBSUFFIX}'))
+    Depends(TARGET, env.subst('../../../src/json/%s' % env['MAPNIK_JSON_LIB_NAME']))
+    Depends(TARGET, env.subst('../../../src/wkt/%s' % env['MAPNIK_WKT_LIB_NAME']))
 
     if 'uninstall' not in COMMAND_LINE_TARGETS:
         env.Install(env['MAPNIK_INPUT_PLUGINS_DEST'], TARGET)

--- a/plugins/input/geojson/build.py
+++ b/plugins/input/geojson/build.py
@@ -50,7 +50,7 @@ else:
     libraries = []
     libraries.append(env['ICU_LIB_NAME'])
     libraries.append('boost_system%s' % env['BOOST_APPEND'])
-    libraries.append('mapnik-json')
+    libraries.append('%s-json' % env['MAPNIK_NAME'])
 
     if env['PLUGIN_LINKING'] == 'shared':
         libraries.append(env['MAPNIK_NAME'])
@@ -63,7 +63,7 @@ else:
 
         # if the plugin links to libmapnik ensure it is built first
         Depends(TARGET, env.subst('../../../src/%s' % env['MAPNIK_LIB_NAME']))
-        Depends(TARGET, env.subst('../../../src/json/libmapnik-json${LIBSUFFIX}'))
+        Depends(TARGET, env.subst('../../../src/json/%s' % env['MAPNIK_JSON_LIB_NAME']))
 
         if 'uninstall' not in COMMAND_LINE_TARGETS:
             env.Install(env['MAPNIK_INPUT_PLUGINS_DEST'], TARGET)

--- a/plugins/input/topojson/build.py
+++ b/plugins/input/topojson/build.py
@@ -48,7 +48,7 @@ else:
     libraries = []
     libraries.append(env['ICU_LIB_NAME'])
     libraries.append('boost_system%s' % env['BOOST_APPEND'])
-    libraries.append('mapnik-json')
+    libraries.append('%s-json' % env['MAPNIK_NAME'])
 
     if env['PLUGIN_LINKING'] == 'shared':
         libraries.append(env['MAPNIK_NAME'])
@@ -61,7 +61,7 @@ else:
 
         # if the plugin links to libmapnik ensure it is built first
         Depends(TARGET, env.subst('../../../src/%s' % env['MAPNIK_LIB_NAME']))
-        Depends(TARGET, env.subst('../../../src/json/libmapnik-json${LIBSUFFIX}'))
+        Depends(TARGET, env.subst('../../../src/json/%s' % env['MAPNIK_JSON_LIB_NAME']))
 
         if 'uninstall' not in COMMAND_LINE_TARGETS:
             env.Install(env['MAPNIK_INPUT_PLUGINS_DEST'], TARGET)

--- a/src/json/build.py
+++ b/src/json/build.py
@@ -21,14 +21,118 @@
 
 import os
 from glob import glob
+from subprocess import Popen, PIPE
 
 Import('env')
 lib_env = env.Clone()
-lib_env.Append(CXXFLAGS='-fPIC')
+
+def call(cmd, silent=True):
+    stdin, stderr = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+    if not stderr:
+        return stdin.strip()
+    elif not silent:
+        print stderr
+
+def ldconfig(*args,**kwargs):
+    call('ldconfig')
+
+if env['LINKING'] == 'static':
+    lib_env.Append(CXXFLAGS='-fPIC')
+
+mapnik_lib_link_flag = ''
+
+ABI_VERSION = env['ABI_VERSION']
+
+if env['PLATFORM'] == 'Darwin':
+    mapnik_libname = env.subst(env['MAPNIK_JSON_LIB_NAME'])
+    if env['FULL_LIB_PATH']:
+        lib_path = '%s/%s' % (env['MAPNIK_LIB_BASE'],mapnik_libname)
+    else:
+        lib_path = '@loader_path/'+mapnik_libname
+    mapnik_lib_link_flag += ' -Wl,-install_name,%s' % lib_path
+    _d = {'version':env['MAPNIK_VERSION_STRING'].replace('-pre','')}
+    mapnik_lib_link_flag += ' -current_version %(version)s -compatibility_version %(version)s' % _d
+else: # unix, non-macos
+    mapnik_libname = env.subst(env['MAPNIK_JSON_LIB_NAME'])
+    if env['ENABLE_SONAME']:
+        mapnik_libname = env.subst(env['MAPNIK_JSON_LIB_NAME']) + (".%d.%d" % (int(ABI_VERSION[0]),int(ABI_VERSION[1])))
+    if env['PLATFORM'] == 'SunOS':
+        if env['CXX'].startswith('CC'):
+            mapnik_lib_link_flag += ' -R. -h %s' % mapnik_libname
+        else:
+            mapnik_lib_link_flag += ' -Wl,-h,%s' %  mapnik_libname
+    else: # Linux and others
+        if env['PLATFORM'] != 'FreeBSD':
+            lib_env['LIBS'].append('dl')
+        mapnik_lib_link_flag += ' -Wl,-rpath-link,.'
+        if env['ENABLE_SONAME']:
+            mapnik_lib_link_flag += ' -Wl,-soname,%s' % mapnik_libname
+        if env['FULL_LIB_PATH']:
+            mapnik_lib_link_flag += ' -Wl,-rpath=%s' % env['MAPNIK_LIB_BASE']
+        else:
+            mapnik_lib_link_flag += ' -Wl,-z,origin -Wl,-rpath=\$$ORIGIN'
+
+# clone the env one more time to isolate mapnik_lib_link_flag
+lib_env_final = lib_env.Clone()
+lib_env_final.Prepend(LINKFLAGS=mapnik_lib_link_flag)
 
 name = "mapnik-json"
-lib = lib_env.StaticLibrary(name, glob('./' + '*.cpp'), LIBS=[])
-target = os.path.join(env['MAPNIK_LIB_BASE_DEST'], env.subst('${LIBPREFIX}%s${LIBSUFFIX}' % name))
-result = env.InstallAs(target=target, source=lib)
-env.Alias(target='install', source=result)
-env['create_uninstall_target'](env, target)
+source = glob('./' + '*.cpp')
+
+if env['PLATFORM'] == 'Darwin' or not env['ENABLE_SONAME']:
+    target_path = env['MAPNIK_LIB_BASE_DEST']
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        if env['LINKING'] == 'static':
+            lib = lib_env_final.StaticLibrary(name, source, LIBS=[])
+        else:
+            lib = lib_env_final.SharedLibrary(name, source, LIBS=[])
+        result = env.Install(target_path, lib)
+        env.Alias(target='install', source=result)
+
+    env['create_uninstall_target'](env, os.path.join(target_path,env.subst(env['MAPNIK_JSON_LIB_NAME'])))
+else:
+    # Symlink command, only works if both files are in same directory
+    def symlink(env, target, source):
+        trgt = str(target[0])
+        src = str(source[0])
+
+        if os.path.islink(trgt) or os.path.exists(trgt):
+            os.remove(trgt)
+        os.symlink(os.path.basename(src), trgt)
+
+    major, minor, micro = ABI_VERSION
+
+    soFile = "%s.%d.%d.%d" % (os.path.basename(env.subst(env['MAPNIK_JSON_LIB_NAME'])), int(major), int(minor), int(micro))
+    target = os.path.join(env['MAPNIK_LIB_BASE_DEST'], soFile)
+
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        if env['LINKING'] == 'static':
+            lib = lib_env_final.StaticLibrary(name, source, LIBS=[])
+        else:
+            lib = lib_env_final.SharedLibrary(name, source, LIBS=[])
+        result = env.InstallAs(target=target, source=lib)
+        env.Alias(target='install', source=result)
+        if result:
+              env.AddPostAction(result, ldconfig)
+
+    # Install symlinks
+    target1 = os.path.join(env['MAPNIK_LIB_BASE_DEST'], "%s.%d.%d" % \
+        (os.path.basename(env.subst(env['MAPNIK_JSON_LIB_NAME'])),int(major), int(minor)))
+    target2 = os.path.join(env['MAPNIK_LIB_BASE_DEST'], os.path.basename(env.subst(env['MAPNIK_JSON_LIB_NAME'])))
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        link1 = env.Command(target1, target, symlink)
+        env.Alias(target='install', source=link1)
+        link2 = env.Command(target2, target1, symlink)
+        env.Alias(target='install', source=link2)
+    # delete in reverse order..
+    env['create_uninstall_target'](env, target2)
+    env['create_uninstall_target'](env, target1)
+    env['create_uninstall_target'](env, target)
+
+    # to enable local testing
+    lib_major_minor = "%s.%d.%d" % (os.path.basename(env.subst(env['MAPNIK_JSON_LIB_NAME'])), int(major), int(minor))
+    local_lib = os.path.basename(env.subst(env['MAPNIK_JSON_LIB_NAME']))
+    if os.path.islink(lib_major_minor) or os.path.exists(lib_major_minor):
+        os.remove(lib_major_minor)
+    os.symlink(local_lib,lib_major_minor)
+    Clean(lib,lib_major_minor);

--- a/src/wkt/build.py
+++ b/src/wkt/build.py
@@ -21,14 +21,118 @@
 
 import os
 from glob import glob
+from subprocess import Popen, PIPE
 
 Import('env')
 lib_env = env.Clone()
-lib_env.Append(CXXFLAGS='-fPIC')
+
+def call(cmd, silent=True):
+    stdin, stderr = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
+    if not stderr:
+        return stdin.strip()
+    elif not silent:
+        print stderr
+
+def ldconfig(*args,**kwargs):
+    call('ldconfig')
+
+if env['LINKING'] == 'static':
+    lib_env.Append(CXXFLAGS='-fPIC')
+
+mapnik_lib_link_flag = ''
+
+ABI_VERSION = env['ABI_VERSION']
+
+if env['PLATFORM'] == 'Darwin':
+    mapnik_libname = env.subst(env['MAPNIK_WKT_LIB_NAME'])
+    if env['FULL_LIB_PATH']:
+        lib_path = '%s/%s' % (env['MAPNIK_LIB_BASE'],mapnik_libname)
+    else:
+        lib_path = '@loader_path/'+mapnik_libname
+    mapnik_lib_link_flag += ' -Wl,-install_name,%s' % lib_path
+    _d = {'version':env['MAPNIK_VERSION_STRING'].replace('-pre','')}
+    mapnik_lib_link_flag += ' -current_version %(version)s -compatibility_version %(version)s' % _d
+else: # unix, non-macos
+    mapnik_libname = env.subst(env['MAPNIK_WKT_LIB_NAME'])
+    if env['ENABLE_SONAME']:
+        mapnik_libname = env.subst(env['MAPNIK_WKT_LIB_NAME']) + (".%d.%d" % (int(ABI_VERSION[0]),int(ABI_VERSION[1])))
+    if env['PLATFORM'] == 'SunOS':
+        if env['CXX'].startswith('CC'):
+            mapnik_lib_link_flag += ' -R. -h %s' % mapnik_libname
+        else:
+            mapnik_lib_link_flag += ' -Wl,-h,%s' %  mapnik_libname
+    else: # Linux and others
+        if env['PLATFORM'] != 'FreeBSD':
+            lib_env['LIBS'].append('dl')
+        mapnik_lib_link_flag += ' -Wl,-rpath-link,.'
+        if env['ENABLE_SONAME']:
+            mapnik_lib_link_flag += ' -Wl,-soname,%s' % mapnik_libname
+        if env['FULL_LIB_PATH']:
+            mapnik_lib_link_flag += ' -Wl,-rpath=%s' % env['MAPNIK_LIB_BASE']
+        else:
+            mapnik_lib_link_flag += ' -Wl,-z,origin -Wl,-rpath=\$$ORIGIN'
+
+# clone the env one more time to isolate mapnik_lib_link_flag
+lib_env_final = lib_env.Clone()
+lib_env_final.Prepend(LINKFLAGS=mapnik_lib_link_flag)
 
 name = "mapnik-wkt"
-lib = lib_env.StaticLibrary(name, glob('./' + '*.cpp'), LIBS=[])
-target = os.path.join(env['MAPNIK_LIB_BASE_DEST'], env.subst('${LIBPREFIX}%s${LIBSUFFIX}' % name))
-result = env.InstallAs(target=target, source=lib)
-env.Alias(target='install', source=result)
-env['create_uninstall_target'](env, target)
+source = glob('./' + '*.cpp')
+
+if env['PLATFORM'] == 'Darwin' or not env['ENABLE_SONAME']:
+    target_path = env['MAPNIK_LIB_BASE_DEST']
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        if env['LINKING'] == 'static':
+            lib = lib_env_final.StaticLibrary(name, source, LIBS=[])
+        else:
+            lib = lib_env_final.SharedLibrary(name, source, LIBS=[])
+        result = env.Install(target_path, lib)
+        env.Alias(target='install', source=result)
+
+    env['create_uninstall_target'](env, os.path.join(target_path,env.subst(env['MAPNIK_WKT_LIB_NAME'])))
+else:
+    # Symlink command, only works if both files are in same directory
+    def symlink(env, target, source):
+        trgt = str(target[0])
+        src = str(source[0])
+
+        if os.path.islink(trgt) or os.path.exists(trgt):
+            os.remove(trgt)
+        os.symlink(os.path.basename(src), trgt)
+
+    major, minor, micro = ABI_VERSION
+
+    soFile = "%s.%d.%d.%d" % (os.path.basename(env.subst(env['MAPNIK_WKT_LIB_NAME'])), int(major), int(minor), int(micro))
+    target = os.path.join(env['MAPNIK_LIB_BASE_DEST'], soFile)
+
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        if env['LINKING'] == 'static':
+            lib = lib_env_final.StaticLibrary(name, source, LIBS=[])
+        else:
+            lib = lib_env_final.SharedLibrary(name, source, LIBS=[])
+        result = env.InstallAs(target=target, source=lib)
+        env.Alias(target='install', source=result)
+        if result:
+              env.AddPostAction(result, ldconfig)
+
+    # Install symlinks
+    target1 = os.path.join(env['MAPNIK_LIB_BASE_DEST'], "%s.%d.%d" % \
+        (os.path.basename(env.subst(env['MAPNIK_WKT_LIB_NAME'])),int(major), int(minor)))
+    target2 = os.path.join(env['MAPNIK_LIB_BASE_DEST'], os.path.basename(env.subst(env['MAPNIK_WKT_LIB_NAME'])))
+    if 'uninstall' not in COMMAND_LINE_TARGETS:
+        link1 = env.Command(target1, target, symlink)
+        env.Alias(target='install', source=link1)
+        link2 = env.Command(target2, target1, symlink)
+        env.Alias(target='install', source=link2)
+    # delete in reverse order..
+    env['create_uninstall_target'](env, target2)
+    env['create_uninstall_target'](env, target1)
+    env['create_uninstall_target'](env, target)
+
+    # to enable local testing
+    lib_major_minor = "%s.%d.%d" % (os.path.basename(env.subst(env['MAPNIK_WKT_LIB_NAME'])), int(major), int(minor))
+    local_lib = os.path.basename(env.subst(env['MAPNIK_WKT_LIB_NAME']))
+    if os.path.islink(lib_major_minor) or os.path.exists(lib_major_minor):
+        os.remove(lib_major_minor)
+    os.symlink(local_lib,lib_major_minor)
+    Clean(lib,lib_major_minor);

--- a/test/build.py
+++ b/test/build.py
@@ -11,8 +11,8 @@ if not env['CPP_TESTS']:
         os.unlink(cpp_test_bin)
 else:
     test_env['LIBS'] = [env['MAPNIK_NAME']]
-    test_env.AppendUnique(LIBS='mapnik-wkt')
-    test_env.AppendUnique(LIBS='mapnik-json')
+    test_env.AppendUnique(LIBS=('%s-wkt' % env['MAPNIK_NAME']))
+    test_env.AppendUnique(LIBS=('%s-json' % env['MAPNIK_NAME']))
     test_env.AppendUnique(LIBS=copy(env['LIBMAPNIK_LIBS']))
     if env['RUNTIME_LINK'] == 'static' and env['PLATFORM'] == 'Linux':
         test_env.AppendUnique(LIBS='dl')
@@ -34,8 +34,8 @@ else:
     sources.extend(glob.glob('./unit/*.cpp'))
     test_program = test_env_local.Program("./unit/run", source=sources)
     Depends(test_program, env.subst('../src/%s' % env['MAPNIK_LIB_NAME']))
-    Depends(test_program, env.subst('../src/json/libmapnik-json${LIBSUFFIX}'))
-    Depends(test_program, env.subst('../src/wkt/libmapnik-wkt${LIBSUFFIX}'))
+    Depends(test_program, env.subst('../src/json/%s' % env['MAPNIK_JSON_LIB_NAME']))
+    Depends(test_program, env.subst('../src/wkt/%s' % env['MAPNIK_WKT_LIB_NAME']))
     if 'install' in COMMAND_LINE_TARGETS:
         env.Alias('install',test_program)
 


### PR DESCRIPTION
This is an initial attempt at allowing the `mapnik-json` and `mapnik-wkt` libraries to be built as shared libraries, mostly by copying the way the main library is built.

That does mean that this introduces quite a lot of duplication, which somebody more familiar with scons could likely avoid by factoring out the duplicated code into a common function somewhere that knows how to do all the magic.