### PR TITLE
update changelog and authors after #3160

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -80,3 +80,4 @@ Mapnik is written by Artem Pavlenko with contributions from:
 * Rich Wareham
 * Nick Whitelegg
 * Leslie Wu
+* Roman Galacz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Developers: Please commit along with changes.
 
 For a complete change history, see the git log.
 
+## 3.0.9
+
+Released:
+
+(Packaged from )
+
+#### Summary
+
+ - Fixed offsetting of complex paths and sharp angles (https://github.com/mapnik/mapnik/pull/3160)
+
 ## 3.0.8
 
 Released: October 23, 2015


### PR DESCRIPTION
Proposing to append https://github.com/mapnik/mapnik/pull/3160 to changelog and Roman Galacz aka @winni159 to authors.