### PR TITLE
fix parsing colors in hexadecimal notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released: YYYY XX, 2015
 
 - Visual tests: new command line arguments `--agg`, `--cairo`, `--svg`, `--grid` for selecting renderers (https://github.com/mapnik/mapnik/pull/3074)
 - Visual tests: new command line argument `--scale-factor` or abbreviated `-s` for setting scale factor (https://github.com/mapnik/mapnik/pull/3074)
+- Fixed parsing colors in hexadecimal notation (https://github.com/mapnik/mapnik/pull/3075)
 
 ## 3.0.5
 

--- a/include/mapnik/css_color_grammar.hpp
+++ b/include/mapnik/css_color_grammar.hpp
@@ -37,6 +37,7 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_action.hpp>
+#include <boost/spirit/include/qi_lexeme.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_fusion.hpp>

--- a/include/mapnik/css_color_grammar_impl.hpp
+++ b/include/mapnik/css_color_grammar_impl.hpp
@@ -39,6 +39,7 @@ css_color_grammar<Iterator>::css_color_grammar()
     qi::_a_type _a;
     qi::_b_type _b;
     qi::_c_type _c;
+    qi::lexeme_type lexeme;
     ascii::no_case_type no_case;
     using phoenix::at_c;
 
@@ -49,18 +50,18 @@ css_color_grammar<Iterator>::css_color_grammar()
         | hex_color_small
         | no_case[named];
 
-    hex_color = lit('#')
+    hex_color = lexeme[ lit('#')
         >> hex2 [ at_c<0>(_val) = _1 ]
         >> hex2 [ at_c<1>(_val) = _1 ]
         >> hex2 [ at_c<2>(_val) = _1 ]
-        >>-hex2 [ at_c<3>(_val) = _1 ]
+        >>-hex2 [ at_c<3>(_val) = _1 ] ]
         ;
 
-    hex_color_small = lit('#')
+    hex_color_small = lexeme[ lit('#')
         >> hex1 [ at_c<0>(_val) = _1 | _1 << 4 ]
         >> hex1 [ at_c<1>(_val) = _1 | _1 << 4 ]
         >> hex1 [ at_c<2>(_val) = _1 | _1 << 4 ]
-        >>-hex1 [ at_c<3>(_val) = _1 | _1 << 4 ]
+        >>-hex1 [ at_c<3>(_val) = _1 | _1 << 4 ] ]
         ;
 
     rgba_color = lit("rgb") >> -lit('a')

--- a/test/unit/color/css_color.cpp
+++ b/test/unit/color/css_color.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include <mapnik/css_color_grammar.hpp>
+#include <mapnik/css_color_grammar_impl.hpp>
 #include <mapnik/safe_cast.hpp>
 
 TEST_CASE("css color") {
@@ -34,5 +35,133 @@ TEST_CASE("css color") {
         CHECK( c.red() == 0 );
         CHECK( c.green() == 0 );
         CHECK( c.blue() == 0 );
+    }
+
+    SECTION("hex colors")
+    {
+        mapnik::css_color_grammar<std::string::const_iterator> color_grammar;
+        boost::spirit::qi::ascii::space_type space;
+
+        {
+            std::string s("#abcdef");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xff );
+            CHECK( c.red() == 0xab );
+            CHECK( c.green() == 0xcd );
+            CHECK( c.blue() == 0xef );
+        }
+
+        {
+            std::string s("#abcdef12");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0x12 );
+            CHECK( c.red() == 0xab );
+            CHECK( c.green() == 0xcd );
+            CHECK( c.blue() == 0xef );
+        }
+
+        {
+            std::string s("  #abcdef");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xff );
+            CHECK( c.red() == 0xab );
+            CHECK( c.green() == 0xcd );
+            CHECK( c.blue() == 0xef );
+        }
+
+        {
+            std::string s("   #abcdef12");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0x12 );
+            CHECK( c.red() == 0xab );
+            CHECK( c.green() == 0xcd );
+            CHECK( c.blue() == 0xef );
+        }
+
+        {
+            std::string s("# abcdef");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("# abcdef12");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("#ab cdef");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("#ab cdef12");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        // hex_color_small
+
+        {
+            std::string s("#abc");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xff );
+            CHECK( c.red() == 0xaa );
+            CHECK( c.green() == 0xbb );
+            CHECK( c.blue() == 0xcc );
+        }
+
+        {
+            std::string s("#abcd");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xdd );
+            CHECK( c.red() == 0xaa );
+            CHECK( c.green() == 0xbb );
+            CHECK( c.blue() == 0xcc );
+        }
+
+        {
+            std::string s("   #abc");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xff );
+            CHECK( c.red() == 0xaa );
+            CHECK( c.green() == 0xbb );
+            CHECK( c.blue() == 0xcc );
+        }
+
+        {
+            std::string s("   #abcd");
+            mapnik::color c;
+            CHECK( boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space, c) );
+            CHECK( c.alpha() == 0xdd );
+            CHECK( c.red() == 0xaa );
+            CHECK( c.green() == 0xbb );
+            CHECK( c.blue() == 0xcc );
+        }
+
+        {
+            std::string s("# abc");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("# abcd");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("#a bc");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
+
+        {
+            std::string s("#a bcd");
+            CHECK( !boost::spirit::qi::phrase_parse(s.cbegin(), s.cend(), color_grammar, space) );
+        }
     }
 }


### PR DESCRIPTION
Hexadecimal colors needs to be considered a parsing primitives. 

If hexa colors are not primitives, `#000000 100%` is parsed as `#00000010` and `0%` in this example:

```
image-filters="colorize-alpha(#000000 0%, #000000 100%)"
```

