### PR TITLE
remove Feature alias of feature_impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Released: YYYY XX, 2015
 - Visual tests: new command line arguments `--agg`, `--cairo`, `--svg`, `--grid` for selecting renderers (https://github.com/mapnik/mapnik/pull/3074)
 - Visual tests: new command line argument `--scale-factor` or abbreviated `-s` for setting scale factor (https://github.com/mapnik/mapnik/pull/3074)
 - Fixed parsing colors in hexadecimal notation (https://github.com/mapnik/mapnik/pull/3075)
+- Removed mapnik::Feature type alias of mapnik::feature_impl (https://github.com/mapnik/mapnik/pull/3099)
 
 ## 3.0.5
 

--- a/include/mapnik/feature.hpp
+++ b/include/mapnik/feature.hpp
@@ -273,9 +273,6 @@ inline std::ostream& operator<< (std::ostream & out,feature_impl const& f)
     return out;
 }
 
-// TODO - remove at Mapnik 3.x
-using Feature = feature_impl;
-
 using feature_ptr = std::shared_ptr<feature_impl>;
 
 }

--- a/include/mapnik/renderer_common/process_group_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_group_symbolizer.hpp
@@ -329,7 +329,7 @@ void render_group_symbolizer(group_symbolizer const& sym,
         // get the layout for this set of properties
         for (auto const& rule : props->get_rules())
         {
-             if (util::apply_visitor(evaluate<Feature,value_type,attributes>(*sub_feature,common.vars_),
+             if (util::apply_visitor(evaluate<feature_impl,value_type,attributes>(*sub_feature,common.vars_),
                                                *(rule->get_filter())).to_bool())
              {
                 // add matched rule and feature to the list of things to draw
@@ -380,7 +380,7 @@ void render_group_symbolizer(group_symbolizer const& sym,
         // evaluate the repeat key with the matched sub feature if we have one
         if (rpt_key_expr)
         {
-            rpt_key_value = util::apply_visitor(evaluate<Feature,value_type,attributes>(*match_feature,common.vars_),
+            rpt_key_value = util::apply_visitor(evaluate<feature_impl,value_type,attributes>(*match_feature,common.vars_),
                                                 *rpt_key_expr).to_unicode();
         }
         helper.add_box_element(layout_manager.offset_box_at(i), rpt_key_value);

--- a/utils/pgsql2sqlite/pgsql2sqlite.hpp
+++ b/utils/pgsql2sqlite/pgsql2sqlite.hpp
@@ -388,7 +388,7 @@ void pgsql2sqlite(Connection conn,
                 {
                     if (oid == geometry_oid)
                     {
-                        mapnik::Feature feat(ctx,pkid);
+                        mapnik::feature_impl feat(ctx,pkid);
                         mapnik::geometry::geometry<double> geom = geometry_utils::from_wkb(buf, size, wkbGeneric);
                         if (!mapnik::geometry::is_empty(geom))
                         {


### PR DESCRIPTION
I was just passing by the `// TODO - remove at Mapnik 3.x` comment so I removed it as @springmeyer proposed in https://github.com/mapnik/mapnik/commit/5a6ea9ee6f297d64e0f699f362de25f7e3b2743f.

But it's still used in node-mapnik [here](https://github.com/mapnik/node-mapnik/blob/40fb7a7cc717bc45ea3dece7523e1743b12e14c4/src/mapnik_expression.cpp#L115) and probably also somewhere else, so I'm not sure whether it is a good idea.

