### PR TITLE
remove incorrect and meaningless comments

### DIFF
--- a/include/mapnik/renderer_common/process_markers_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_markers_symbolizer.hpp
@@ -115,7 +115,7 @@ struct render_marker_symbolizer_visitor
                                             feature_,
                                             common_.vars_,
                                             common_.scale_factor_);
-            if (clip) // optional clip (default: true)
+            if (clip)
             {
                 geometry::geometry_types type = geometry::geometry_type(feature_.get_geometry());
                 if (type == geometry::geometry_types::Polygon || type == geometry::geometry_types::MultiPolygon)
@@ -161,7 +161,7 @@ struct render_marker_symbolizer_visitor
                                             feature_,
                                             common_.vars_,
                                             common_.scale_factor_);
-            if (clip) // optional clip (default: true)
+            if (clip)
             {
                 geometry::geometry_types type = geometry::geometry_type(feature_.get_geometry());
                 if (type == geometry::geometry_types::Polygon || type == geometry::geometry_types::MultiPolygon)
@@ -220,7 +220,7 @@ struct render_marker_symbolizer_visitor
                                         common_.vars_,
                                         common_.scale_factor_);
 
-        if (clip) // optional clip (default: true)
+        if (clip)
         {
             geometry::geometry_types type = geometry::geometry_type(feature_.get_geometry());
             if (type == geometry::geometry_types::Polygon || type == geometry::geometry_types::MultiPolygon)

--- a/include/mapnik/renderer_common/process_polygon_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_polygon_symbolizer.hpp
@@ -54,7 +54,7 @@ void render_polygon_symbolizer(polygon_symbolizer const &sym,
     vertex_converter_type converter(clip_box, sym, common.t_, prj_trans, tr,
                                     feature,common.vars_,common.scale_factor_);
 
-    if (prj_trans.equal() && clip) converter.template set<clip_poly_tag>(); //optional clip (default: true)
+    if (prj_trans.equal() && clip) converter.template set<clip_poly_tag>();
     converter.template set<transform_tag>(); //always transform
     converter.template set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter.template set<simplify_tag>(); // optional simplify converter

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -134,7 +134,7 @@ struct agg_renderer_process_visitor_l
 
         vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
-        if (clip) converter.set<clip_line_tag>(); //optional clip (default: true)
+        if (clip) converter.set<clip_line_tag>();
         converter.set<transform_tag>(); //always transform
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
         if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
@@ -204,7 +204,7 @@ struct agg_renderer_process_visitor_l
 
         vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
-        if (clip) converter.set<clip_line_tag>(); //optional clip (default: true)
+        if (clip) converter.set<clip_line_tag>();
         converter.set<transform_tag>(); //always transform
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
         if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -165,7 +165,7 @@ struct agg_renderer_process_visitor_p
         vertex_converter_type converter(clip_box,sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
 
-        if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
+        if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>();
         converter.set<transform_tag>(); //always transform
         converter.set<affine_transform_tag>(); // optional affine transform
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter
@@ -264,7 +264,7 @@ struct agg_renderer_process_visitor_p
 
         vertex_converter_type converter(clip_box, sym_,common_.t_,prj_trans_,tr,feature_,common_.vars_,common_.scale_factor_);
 
-        if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
+        if (prj_trans_.equal() && clip) converter.set<clip_poly_tag>();
         converter.set<transform_tag>(); //always transform
         converter.set<affine_transform_tag>(); // optional affine transform
         if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -150,7 +150,7 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
 
     vertex_converter_type converter(clipping_extent,sym, common_.t_, prj_trans, tr, feature, common_.vars_, common_.scale_factor_);
 
-    if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
+    if (clip) converter.set<clip_line_tag>();
     converter.set<transform_tag>(); // always transform
     if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
     converter.set<affine_transform_tag>(); // optional affine transform

--- a/src/cairo/process_polygon_pattern_symbolizer.cpp
+++ b/src/cairo/process_polygon_pattern_symbolizer.cpp
@@ -132,7 +132,7 @@ void cairo_renderer<T>::process(polygon_pattern_symbolizer const& sym,
                                                    smooth_tag>;
 
     vertex_converter_type converter(clip_box,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
-    if (prj_trans.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
+    if (prj_trans.equal() && clip) converter.set<clip_poly_tag>();
     converter.set<transform_tag>(); //always transform
     converter.set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -120,7 +120,7 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
                                                    simplify_tag,smooth_tag,
                                                    offset_transform_tag,stroke_tag>;
     vertex_converter_type converter(clipping_extent,line,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
-    if (clip) converter.set<clip_line_tag>(); // optional clip (default: true)
+    if (clip) converter.set<clip_line_tag>();
     converter.set<transform_tag>(); // always transform
     if (std::fabs(offset) > 0.0) converter.set<offset_transform_tag>(); // parallel offset
     converter.set<affine_transform_tag>(); // optional affine transform

--- a/src/grid/process_polygon_pattern_symbolizer.cpp
+++ b/src/grid/process_polygon_pattern_symbolizer.cpp
@@ -79,7 +79,7 @@ void grid_renderer<T>::process(polygon_pattern_symbolizer const& sym,
     using vertex_converter_type = vertex_converter<clip_poly_tag,transform_tag,affine_transform_tag,smooth_tag>;
     vertex_converter_type converter(common_.query_extent_,sym,common_.t_,prj_trans,tr,feature,common_.vars_,common_.scale_factor_);
 
-    if (prj_trans.equal() && clip) converter.set<clip_poly_tag>(); //optional clip (default: true)
+    if (prj_trans.equal() && clip) converter.set<clip_poly_tag>();
     converter.set<transform_tag>(); //always transform
     converter.set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter.set<simplify_tag>(); // optional simplify converter

--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -288,7 +288,7 @@ text_symbolizer_helper::text_symbolizer_helper(
     value_double simplify_tolerance = mapnik::get<value_double, keys::simplify_tolerance>(sym_, feature_, vars_);
     value_double smooth = mapnik::get<value_double, keys::smooth>(sym_, feature_, vars_);
 
-    if (clip) converter_.template set<clip_line_tag>(); //optional clip (default: true)
+    if (clip) converter_.template set<clip_line_tag>();
     converter_.template set<transform_tag>(); //always transform
     converter_.template set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter_.template set<simplify_tag>(); // optional simplify converter
@@ -413,7 +413,7 @@ text_symbolizer_helper::text_symbolizer_helper(
     value_double simplify_tolerance = mapnik::get<value_double, keys::simplify_tolerance>(sym_, feature_, vars_);
     value_double smooth = mapnik::get<value_double, keys::smooth>(sym_, feature_, vars_);
 
-    if (clip) converter_.template set<clip_line_tag>(); //optional clip (default: true)
+    if (clip) converter_.template set<clip_line_tag>();
     converter_.template set<transform_tag>(); //always transform
     converter_.template set<affine_transform_tag>();
     if (simplify_tolerance > 0.0) converter_.template set<simplify_tag>(); // optional simplify converter


### PR DESCRIPTION
Removes `// optional clip (default: true)` as it is incorrect (default is false) and meaningless (everyone can see the `if` statement).