### PR TITLE
mapnik-index: fix linking on Linux

### DIFF
--- a/utils/mapnik-index/build.py
+++ b/utils/mapnik-index/build.py
@@ -42,9 +42,9 @@ boost_program_options = 'boost_program_options%s' % env['BOOST_APPEND']
 boost_system = 'boost_system%s' % env['BOOST_APPEND']
 libraries =  [env['MAPNIK_NAME'], boost_program_options, boost_system]
 # need on linux: https://github.com/mapnik/mapnik/issues/3145
-libraries.append(env['ICU_LIB_NAME'])
 libraries.append('mapnik-json')
 libraries.append('mapnik-wkt')
+libraries.append(env['ICU_LIB_NAME'])
 
 if env['RUNTIME_LINK'] == 'static':
     libraries.extend(copy(env['LIBMAPNIK_LIBS']))


### PR DESCRIPTION
Fixes https://github.com/mapnik/mapnik/issues/3174.

It seems library order is important on some systems.