### PR TITLE
Postgis plugin: Add key_field_as_attribute 

### DIFF
--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -94,7 +94,8 @@ postgis_datasource::postgis_datasource(parameters const& params)
       pattern_(boost::regex("(@\\w+)",boost::regex::normal | boost::regbase::icase)),
       // params below are for testing purposes only and may be removed at any time
       intersect_min_scale_(*params.get<mapnik::value_integer>("intersect_min_scale", 0)),
-      intersect_max_scale_(*params.get<mapnik::value_integer>("intersect_max_scale", 0))
+      intersect_max_scale_(*params.get<mapnik::value_integer>("intersect_max_scale", 0)),
+      key_field_as_attribute_(*params.get<mapnik::value_integer>("key_field_as_attribute", true))
 {
 #ifdef MAPNIK_STATS
     mapnik::progress_timer __stats__(std::clog, "postgis_datasource::init");
@@ -372,7 +373,10 @@ postgis_datasource::postgis_datasource(parameters const& params)
                     if (type_oid == 20 || type_oid == 21 || type_oid == 23)
                     {
                         found_key_field = true;
-                        desc_.add_descriptor(attribute_descriptor(fld_name, mapnik::Integer));
+                        if (key_field_as_attribute_)
+                        {
+                            desc_.add_descriptor(attribute_descriptor(fld_name, mapnik::Integer));
+                        }
                     }
                     else
                     {
@@ -819,7 +823,10 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
         if (! key_field_.empty())
         {
             mapnik::sql_utils::quote_attr(s, key_field_);
-            ctx->push(key_field_);
+            if (key_field_as_attribute_)
+            {
+                ctx->push(key_field_);
+            }
 
             for (; pos != end; ++pos)
             {
@@ -849,7 +856,7 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
         }
 
         std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool, proc_ctx);
-        return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty());
+        return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty(), key_field_as_attribute_);
 
     }
 
@@ -902,7 +909,10 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
             if (! key_field_.empty())
             {
                 mapnik::sql_utils::quote_attr(s, key_field_);
-                ctx->push(key_field_);
+                if (key_field_as_attribute_)
+                {
+                    ctx->push(key_field_);
+                }
                 for (; itr != end; ++itr)
                 {
                     if (itr->get_name() != key_field_)
@@ -932,7 +942,7 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
             }
 
             std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
-            return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty());
+            return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty(), key_field_as_attribute_);
         }
     }
 

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -122,6 +122,7 @@ private:
     boost::regex pattern_;
     int intersect_min_scale_;
     int intersect_max_scale_;
+    bool key_field_as_attribute_;
 };
 
 #endif // POSTGIS_DATASOURCE_HPP

--- a/plugins/input/postgis/postgis_featureset.cpp
+++ b/plugins/input/postgis/postgis_featureset.cpp
@@ -48,13 +48,15 @@ using mapnik::context_ptr;
 postgis_featureset::postgis_featureset(std::shared_ptr<IResultSet> const& rs,
                                        context_ptr const& ctx,
                                        std::string const& encoding,
-                                       bool key_field)
+                                       bool key_field,
+                                       bool key_field_as_attribute)
     : rs_(rs),
       ctx_(ctx),
       tr_(new transcoder(encoding)),
       totalGeomSize_(0),
       feature_id_(1),
-      key_field_(key_field)
+      key_field_(key_field),
+      key_field_as_attribute_(key_field_as_attribute)
 {
 }
 
@@ -97,10 +99,10 @@ feature_ptr postgis_featureset::next()
             }
 
             feature = feature_factory::create(ctx_, val);
-            // TODO - extend feature class to know
-            // that its id is also an attribute to avoid
-            // this duplication
-            feature->put<mapnik::value_integer>(name,val);
+            if (key_field_as_attribute_)
+            {
+                feature->put<mapnik::value_integer>(name,val);
+            }
             ++pos;
         }
         else

--- a/plugins/input/postgis/postgis_featureset.hpp
+++ b/plugins/input/postgis/postgis_featureset.hpp
@@ -43,7 +43,8 @@ public:
     postgis_featureset(std::shared_ptr<IResultSet> const& rs,
                        context_ptr const& ctx,
                        std::string const& encoding,
-                       bool key_field = false);
+                       bool key_field,
+                       bool key_field_as_attribute);
     feature_ptr next();
     ~postgis_featureset();
 
@@ -54,6 +55,7 @@ private:
     unsigned totalGeomSize_;
     mapnik::value_integer feature_id_;
     bool key_field_;
+    bool key_field_as_attribute_;
 };
 
 #endif // POSTGIS_FEATURESET_HPP


### PR DESCRIPTION
The new `key_field_as_attribute ` will default to true (to keep back compatible/existing behavior). Flipping to false will trigger the value to not be duplicated as feature attribute

- refs #3115