### PR TITLE
Raster Type Memory Datasource

### DIFF
--- a/include/mapnik/memory_datasource.hpp
+++ b/include/mapnik/memory_datasource.hpp
@@ -55,6 +55,7 @@ private:
     mapnik::layer_descriptor desc_;
     datasource::datasource_t type_;
     bool bbox_check_;
+    bool type_set_;
     mutable box2d<double> extent_;
     mutable bool dirty_extent_ = true;
 };

--- a/src/memory_datasource.cpp
+++ b/src/memory_datasource.cpp
@@ -73,7 +73,8 @@ memory_datasource::memory_datasource(parameters const& params)
       desc_(memory_datasource::name(),
             *params.get<std::string>("encoding","utf-8")),
       type_(datasource::Vector),
-      bbox_check_(*params.get<boolean_type>("bbox_check", true)) {}
+      bbox_check_(*params.get<boolean_type>("bbox_check", true)),
+      type_set_(false) {}
 
 memory_datasource::~memory_datasource() {}
 
@@ -81,6 +82,30 @@ void memory_datasource::push(feature_ptr feature)
 {
     // TODO - collect attribute descriptors?
     //desc_.add_descriptor(attribute_descriptor(fld_name,mapnik::Integer));
+    if (feature->get_raster())
+    {
+        // if a feature has a raster_ptr set it must be of raster type.
+        if (!type_set_)
+        {
+            type_ = datasource::Raster;
+            type_set_ = true;
+        }
+        else if (type_ == datasource::Vector)
+        {
+            throw std::runtime_error("Can not add a raster feature to a memory datasource that contains vectors");
+        }
+    }
+    else 
+    {
+        if (!type_set_)
+        {
+            type_set_ = true;
+        }
+        else if (type_ == datasource::Raster)
+        {
+            throw std::runtime_error("Can not add a vector feature to a memory datasource that contains rasters");
+        }
+    }
     features_.push_back(feature);
     dirty_extent_ = true;
 }


### PR DESCRIPTION
Made it possible to change the type of a memory datasource by inspecting the features that are added to the memory datasource /cc @artemp 