### PR TITLE
colorize-alpha: add support for transparent colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Released: YYYY XX, 2015
 - `scale-hsla` image filter: parameters are no longer limited by interval \[0, 1\] (https://github.com/mapnik/mapnik/pull/3054)
 - Windows: Fixed SVG file loading from unicode paths
 - `colorize-alpha` image filter: fixed normalization of color components (https://github.com/mapnik/mapnik/pull/3058)
+- `colorize-alpha` image filter: added support for transparent colors (https://github.com/mapnik/mapnik/pull/3061)
 
 ## 3.0.4
 

--- a/include/mapnik/image_filter.hpp
+++ b/include/mapnik/image_filter.hpp
@@ -505,6 +505,7 @@ void apply_filter(Src & src, colorize_alpha const& op)
                 uint8_t & a = get_color(src_it[x], alpha_t());
                 if ( a > 0)
                 {
+                    a = (c.alpha() * a + 255) >> 8;
                     r = (c.red() * a + 255) >> 8;
                     g = (c.green() * a + 255) >> 8;
                     b = (c.blue() * a + 255) >> 8;
@@ -549,6 +550,7 @@ void apply_filter(Src & src, colorize_alpha const& op)
                     if ( a > 0)
                     {
                         agg::rgba8 c = grad_lut[a];
+                        a = (c.a * a + 255) >> 8;
                         r = (c.r * a + 255) >> 8;
                         g = (c.g * a + 255) >> 8;
                         b = (c.b * a + 255) >> 8;

--- a/test/unit/imaging/image_filter.cpp
+++ b/test/unit/imaging/image_filter.cpp
@@ -348,6 +348,46 @@ SECTION("test colorize-alpha - two color") {
     
 } // END SECTION
 
+SECTION("test colorize-alpha - one color with transparency") {
+
+    mapnik::image_rgba8 im(3,3);
+    mapnik::fill(im,mapnik::color("#0000ffaa"));
+    mapnik::set_pixel(im, 1, 1, mapnik::color("#aaaaaaaa"));
+
+    mapnik::filter::filter_image(im, "colorize-alpha(#0000ff99)");
+
+    CHECK(im(0,0) == 0x66660000);
+    CHECK(im(0,1) == 0x66660000);
+    CHECK(im(0,2) == 0x66660000);
+    CHECK(im(1,0) == 0x66660000);
+    CHECK(im(1,1) == 0x66660000);
+    CHECK(im(1,2) == 0x66660000);
+    CHECK(im(2,0) == 0x66660000);
+    CHECK(im(2,1) == 0x66660000);
+    CHECK(im(2,2) == 0x66660000);
+
+} // END SECTION
+
+SECTION("test colorize-alpha - two color with transparency") {
+
+    mapnik::image_rgba8 im(3,3);
+    mapnik::fill(im,mapnik::color("#0000ffaa"));
+    mapnik::set_pixel(im, 1, 1, mapnik::color("#aaaaaaaa"));
+
+    mapnik::filter::filter_image(im, "colorize-alpha(#0000ff00,#00ff00ff)");
+
+    CHECK(im(0,0) == 0x70264a00);
+    CHECK(im(0,1) == 0x70264a00);
+    CHECK(im(0,2) == 0x70264a00);
+    CHECK(im(1,0) == 0x70264a00);
+    CHECK(im(1,1) == 0x70264a00);
+    CHECK(im(1,2) == 0x70264a00);
+    CHECK(im(2,0) == 0x70264a00);
+    CHECK(im(2,1) == 0x70264a00);
+    CHECK(im(2,2) == 0x70264a00);
+
+} // END SECTION
+
 SECTION("test color-blind-protanope") {
     
     mapnik::image_rgba8 im(2,2);


### PR DESCRIPTION
Addresses https://github.com/mapnik/mapnik/issues/3053.