### PR TITLE
Throttle parallelization of memory-intensive compilation tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ ifeq ($(JOBS),)
 	JOBS:=1
 endif
 
+ifeq ($(HOGS),)
+	HOGS:=1
+endif
+
 all: mapnik
 
 install:
-	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1 install
+	$(PYTHON) scons/scons.py -j$(JOBS) --hogs=$(HOGS) --config=cache --implicit-cache --max-drift=1 install
 
 release:
 	export MAPNIK_VERSION=$(shell ./utils/mapnik-config/mapnik-config --version) && \
@@ -36,27 +40,8 @@ python:
 	make
 	python bindings/python/test/visual.py -q
 
-src/json/libmapnik-json.a:
-	# we first build memory intensive files with -j1
-	$(PYTHON) scons/scons.py -j1 \
-		--config=cache --implicit-cache --max-drift=1 \
-		src/renderer_common/process_group_symbolizer.os \
-		src/json/libmapnik-json.a \
-		src/wkt/libmapnik-wkt.a \
-		src/css_color_grammar.os \
-		src/expression_grammar.os \
-		src/transform_expression_grammar.os \
-		src/image_filter_types.os \
-		src/agg/process_markers_symbolizer.os \
-		src/agg/process_group_symbolizer.os \
-		src/grid/process_markers_symbolizer.os \
-		src/grid/process_group_symbolizer.os \
-		src/cairo/process_markers_symbolizer.os \
-		src/cairo/process_group_symbolizer.os \
-
-mapnik: src/json/libmapnik-json.a
-	# then install the rest with -j$(JOBS)
-	$(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
+mapnik:
+	$(PYTHON) scons/scons.py -j$(JOBS) --hogs=$(HOGS) --config=cache --implicit-cache --max-drift=1
 
 clean:
 	@$(PYTHON) scons/scons.py -j$(JOBS) -c --config=cache --implicit-cache --max-drift=1

--- a/include/build.py
+++ b/include/build.py
@@ -55,3 +55,53 @@ if 'install' in COMMAND_LINE_TARGETS:
         env.Alias(target='install', source=env.Install(inc_target, includes))
 
 env['create_uninstall_target'](env, os.path.normpath(env['INSTALL_PREFIX']+'/include/mapnik/'))
+
+# Mark all `*_grammar.hpp` and `*_grammar_impl.hpp` headers as memory hogs.
+# Sources that #include (directly or indirectly) any of those are restricted
+# to at most --hogs=M parallel compilation tasks. They still count towards
+# the total limit given by --jobs=N, but don't prevent parallel compilation
+# of regular sources. There may M memory-intensive plus N-M memory-savvy
+# sources being compiled in parallel.
+env.MemoryHog(Split(
+    """
+    mapnik/css_color_grammar.hpp
+    mapnik/css_color_grammar_impl.hpp
+    mapnik/csv/csv_grammar.hpp
+    mapnik/expression_grammar.hpp
+    mapnik/expression_grammar_impl.hpp
+    mapnik/image_filter_grammar.hpp
+    mapnik/image_filter_grammar_impl.hpp
+    mapnik/json/extract_bounding_box_grammar.hpp
+    mapnik/json/extract_bounding_box_grammar_impl.hpp
+    mapnik/json/feature_collection_grammar.hpp
+    mapnik/json/feature_collection_grammar_impl.hpp
+    mapnik/json/feature_generator_grammar.hpp
+    mapnik/json/feature_generator_grammar_impl.hpp
+    mapnik/json/feature_grammar.hpp
+    mapnik/json/feature_grammar_impl.hpp
+    mapnik/json/geometry_generator_grammar.hpp
+    mapnik/json/geometry_generator_grammar_impl.hpp
+    mapnik/json/geometry_grammar.hpp
+    mapnik/json/geometry_grammar_impl.hpp
+    mapnik/json/positions_grammar.hpp
+    mapnik/json/positions_grammar_impl.hpp
+    mapnik/json/properties_generator_grammar.hpp
+    mapnik/json/properties_generator_grammar_impl.hpp
+    mapnik/json/symbolizer_grammar.hpp
+    mapnik/json/topojson_grammar.hpp
+    mapnik/json/topojson_grammar_impl.hpp
+    mapnik/path_expression_grammar.hpp
+    mapnik/path_expression_grammar_impl.hpp
+    mapnik/svg/output/svg_output_grammars.hpp
+    mapnik/svg/output/svg_output_grammars_impl.hpp
+    mapnik/svg/svg_path_grammar.hpp
+    mapnik/svg/svg_points_grammar.hpp
+    mapnik/svg/svg_transform_grammar.hpp
+    mapnik/transform_expression_grammar.hpp
+    mapnik/transform_expression_grammar_impl.hpp
+    mapnik/wkt/wkt_generator_grammar.hpp
+    mapnik/wkt/wkt_generator_grammar_impl.hpp
+    mapnik/wkt/wkt_grammar.hpp
+    mapnik/wkt/wkt_grammar_impl.hpp
+    """
+    ))

--- a/scons/scons-local-2.4.1/SCons/Environment.py
+++ b/scons/scons-local-2.4.1/SCons/Environment.py
@@ -2100,6 +2100,18 @@ class Base(SubstitutionEnvironment):
                    ret.append(t)
         return ret
 
+    def MemoryHog(self, *targets):
+        """
+        Mark targets as memory hogs. This will limit the number
+        of parallel jobs used to build their direct parents.
+        """
+        tlist = []
+        for t in targets:
+            tlist.extend(self.arg2nodes(t, self.fs.Entry))
+        for t in tlist:
+            t.set_memory_hog()
+        return tlist
+
     def Precious(self, *targets):
         tlist = []
         for t in targets:

--- a/scons/scons-local-2.4.1/SCons/Node/__init__.py
+++ b/scons/scons-local-2.4.1/SCons/Node/__init__.py
@@ -511,6 +511,7 @@ class Node(object):
                  'noclean',
                  'nocache',
                  'cached',
+                 'memory_hog',
                  'always_build',
                  'includes',
                  'attributes',
@@ -574,6 +575,7 @@ class Node(object):
         self.noclean = 0
         self.nocache = 0
         self.cached = 0 # is this node pulled from cache?
+        self.memory_hog = False
         self.always_build = None
         self.includes = None
         self.attributes = self.Attrs() # Generic place to stick information about the Node.
@@ -1171,7 +1173,7 @@ class Node(object):
         self.precious = precious
 
     def set_pseudo(self, pseudo = True):
-        """Set the Node's precious value."""
+        """Set the Node's pseudo value."""
         self.pseudo = pseudo
 
     def set_noclean(self, noclean = 1):
@@ -1185,6 +1187,10 @@ class Node(object):
         # Make sure nocache is an integer so the --debug=stree
         # output in Util.py can use it as an index.
         self.nocache = nocache and 1 or 0
+
+    def set_memory_hog(self, hog = True):
+        """Set the Node's memory_hog value."""
+        self.memory_hog = hog
 
     def set_always_build(self, always_build = 1):
         """Set the Node's always_build value."""

--- a/scons/scons-local-2.4.1/SCons/SConf.py
+++ b/scons/scons-local-2.4.1/SCons/SConf.py
@@ -521,7 +521,7 @@ class SConfBase(object):
             SConfFS.set_max_drift(0)
             tm = SCons.Taskmaster.Taskmaster(nodes, SConfBuildTask)
             # we don't want to build tests in parallel
-            jobs = SCons.Job.Jobs(1, tm )
+            jobs = SCons.Job.Jobs(1, 1, tm)
             jobs.run()
             for n in nodes:
                 state = n.get_state()

--- a/scons/scons-local-2.4.1/SCons/Script/Main.py
+++ b/scons/scons-local-2.4.1/SCons/Script/Main.py
@@ -1258,7 +1258,7 @@ def _build_targets(fs, options, targets, target_top):
 
     global num_jobs
     num_jobs = options.num_jobs
-    jobs = SCons.Job.Jobs(num_jobs, taskmaster)
+    jobs = SCons.Job.Jobs(num_jobs, options.num_hogs, taskmaster)
     if num_jobs > 1:
         msg = None
         if jobs.num_jobs == 1:

--- a/scons/scons-local-2.4.1/SCons/Script/SConsOptions.py
+++ b/scons/scons-local-2.4.1/SCons/Script/SConsOptions.py
@@ -123,6 +123,7 @@ class SConsValues(optparse.Values):
         'max_drift',
         'md5_chunksize',
         'no_exec',
+        'num_hogs',
         'num_jobs',
         'random',
         'stack_size',
@@ -136,7 +137,7 @@ class SConsValues(optparse.Values):
         if not name in self.settable:
             raise SCons.Errors.UserError("This option is not settable from a SConscript file: %s"%name)
 
-        if name == 'num_jobs':
+        if name == 'num_jobs' or name == 'num_hogs':
             try:
                 value = int(value)
                 if value < 1:
@@ -752,6 +753,13 @@ def Parser(version):
     op.add_option("-H", "--help-options",
                   action="help",
                   help="Print this message and exit.")
+
+    op.add_option('--hogs',
+                  nargs=1, type="int",
+                  dest="num_hogs", default=1,
+                  action="store",
+                  help="Allow N memory-intensive jobs at once.",
+                  metavar="N")
 
     op.add_option('-i', '--ignore-errors',
                   dest='ignore_errors', default=False,

--- a/src/build.py
+++ b/src/build.py
@@ -257,6 +257,11 @@ source = Split(
     math.cpp
     """
     )
+env.MemoryHog(Split(
+    """
+    renderer_common/process_group_symbolizer.cpp
+    """
+    ))
 
 if env['PLUGIN_LINKING'] == 'static':
     hit = False
@@ -317,6 +322,13 @@ if env['HAS_CAIRO']:
     cairo/process_raster_symbolizer.cpp
     cairo/process_building_symbolizer.cpp
     """)
+    env.MemoryHog(Split(
+        """
+        cairo/process_group_symbolizer.cpp
+        cairo/process_line_symbolizer.cpp
+        cairo/process_markers_symbolizer.cpp
+        """
+        ))
 
 for cpp in enabled_imaging_libraries:
     source.append(cpp)
@@ -340,6 +352,13 @@ source += Split(
     agg/process_debug_symbolizer.cpp
     """
     )
+env.MemoryHog(Split(
+    """
+    agg/process_group_symbolizer.cpp
+    agg/process_line_symbolizer.cpp
+    agg/process_markers_symbolizer.cpp
+    """
+    ))
 
 if env['RUNTIME_LINK'] == "static":
     source += glob.glob('../deps/agg/src/' + '*.cpp')
@@ -367,6 +386,13 @@ if env['GRID_RENDERER']:
         grid/process_shield_symbolizer.cpp
         grid/process_text_symbolizer.cpp
         """)
+    env.MemoryHog(Split(
+        """
+        grid/process_group_symbolizer.cpp
+        grid/process_line_symbolizer.cpp
+        grid/process_markers_symbolizer.cpp
+        """
+        ))
     lib_env.Append(CPPDEFINES = '-DGRID_RENDERER')
     libmapnik_defines.append('-DGRID_RENDERER')
 


### PR DESCRIPTION
There's this trick in [Makefile](https://github.com/mapnik/mapnik/blob/6e93b05a063387e3ec8a3493661ed8cd91d9c52d/Makefile#L39):

``` make
src/json/libmapnik-json.a:
    # we first build memory intensive files with -j1
    $(PYTHON) scons/scons.py -j1 --config=cache --implicit-cache --max-drift=1 \
        src/...

mapnik: src/json/libmapnik-json.a
    # then install the rest with -j$(JOBS)
    $(PYTHON) scons/scons.py -j$(JOBS) --config=cache --implicit-cache --max-drift=1
```

But that only works when `libmapnik-json.a` doesn't exist. If you don't delete the library from the previous build and do `make JOBS=2`, everything will be built with `-j2`. Which may be rough. For me `gcc src/*/process_markers_symbolizer.cpp` takes ~140s and ~4GB of memory, so whenever I change a header included by two of those, it's very likely they will meet, eat all 8GB of my RAM and end up in a swap-thrashing limbo.

If you do delete the library, or change the `-j1` target to a phony one, you'll be waiting for scons to start twice every time.

This PR adds a new option to scons: --hogs=N (defaults to 1)
It controls how many jobs (out of the total number given by --jobs) may run memory-intensive tasks.

Which tasks are considered memory-intensive is specified by tagging sources or headers with new scons environment method `MemoryHog`. Here I'm not entirely sure that was the correct way to do this, my knowledge of the scons system is quite shallow. Note: this modifies `SCons.Node` class, so you may need to `rm -f config.cache .sconsign.dblite` to get rid of old pickled data.

In the second commit I marked all grammar headers and heavy symbolizer sources as memory hogs, and replaced the above Makefile trick with an additional make variable `HOGS`.
