### PR TITLE
Add section for Python Bindings

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ Additional optional dependencies:
     - pg_config - PostgreSQL installation capabilities
  * libgdal - GDAL/OGR input (For gdal and ogr plugin support)
  * libsqlite3 - SQLite input (needs RTree support builtin) (sqlite plugin support)
- 
+
 Instructions for installing many of these dependencies on
 various platforms can be found at the Mapnik Wiki:
 
@@ -160,7 +160,7 @@ You can run the Mapnik tests locally (without installing) like:
 
 Python bindings are not included by default. You'll need to add those separately. 
 
-    * Build from source: https://github.com/mapnik/python-mapnik
+ * Build from source: https://github.com/mapnik/python-mapnik
 
 ## Learning Mapnik
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ Additional optional dependencies:
     - pg_config - PostgreSQL installation capabilities
  * libgdal - GDAL/OGR input (For gdal and ogr plugin support)
  * libsqlite3 - SQLite input (needs RTree support builtin) (sqlite plugin support)
-
+ 
 Instructions for installing many of these dependencies on
 various platforms can be found at the Mapnik Wiki:
 
@@ -155,6 +155,12 @@ For more details on usage see:
 You can run the Mapnik tests locally (without installing) like:
 
     make test
+
+## Python Bindings
+
+Python bindings are not included by default. You'll need to add those separately. 
+
+    * Build from source: https://github.com/mapnik/python-mapnik
 
 ## Learning Mapnik
 


### PR DESCRIPTION
Since these aren't included by default, the other package needs to be referenced here to avoid a wild goose chase.