### PR TITLE
fix build on linux

### DIFF
--- a/include/mapnik/quad_tree.hpp
+++ b/include/mapnik/quad_tree.hpp
@@ -32,6 +32,8 @@
 #include <vector>
 #include <type_traits>
 
+#include <cstring>
+
 namespace mapnik
 {
 template <typename T>


### PR DESCRIPTION
Fixes build on Linux after https://github.com/mapnik/mapnik/commit/2f35c71606068562f3e28cb58ba82a63a790a9cb

`std::memset` needs `<cstring>` to be included.

The problem can be also seen in Travis: https://travis-ci.org/mapnik/mapnik/jobs/83123000