### PR TITLE
visual tests: command line switches for renderers, scale-factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Released: YYYY XX, 2015
 #### Summary
 
 - Visual tests: new command line arguments `--agg`, `--cairo`, `--svg`, `--grid` for selecting renderers (https://github.com/mapnik/mapnik/pull/3074)
+- Visual tests: new command line argument `--scale-factor` or abbreviated `-s` for setting scale factor (https://github.com/mapnik/mapnik/pull/3074)
 
 ## 3.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Released: YYYY XX, 2015
 
 (Packaged from xxxx)
 
+#### Summary
+
+- Visual tests: new command line arguments `--agg`, `--cairo`, `--svg`, `--grid` for selecting renderers (https://github.com/mapnik/mapnik/pull/3074)
+
 ## 3.0.5
 
 Released: September 16, 2015

--- a/test/visual/renderer.hpp
+++ b/test/visual/renderer.hpp
@@ -33,6 +33,7 @@
 #include <mapnik/map.hpp>
 #include <mapnik/image_util.hpp>
 #include <mapnik/image_reader.hpp>
+#include <mapnik/util/variant.hpp>
 #include <mapnik/agg_renderer.hpp>
 #if defined(GRID_RENDERER)
 #include <mapnik/grid/grid_renderer.hpp>
@@ -326,10 +327,22 @@ private:
     }
 
     const Renderer ren;
-    boost::filesystem::path const & output_dir;
-    boost::filesystem::path const & reference_dir;
+    const boost::filesystem::path output_dir;
+    const boost::filesystem::path reference_dir;
     const bool overwrite;
 };
+
+using renderer_type = mapnik::util::variant<renderer<agg_renderer>
+#if defined(HAVE_CAIRO)
+                                            ,renderer<cairo_renderer>
+#endif
+#if defined(SVG_RENDERER)
+                                            ,renderer<svg_renderer>
+#endif
+#if defined(GRID_RENDERER)
+                                            ,renderer<grid_renderer>
+#endif
+                                            >;
 
 }
 

--- a/test/visual/run.cpp
+++ b/test/visual/run.cpp
@@ -43,11 +43,50 @@ log_levels_map log_levels
 };
 #endif
 
+using namespace visual_tests;
+namespace po = boost::program_options;
+
+runner::renderer_container create_renderers(po::variables_map const & args,
+                                            boost::filesystem::path const & output_dir,
+                                            bool append_all = false)
+{
+    boost::filesystem::path reference_dir(args["images-dir"].as<std::string>());
+    bool overwrite = args.count("overwrite");
+    runner::renderer_container renderers;
+
+    if (append_all || args.count(agg_renderer::name))
+    {
+        renderers.emplace_back(renderer<agg_renderer>(output_dir, reference_dir, overwrite));
+    }
+#if defined(HAVE_CAIRO)
+    if (append_all || args.count(cairo_renderer::name))
+    {
+        renderers.emplace_back(renderer<cairo_renderer>(output_dir, reference_dir, overwrite));
+    }
+#endif
+#if defined(SVG_RENDERER)
+    if (append_all || args.count(svg_renderer::name))
+    {
+        renderers.emplace_back(renderer<svg_renderer>(output_dir, reference_dir, overwrite));
+    }
+#endif
+#if defined(GRID_RENDERER)
+    if (append_all || args.count(grid_renderer::name))
+    {
+        renderers.emplace_back(renderer<grid_renderer>(output_dir, reference_dir, overwrite));
+    }
+#endif
+
+    if (renderers.empty())
+    {
+        return create_renderers(args, output_dir, true);
+    }
+
+    return renderers;
+}
+
 int main(int argc, char** argv)
 {
-    using namespace visual_tests;
-    namespace po = boost::program_options;
-
     po::options_description desc("visual test runner");
     desc.add_options()
         ("help,h", "produce usage message")
@@ -68,6 +107,16 @@ int main(int argc, char** argv)
         ("log", po::value<std::string>()->default_value(std::find_if(log_levels.begin(), log_levels.end(),
              [](log_levels_map::value_type const & level) { return level.second == mapnik::logger::get_severity(); } )->first),
              "log level (debug, warn, error, none)")
+#endif
+        (agg_renderer::name, "render with AGG renderer")
+#if defined(HAVE_CAIRO)
+        (cairo_renderer::name, "render with Cairo renderer")
+#endif
+#if defined(SVG_RENDERER)
+        (svg_renderer::name, "render with SVG renderer")
+#endif
+#if defined(GRID_RENDERER)
+        (grid_renderer::name, "render with Grid renderer")
 #endif
         ;
 
@@ -108,12 +157,10 @@ int main(int argc, char** argv)
     }
 
     runner run(vm["styles-dir"].as<std::string>(),
-               output_dir,
-               vm["images-dir"].as<std::string>(),
-               vm.count("overwrite"),
                vm["iterations"].as<std::size_t>(),
                vm["limit"].as<std::size_t>(),
-               vm["jobs"].as<std::size_t>());
+               vm["jobs"].as<std::size_t>(),
+               create_renderers(vm, output_dir));
     bool show_duration = vm.count("duration");
     report_type report(vm.count("verbose") ? report_type((console_report(show_duration))) : report_type((console_short_report(show_duration))));
     result_list results;

--- a/test/visual/run.cpp
+++ b/test/visual/run.cpp
@@ -108,6 +108,7 @@ int main(int argc, char** argv)
              [](log_levels_map::value_type const & level) { return level.second == mapnik::logger::get_severity(); } )->first),
              "log level (debug, warn, error, none)")
 #endif
+        ("scale-factor,s", po::value<std::vector<double>>()->default_value({ 1.0, 2.0 }, "1.0, 2.0"), "scale factor")
         (agg_renderer::name, "render with AGG renderer")
 #if defined(HAVE_CAIRO)
         (cairo_renderer::name, "render with Cairo renderer")
@@ -156,7 +157,11 @@ int main(int argc, char** argv)
         output_dir /= boost::filesystem::unique_path();
     }
 
+    config defaults;
+    defaults.scales = vm["scale-factor"].as<std::vector<double>>();
+
     runner run(vm["styles-dir"].as<std::string>(),
+               defaults,
                vm["iterations"].as<std::size_t>(),
                vm["limit"].as<std::size_t>(),
                vm["jobs"].as<std::size_t>(),

--- a/test/visual/runner.cpp
+++ b/test/visual/runner.cpp
@@ -126,11 +126,13 @@ private:
 };
 
 runner::runner(runner::path_type const & styles_dir,
+               config const & defaults,
                std::size_t iterations,
                std::size_t fail_limit,
                std::size_t jobs,
                runner::renderer_container const & renderers)
     : styles_dir_(styles_dir),
+      defaults_(defaults),
       jobs_(jobs),
       iterations_(iterations),
       fail_limit_(fail_limit),
@@ -211,7 +213,6 @@ result_list runner::test_range(files_iterator begin,
                                std::reference_wrapper<report_type> report,
                                std::reference_wrapper<std::atomic<std::size_t>> fail_count) const
 {
-    config defaults;
     result_list results;
 
     for (runner::files_iterator i = begin; i != end; i++)
@@ -221,7 +222,7 @@ result_list runner::test_range(files_iterator begin,
         {
             try
             {
-                result_list r = test_one(file, defaults, report, fail_count.get());
+                result_list r = test_one(file, report, fail_count.get());
                 std::move(r.begin(), r.end(), std::back_inserter(results));
             }
             catch (std::exception const& ex)
@@ -246,10 +247,10 @@ result_list runner::test_range(files_iterator begin,
 }
 
 result_list runner::test_one(runner::path_type const& style_path,
-                             config cfg,
                              report_type & report,
                              std::atomic<std::size_t> & fail_count) const
 {
+    config cfg(defaults_);
     mapnik::Map map(cfg.sizes.front().width, cfg.sizes.front().height);
     result_list results;
 

--- a/test/visual/runner.cpp
+++ b/test/visual/runner.cpp
@@ -126,29 +126,15 @@ private:
 };
 
 runner::runner(runner::path_type const & styles_dir,
-               runner::path_type const & output_dir,
-               runner::path_type const & reference_dir,
-               bool overwrite,
                std::size_t iterations,
                std::size_t fail_limit,
-               std::size_t jobs)
+               std::size_t jobs,
+               runner::renderer_container const & renderers)
     : styles_dir_(styles_dir),
-      output_dir_(output_dir),
-      reference_dir_(reference_dir),
       jobs_(jobs),
       iterations_(iterations),
       fail_limit_(fail_limit),
-      renderers_{ renderer<agg_renderer>(output_dir_, reference_dir_, overwrite)
-#if defined(HAVE_CAIRO)
-                  ,renderer<cairo_renderer>(output_dir_, reference_dir_, overwrite)
-#endif
-#if defined(SVG_RENDERER)
-                  ,renderer<svg_renderer>(output_dir_, reference_dir_, overwrite)
-#endif
-#if defined(GRID_RENDERER)
-                  ,renderer<grid_renderer>(output_dir_, reference_dir_, overwrite)
-#endif
-                }
+      renderers_(renderers)
 {
 }
 

--- a/test/visual/runner.hpp
+++ b/test/visual/runner.hpp
@@ -40,6 +40,7 @@ public:
     using renderer_container = std::vector<renderer_type>;
 
     runner(path_type const & styles_dir,
+           config const & cfg,
            std::size_t iterations,
            std::size_t fail_limit,
            std::size_t jobs,
@@ -55,12 +56,13 @@ private:
                            std::reference_wrapper<report_type> report,
                            std::reference_wrapper<std::atomic<std::size_t>> fail_limit) const;
     result_list test_one(path_type const & style_path,
-                         config cfg, report_type & report,
+                         report_type & report,
                          std::atomic<std::size_t> & fail_limit) const;
     void parse_map_sizes(std::string const & str, std::vector<map_size> & sizes) const;
 
     const map_sizes_grammar<std::string::const_iterator> map_sizes_parser_;
     const path_type styles_dir_;
+    const config defaults_;
     const std::size_t jobs_;
     const std::size_t iterations_;
     const std::size_t fail_limit_;

--- a/test/visual/runner.hpp
+++ b/test/visual/runner.hpp
@@ -23,8 +23,6 @@
 #ifndef VISUAL_TEST_RUNNER_HPP
 #define VISUAL_TEST_RUNNER_HPP
 
-#include <mapnik/util/variant.hpp>
-
 #include "config.hpp"
 #include "report.hpp"
 #include "renderer.hpp"
@@ -35,28 +33,17 @@ namespace visual_tests
 
 class runner
 {
-    using renderer_type = mapnik::util::variant<renderer<agg_renderer>
-#if defined(HAVE_CAIRO)
-                                                ,renderer<cairo_renderer>
-#endif
-#if defined(SVG_RENDERER)
-                                                ,renderer<svg_renderer>
-#endif
-#if defined(GRID_RENDERER)
-                                                ,renderer<grid_renderer>
-#endif
-                                                >;
     using path_type = boost::filesystem::path;
     using files_iterator = std::vector<path_type>::const_iterator;
 
 public:
+    using renderer_container = std::vector<renderer_type>;
+
     runner(path_type const & styles_dir,
-           path_type const & output_dir,
-           path_type const & reference_dir,
-           bool overwrite,
            std::size_t iterations,
            std::size_t fail_limit,
-           std::size_t jobs);
+           std::size_t jobs,
+           renderer_container const & renderers);
 
     result_list test_all(report_type & report) const;
     result_list test(std::vector<std::string> const & style_names, report_type & report) const;
@@ -74,12 +61,10 @@ private:
 
     const map_sizes_grammar<std::string::const_iterator> map_sizes_parser_;
     const path_type styles_dir_;
-    const path_type output_dir_;
-    const path_type reference_dir_;
     const std::size_t jobs_;
     const std::size_t iterations_;
     const std::size_t fail_limit_;
-    const renderer_type renderers_[boost::mpl::size<renderer_type::types>::value];
+    const renderer_container renderers_;
 };
 
 }


### PR DESCRIPTION
It's useful for profiling and debugging to run tests with particular renderer and scale factor. I have added these new command line arguments:
* `--agg`, `--cairo`, `--svg`, `--grid` for selecting renderers 
* `--scale-factor` or abbreviated `-s` for setting scale factors

Example with test `polygon-interior-1`, AGG renderer and scale factor 1.0: 
```
 $ test/visual/run -s 1 --agg polygon-interior-1 -v
"polygon-interior-1-800-800-1.0" with agg... OK

Visual rendering: 0 failed / 1 passed / 0 overwritten / 0 errors
```

Example running all tests with AGG and Cairo renderers with scale factors 2.0, 3.0:
```
 $ test/visual/run --agg --cairo -s 2 -s 3                                                                                                           [8:24:33]
..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓✘✘✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓✘✘✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓..✓✓
Visual rendering: 4 failed / 642 passed / 646 overwritten / 0 errors
View failure report at "/tmp/mapnik-visual-images/visual-test-results/index.html"
```

