### PR TITLE
fix text-minimum-path-length

### DIFF
--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -79,11 +79,10 @@ struct split_multi_geometries
 {
     using container_type = T;
     split_multi_geometries(container_type & cont, view_transform const& t,
-                           proj_transform const& prj_trans, double minimum_path_length)
+                           proj_transform const& prj_trans)
         : cont_(cont),
           t_(t),
-          prj_trans_(prj_trans),
-          minimum_path_length_(minimum_path_length) {}
+          prj_trans_(prj_trans) { }
 
     void operator() (geometry::geometry_empty const&) const {}
     void operator() (geometry::multi_point<double> const& multi_pt) const
@@ -95,18 +94,7 @@ struct split_multi_geometries
     }
     void operator() (geometry::line_string<double> const& line) const
     {
-        if (minimum_path_length_ > 0)
-        {
-            box2d<double> bbox = t_.forward(geometry::envelope(line), prj_trans_);
-            if (bbox.width() >= minimum_path_length_)
-            {
-                cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(line)));
-            }
-        }
-        else
-        {
-            cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(line)));
-        }
+        cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(line)));
     }
 
     void operator() (geometry::multi_line_string<double> const& multi_line) const
@@ -119,18 +107,7 @@ struct split_multi_geometries
 
     void operator() (geometry::polygon<double> const& poly) const
     {
-        if (minimum_path_length_ > 0)
-        {
-            box2d<double> bbox = t_.forward(geometry::envelope(poly), prj_trans_);
-            if (bbox.width() >= minimum_path_length_)
-            {
-                cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(poly)));
-            }
-        }
-        else
-        {
-            cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(poly)));
-        }
+        cont_.push_back(base_symbolizer_helper::geometry_cref(std::cref(poly)));
     }
 
     void operator() (geometry::multi_polygon<double> const& multi_poly) const
@@ -158,7 +135,6 @@ struct split_multi_geometries
     container_type & cont_;
     view_transform const& t_;
     proj_transform const& prj_trans_;
-    double minimum_path_length_;
 };
 
 } // ns detail
@@ -210,7 +186,7 @@ void base_symbolizer_helper::initialize_geometries() const
     double minimum_path_length = text_props_->minimum_path_length;
     auto const& geom = feature_.get_geometry();
     util::apply_visitor(detail::split_multi_geometries<geometry_container_type>
-                        (geometries_to_process_, t_, prj_trans_, minimum_path_length ), geom);
+                        (geometries_to_process_, t_, prj_trans_), geom);
     if (!geometries_to_process_.empty())
     {
         auto type = geometry::geometry_type(geom);


### PR DESCRIPTION
Fixes `minimum-path-length` which is broken from 5a032ee98be4daa3587110acd7a1aa61aaaffa6b, see https://github.com/mapnik/mapnik/commit/5a032ee98be4daa3587110acd7a1aa61aaaffa6b#commitcomment-12196717

Test results:

Before:
![text-minimum-path-length-512-512-1 0-agg-reference](https://cloud.githubusercontent.com/assets/1950911/8799240/f770ff2e-2fa8-11e5-8aae-f913be10d010.png)
After:
![text-minimum-path-length-512-512-1 0-agg-reference](https://cloud.githubusercontent.com/assets/1950911/8799249/ff093bc0-2fa8-11e5-8cba-ae714bdcd176.png)

Before:
![text-minimum-path-length-polygon-512-512-1 0-agg-reference](https://cloud.githubusercontent.com/assets/1950911/8799241/f77ebc2c-2fa8-11e5-9536-315b2886a36b.png)
After:
![text-minimum-path-length-polygon-512-512-1 0-agg-reference](https://cloud.githubusercontent.com/assets/1950911/8799248/ff08fc6e-2fa8-11e5-887e-db876ed60748.png)

