### PR TITLE
Viz hidden

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1786,7 +1786,7 @@ if not preconfigured:
 
         # Common flags for g++/clang++ CXX compiler.
         # TODO: clean up code more to make -Wextra -Wsign-compare -Wsign-conversion -Wconversion viable
-        common_cxx_flags = '-Wall %s %s -ftemplate-depth-300 -Wsign-compare -Wshadow ' % (env['WARNING_CXXFLAGS'], pthread)
+        common_cxx_flags = '-fvisibility=hidden -fvisibility-inlines-hidden -Wall %s %s -ftemplate-depth-300 -Wsign-compare -Wshadow ' % (env['WARNING_CXXFLAGS'], pthread)
 
         if 'clang++' in env['CXX']:
             common_cxx_flags += ' -Wno-unsequenced '
@@ -1794,8 +1794,6 @@ if not preconfigured:
         if env['DEBUG']:
             env.Append(CXXFLAGS = common_cxx_flags + '-O0')
         else:
-            # TODO - add back -fvisibility-inlines-hidden
-            # https://github.com/mapnik/mapnik/issues/1863
             env.Append(CXXFLAGS = common_cxx_flags + '-O%s' % (env['OPTIMIZATION']))
         if env['DEBUG_UNDEFINED']:
             env.Append(CXXFLAGS = '-fsanitize=undefined-trap -fsanitize-undefined-trap-on-error -ftrapv -fwrapv')

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -89,7 +89,6 @@ function make_config() {
     echo "
 CXX = '$CXX'
 CC = '$CC'
-CUSTOM_CXXFLAGS = '-fvisibility=hidden -fvisibility-inlines-hidden -DU_CHARSET_IS_UTF8=1'
 RUNTIME_LINK = 'static'
 INPUT_PLUGINS = 'all'
 PATH = '${MASON_LINKED_REL}/bin'


### PR DESCRIPTION
We originally backed off from making `-fvisibility-inlines-hidden` and `-fvisibility=hidden` default compile flags on unix due to #1863. But #1863 is no longer relevant because we don't need to / nor can we support older g++ now that we require c++11. And these flags a important for reducing binary size, so let's now start defaulting to them. This will avoid all of a sudden breakages when packaging (since we've been depending on these flags for packaging for some time). It will also make symbol visibility like windows, so will help avoid windows build issues that are not seen on unix.

So this finishes the work started in #1826 and #1832.