### PR TITLE
Windows: fix loading of SVG files from unicode paths. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Released: YYYY XX, 2015
 
 #### Summary
 
-- `scale-hsla` image filter: parameters are no longer limited by interval [0, 1] (https://github.com/mapnik/mapnik/pull/3054)
+- `scale-hsla` image filter: parameters are no longer limited by interval [0, 1](https://github.com/mapnik/mapnik/pull/3054)
+- Windows: Fixed SVG file loading from unicode paths
 
 ## 3.0.4
 

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -28,6 +28,7 @@
 #include <mapnik/safe_cast.hpp>
 #include <mapnik/svg/svg_parser_exception.hpp>
 #include <mapnik/util/file_io.hpp>
+#include <mapnik/util/utf_conv_win.hpp>
 #include "agg_ellipse.h"
 #include "agg_rounded_rect.h"
 #include "agg_span_gradient.h"
@@ -974,7 +975,11 @@ svg_parser::~svg_parser() {}
 
 bool svg_parser::parse(std::string const& filename)
 {
+#ifdef _WINDOWS
+    std::basic_ifstream<char> stream(mapnik::utf8_to_utf16(filename));
+#else
     std::basic_ifstream<char> stream(filename.c_str());
+#endif
     if (!stream)
     {
         std::stringstream ss;


### PR DESCRIPTION
Surfaced in `node-mapnik` tests:
 https://github.com/mapnik/node-mapnik/issues/517

![image](https://cloud.githubusercontent.com/assets/4549888/9786862/e1bcdbe0-57ac-11e5-894f-477efc423732.png)
