### PR TITLE
Null text collision box

### DIFF
--- a/include/mapnik/text/placement_finder.hpp
+++ b/include/mapnik/text/placement_finder.hpp
@@ -74,7 +74,7 @@ private:
     // Checks for collision.
     bool collision(box2d<double> const& box, const value_unicode_string &repeat_key, bool line_placement) const;
     // Adds marker to glyph_positions and to collision detector. Returns false if there is a collision.
-    bool add_marker(glyph_positions_ptr & glyphs, pixel_position const& pos) const;
+    bool add_marker(glyph_positions_ptr & glyphs, pixel_position const& pos, std::vector<box2d<double>> & bboxes) const;
     // Maps upright==auto, left-only and right-only to left,right to simplify processing.
     // angle = angle of at start of line (to estimate best option for upright==auto)
     text_upright_e simplify_upright(text_upright_e upright, double angle) const;

--- a/src/text/placement_finder.cpp
+++ b/src/text/placement_finder.cpp
@@ -423,10 +423,10 @@ bool placement_finder::add_marker(glyph_positions_ptr & glyphs, pixel_position c
     pixel_position real_pos = (marker_unlocked_ ? pos : glyphs->get_base_point()) + marker_displacement_;
     box2d<double> bbox = marker_box_;
     bbox.move(real_pos.x, real_pos.y);
-    glyphs->set_marker(marker_, real_pos);
     if (collision(bbox, layouts_.text(), false)) return false;
     detector_.insert(bbox);
     bboxes.push_back(std::move(bbox));
+    glyphs->set_marker(marker_, real_pos);
     return true;
 }
 

--- a/src/text/placement_finder.cpp
+++ b/src/text/placement_finder.cpp
@@ -143,7 +143,7 @@ bool placement_finder::find_point_placement(pixel_position const& pos)
         /* For point placements it is faster to just check the bounding box. */
         if (collision(bbox, layouts_.text(), false)) return false;
 
-        if (layout.num_lines()) bboxes.push_back(std::move(bbox));
+        if (layout.glyphs_count()) bboxes.push_back(std::move(bbox));
 
         pixel_position layout_offset = layout_center - glyphs->get_base_point();
         layout_offset.y = -layout_offset.y;
@@ -178,7 +178,7 @@ bool placement_finder::find_point_placement(pixel_position const& pos)
     }
 
     // add_marker first checks for collision and then updates the detector.
-    if (has_marker_ && !add_marker(glyphs, pos)) return false;
+    if (has_marker_ && !add_marker(glyphs, pos, bboxes)) return false;
 
     box2d<double> label_box;
     bool first = true;
@@ -418,7 +418,7 @@ void placement_finder::set_marker(marker_info_ptr m, box2d<double> box, bool mar
 }
 
 
-bool placement_finder::add_marker(glyph_positions_ptr & glyphs, pixel_position const& pos) const
+bool placement_finder::add_marker(glyph_positions_ptr & glyphs, pixel_position const& pos, std::vector<box2d<double>> & bboxes) const
 {
     pixel_position real_pos = (marker_unlocked_ ? pos : glyphs->get_base_point()) + marker_displacement_;
     box2d<double> bbox = marker_box_;
@@ -426,6 +426,7 @@ bool placement_finder::add_marker(glyph_positions_ptr & glyphs, pixel_position c
     glyphs->set_marker(marker_, real_pos);
     if (collision(bbox, layouts_.text(), false)) return false;
     detector_.insert(bbox);
+    bboxes.push_back(std::move(bbox));
     return true;
 }
 


### PR DESCRIPTION
This is rather edge case and minor thing. Null or empty text does not affect rendered map, of course, but in case of `point` placement bbox with zero size is inserted into collision detector. This is not happening with `line` placement.

This patch unify `point` and `line` placement in way no bbox is inserted into collision detector for empty text. By empty text is meant text with zero glyphs.