### PR TITLE
Fix std::string errors in GCC 5.2.1

### DIFF
--- a/include/mapnik/util/variant.hpp
+++ b/include/mapnik/util/variant.hpp
@@ -597,6 +597,7 @@ public:
     friend void copy(variant<Types...> & target, variant<Types...> & source)
     {
         helper_type::destroy(target.type_index, &target.data);
+        target.type_index = detail::invalid_value;
         helper_type::copy(source.type_index, &source.data, &target.data);
         target.type_index = source.type_index;
     }

--- a/include/mapnik/util/variant.hpp
+++ b/include/mapnik/util/variant.hpp
@@ -25,7 +25,6 @@
 
 #include <mapnik/config.hpp>
 
-#include <utility> // swap
 #include <typeinfo>
 #include <type_traits>
 #include <stdexcept> // runtime_error
@@ -595,16 +594,16 @@ public:
         helper_type::move(old.type_index, &old.data, &data);
     }
 
-    friend void swap(variant<Types...> & first, variant<Types...> & second)
+    friend void copy(variant<Types...> & target, variant<Types...> & source)
     {
-        using std::swap; //enable ADL
-        swap(first.type_index, second.type_index);
-        swap(first.data, second.data);
+        helper_type::destroy(target.type_index, &target.data);
+        helper_type::copy(source.type_index, &source.data, &target.data);
+        target.type_index = source.type_index;
     }
 
     VARIANT_INLINE variant<Types...>& operator=(variant<Types...> other)
     {
-        swap(*this, other);
+        copy(*this, other);
         return *this;
     }
 
@@ -614,7 +613,7 @@ public:
     VARIANT_INLINE variant<Types...>& operator=(T && rhs) noexcept
     {
         variant<Types...> temp(std::forward<T>(rhs));
-        swap(*this, temp);
+        copy(*this, temp);
         return *this;
     }
 
@@ -623,7 +622,7 @@ public:
     VARIANT_INLINE variant<Types...>& operator=(T const& rhs)
     {
         variant<Types...> temp(rhs);
-        swap(*this, temp);
+        copy(*this, temp);
         return *this;
     }
 


### PR DESCRIPTION
This fixes #3140 and possibly #3090.

There are some unit test failures, and a lot of visual test failures, but the test from https://github.com/springmeyer/mapnik-c-api now works.

```

test/unit/datasource/ogr.cpp:54: FAILED:
  REQUIRE( mapnik::compare(expected, im) == 0 )
with expansion:
  5 == 0

*** Error in `test/standalone/csv_test-bin': munmap_chunk(): invalid pointer: 0x00007ffdb5799528 ***

test/standalone/csv_test.cpp:185: FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  "test/data/csv/fails/no_headers.csv"
  SIGABRT - Abort (abnormal termination) signal

```