### PR TITLE
colorize-alpha: fix normalization of color components

### DIFF
--- a/include/mapnik/image_filter.hpp
+++ b/include/mapnik/image_filter.hpp
@@ -528,10 +528,10 @@ void apply_filter(Src & src, colorize_alpha const& op)
             {
                 stop_offset = offset;
             }
-            grad_lut.add_color(stop_offset, agg::rgba(c.red()/256.0,
-                                                      c.green()/256.0,
-                                                      c.blue()/256.0,
-                                                      c.alpha()/256.0));
+            grad_lut.add_color(stop_offset, agg::rgba(c.red()/255.0,
+                                                      c.green()/255.0,
+                                                      c.blue()/255.0,
+                                                      c.alpha()/255.0));
             offset += step;
         }
         if (grad_lut.build_lut())

--- a/test/unit/imaging/image_filter.cpp
+++ b/test/unit/imaging/image_filter.cpp
@@ -310,15 +310,15 @@ SECTION("test colorize-alpha - two color") {
 
     mapnik::filter::filter_image(im, "colorize-alpha(green,blue)");
 
-    CHECK(im(0,0) == 0xfffc0000);
-    CHECK(im(0,1) == 0xfffc0000);
-    CHECK(im(0,2) == 0xfffc0000);
-    CHECK(im(1,0) == 0xfffc0000);
-    CHECK(im(1,1) == 0xfffc0000);
-    CHECK(im(1,2) == 0xfffc0000);
-    CHECK(im(2,0) == 0xfffc0000);
-    CHECK(im(2,1) == 0xfffc0000);
-    CHECK(im(2,2) == 0xfffc0000);
+    CHECK(im(0,0) == 0xfffd0000);
+    CHECK(im(0,1) == 0xfffd0000);
+    CHECK(im(0,2) == 0xfffd0000);
+    CHECK(im(1,0) == 0xfffd0000);
+    CHECK(im(1,1) == 0xfffd0000);
+    CHECK(im(1,2) == 0xfffd0000);
+    CHECK(im(2,0) == 0xfffd0000);
+    CHECK(im(2,1) == 0xfffd0000);
+    CHECK(im(2,2) == 0xfffd0000);
     
 } // END SECTION
 


### PR DESCRIPTION
Normalization like `c.red()/256.0` is incorrect, because max value of `c.red()` is 255. Therefore max value of normalized red is `255 / 256` which is less than full red.