### PR TITLE
Add viewbox fallback logic for dimension parsing

### DIFF
--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -164,12 +164,14 @@ bool parse_double_list(T & error_messages, const char* str, double* list)
     using boost::phoenix::ref;
     qi::_1_type _1;
     qi::double_type double_;
-    qi::char_type char_;
+    qi::lit_type lit;
+    using skip_type = boost::spirit::ascii::space_type;
 
-    if (!parse(str, str + std::strlen(str), double_[ref(list[0])=_1] >> (char_(' ') | char_(','))
-                >> double_[ref(list[1])=_1] >> (char_(' ') | char_(','))
-                >> double_[ref(list[2])=_1] >> (char_(' ') | char_(','))
-                >> double_[ref(list[3])=_1]))
+    if (!phrase_parse(str, str + std::strlen(str),
+                      double_[ref(list[0])=_1] >> -lit(',') >>
+                      double_[ref(list[1])=_1] >> -lit(',') >>
+                      double_[ref(list[2])=_1] >> -lit(',') >>
+                      double_[ref(list[3])=_1], skip_type()))
     {
         error_messages.emplace_back("failed to parse list of doubles from " + std::string(str));
         return false;
@@ -522,7 +524,7 @@ void parse_dimensions(svg_parser & parser, rapidxml::xml_node<char> const* node)
         width = viewbox[2];
         height = viewbox[3];
     }
-    
+
     parser.path_.set_dimensions(width, height);
 }
 

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -166,9 +166,9 @@ bool parse_double_list(T & error_messages, const char* str, double* list)
     qi::double_type double_;
     qi::char_type char_;
 
-    if (!parse(str, str + std::strlen(str), double_[ref(list[0])=_1] >> char_(' ') | char_(',')
-                >> double_[ref(list[1])=_1] >> char_(' ') | char_(',')
-                >> double_[ref(list[2])=_1] >> char_(' ') | char_(',')
+    if (!parse(str, str + std::strlen(str), double_[ref(list[0])=_1] >> (char_(' ') | char_(','))
+                >> double_[ref(list[1])=_1] >> (char_(' ') | char_(','))
+                >> double_[ref(list[2])=_1] >> (char_(' ') | char_(','))
                 >> double_[ref(list[3])=_1]))
     {
         error_messages.emplace_back("failed to parse list of doubles from " + std::string(str));
@@ -506,13 +506,6 @@ void parse_dimensions(svg_parser & parser, rapidxml::xml_node<char> const* node)
     {
         has_viewbox = parse_double_list(parser.error_messages_, viewbox_attr->value(), viewbox);
     }
-
-    std::cout << "Width = " << width << std::endl;
-    std::cout << "Width has percent = " << has_percent_width << std::endl;
-    std::cout << "Height has percent = " << has_percent_height << std::endl;
-    std::cout << "Viewbox = " << viewbox[0] << "," << viewbox[1] << "," << viewbox[2] << "," << viewbox[3] << std::endl;
-    std::cout << "Viewbox exists = " << has_viewbox << std::endl;
-
 
     if (has_percent_width && !has_percent_height && has_viewbox)
     {

--- a/test/unit/svg/svg_parser_test.cpp
+++ b/test/unit/svg/svg_parser_test.cpp
@@ -333,6 +333,26 @@ TEST_CASE("SVG parser") {
         REQUIRE(std::equal(expected.begin(),expected.end(), vec.begin(),detail::vertex_equal<3>()));
     }
 
+    SECTION("SVG viewbox fallback")
+    {
+        std::string svg_name("./test/data/svg/viewbox-missing-width-and-height.svg");
+        std::ifstream in(svg_name.c_str());
+        std::string svg_str((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+
+        using namespace mapnik::svg;
+        mapnik::svg_storage_type path;
+        vertex_stl_adapter<svg_path_storage> stl_storage(path.source());
+        svg_path_adapter svg_path(stl_storage);
+        svg_converter_type svg(svg_path, path.attributes());
+        svg_parser p(svg);
+        p.parse_from_string(svg_str);
+        auto width = svg.width();
+        auto height = svg.height();
+        REQUIRE(width == 100);
+        REQUIRE(height == 100);
+    }
+
     SECTION("SVG rounded <rect>s missing rx or ry")
     {
         std::string svg_name("./test/data/svg/rounded_rect-missing-one-radius.svg");


### PR DESCRIPTION
SVG's now have fallback on viewbox. Still debugging the boost Qi parser. refs #3077 cc/ @artemp @flippmoke 