### PR TITLE
add util::movable to complement util::noncopyable

### DIFF
--- a/include/mapnik/util/noncopyable.hpp
+++ b/include/mapnik/util/noncopyable.hpp
@@ -28,6 +28,15 @@ namespace mapnik { namespace util {
 namespace non_copyable_
 {
 
+class movable
+{
+protected:
+    constexpr movable() = default;
+    ~movable() = default;
+    movable( movable && ) = default;
+    movable& operator=(movable && ) = default;
+};
+
 class noncopyable
 {
 protected:
@@ -36,8 +45,10 @@ protected:
     noncopyable( noncopyable const& ) = delete;
     noncopyable& operator=(noncopyable const& ) = delete;
 };
+
 }
 
+using movable = non_copyable_::movable;
 using noncopyable = non_copyable_::noncopyable;
 
 }}


### PR DESCRIPTION
`util::noncopyable` (rightfully) prevents default move construction. But sometimes you want something noncopyable but movable.

Example use case from [renderer_common/process_group_symbolizer.hpp](https://github.com/mapnik/mapnik/blob/d3d11068651673388490028b16478d4f5f8ab1f9/include/mapnik/renderer_common/process_group_symbolizer.hpp#L140)
```c++

struct text_render_thunk : util::noncopyable
{
    // ... stuff
    text_render_thunk(more, stuff);

    text_render_thunk(text_render_thunk && rhs);
};
```

The move constructor cannot be defaulted because noncopyable has deleted copy and move constructor. So there's a boring definition spelled out in .cpp

With util::movable you can have this:
```c++
struct text_render_thunk : util::movable
{
    // ... stuff
    text_render_thunk(more, stuff);

    text_render_thunk(text_render_thunk && rhs) = default;
};
```

Regarding the name and placement - `noncopyable_but_movable` would be more descriptive, and more typing. I placed it in noncopyable.hpp, as it's very closely related to `noncopyable`, and if you have to `#include <mapnik/util/noncopyable.hpp>` to use `movable`, then you'll know the class has both of those qualities.