### PR TITLE
colorize-alpha: remove needless conditions

### DIFF
--- a/include/mapnik/image_filter.hpp
+++ b/include/mapnik/image_filter.hpp
@@ -552,9 +552,6 @@ void apply_filter(Src & src, colorize_alpha const& op)
                         r = (c.r * a + 255) >> 8;
                         g = (c.g * a + 255) >> 8;
                         b = (c.b * a + 255) >> 8;
-                        if (r>a) r=a;
-                        if (g>a) g=a;
-                        if (b>a) b=a;
         #if 0
                         // rainbow
                         r = 0;


### PR DESCRIPTION
These conditions never evaluate to true. Here is brute force Python proof :-)

```
>>> True in [(((x[0] * x[1] + 255) >> 8) > x[0]) for x in [(r,a) for r in range(256) for a in range(256)]]
False
```