### PR TITLE
Bugfix: dot symbolizer not acknowledging scale factor

### DIFF
--- a/src/agg/process_dot_symbolizer.cpp
+++ b/src/agg/process_dot_symbolizer.cpp
@@ -106,8 +106,8 @@ void agg_renderer<T0,T1>::process(dot_symbolizer const& sym,
     {
         width = height = get<double>(sym, keys::height, feature, common_.vars_, 0.0);
     }
-    double rx = width/2.0;
-    double ry = height/2.0;
+    double rx = width/2.0 * common_.scale_factor_;
+    double ry = height/2.0 * common_.scale_factor_;
     double opacity = get<double>(sym, keys::opacity, feature, common_.vars_, 1.0);
     color const& fill = get<mapnik::color>(sym, keys::fill, feature, common_.vars_, mapnik::color(128,128,128));
     ras_ptr->reset();


### PR DESCRIPTION
**Before (1x/2x)**
![dots-500-100-2 0-agg-reference](https://cloud.githubusercontent.com/assets/118480/9027981/b947acd4-3926-11e5-9c5d-015d9ef6f6e4.png)
![dots-500-100-2 0-agg-reference](https://cloud.githubusercontent.com/assets/118480/9027981/b947acd4-3926-11e5-9c5d-015d9ef6f6e4.png)
**After (1x/2x)**
![dots-500-100-2 0-agg-reference](https://cloud.githubusercontent.com/assets/118480/9027981/b947acd4-3926-11e5-9c5d-015d9ef6f6e4.png)
![dots-500-100-2 0-agg](https://cloud.githubusercontent.com/assets/118480/9027984/bba310ea-3926-11e5-9fc1-bf8278721add.png)