### PR TITLE
Adapt geometry tests got changes in boost 1.60

### DIFF
--- a/test/unit/geometry/geometry_is_simple.cpp
+++ b/test/unit/geometry/geometry_is_simple.cpp
@@ -163,6 +163,36 @@ SECTION("polygon 3 repeated points") {
     CHECK( !mapnik::geometry::is_simple(poly) );
 }
 
+#if BOOST_VERSION >= 106000
+
+SECTION("polygon that is empty") {
+    mapnik::geometry::polygon<double> poly;
+    CHECK( !mapnik::geometry::is_simple(poly) );
+}
+
+SECTION("polygon that has empty exterior ring") {
+    mapnik::geometry::polygon<double> poly;
+    mapnik::geometry::linear_ring<double> ring;
+    poly.set_exterior_ring(std::move(ring));
+    CHECK( !mapnik::geometry::is_simple(poly) );
+}
+
+SECTION("polygon that has empty interior ring") {
+    mapnik::geometry::polygon<double> poly;
+    mapnik::geometry::linear_ring<double> ring;
+    ring.add_coord(0,0);    
+    ring.add_coord(1,0);
+    ring.add_coord(1,1);
+    ring.add_coord(0,1);
+    ring.add_coord(0,0);
+    poly.set_exterior_ring(std::move(ring));
+    mapnik::geometry::linear_ring<double> ring2;
+    poly.add_hole(std::move(ring2));
+    CHECK( !mapnik::geometry::is_simple(poly) );
+}
+
+#else // BOOST_VERSION >= 1.60
+
 SECTION("polygon that is empty") {
     mapnik::geometry::polygon<double> poly;
     CHECK( mapnik::geometry::is_simple(poly) );
@@ -188,6 +218,8 @@ SECTION("polygon that has empty interior ring") {
     poly.add_hole(std::move(ring2));
     CHECK( mapnik::geometry::is_simple(poly) );
 }
+
+#endif // BOOST_VERSION >= 1.60
 
 // A polygon with a spike can still be simple
 SECTION("polygon with spike") {

--- a/test/unit/geometry/geometry_is_valid.cpp
+++ b/test/unit/geometry/geometry_is_valid.cpp
@@ -54,6 +54,36 @@ SECTION("point unitialized") {
     CHECK( failure2 == boost::geometry::no_failure );
 }
 
+#if BOOST_VERSION >= 106000
+
+SECTION("point NaN") {
+    mapnik::geometry::point<double> pt(std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN());
+    CHECK( std::isnan(pt.x) );
+    CHECK( std::isnan(pt.y) );
+    CHECK( !mapnik::geometry::is_valid(pt) );
+    std::string message;
+    CHECK( !mapnik::geometry::is_valid(pt, message) );
+    CHECK( message == "Geometry has point(s) with invalid coordinate(s)");
+    boost::geometry::validity_failure_type failure;
+    CHECK( !mapnik::geometry::is_valid(pt, failure) );
+    CHECK( failure == boost::geometry::failure_invalid_coordinate );
+}
+
+SECTION("point Infinity") {
+    mapnik::geometry::point<double> pt(std::numeric_limits<double>::infinity(),std::numeric_limits<double>::infinity());
+    CHECK( std::isinf(pt.x) );
+    CHECK( std::isinf(pt.y) );
+    CHECK( !mapnik::geometry::is_valid(pt) );
+    std::string message;
+    CHECK( !mapnik::geometry::is_valid(pt, message) );
+    CHECK( message == "Geometry has point(s) with invalid coordinate(s)");
+    boost::geometry::validity_failure_type failure;
+    CHECK( !mapnik::geometry::is_valid(pt, failure) );
+    CHECK( failure == boost::geometry::failure_invalid_coordinate );
+}
+
+#else // BOOST_VERSION >= 1.60
+
 // This is funky that boost geometry is_valid does not check for NAN when dealing with a point
 // this test is here in case the logic ever changes
 // Bug report on this: https://svn.boost.org/trac/boost/ticket/11711
@@ -85,6 +115,8 @@ SECTION("point Infinity") {
     CHECK( mapnik::geometry::is_valid(pt, failure) );
     CHECK( failure == boost::geometry::no_failure );
 }
+
+#endif // BOOST_VERSION >= 1.60
 
 SECTION("multi point") {
     mapnik::geometry::multi_point<double> mpt;


### PR DESCRIPTION
The issues with points at NaN and infinity bring considered as valid reported in https://svn.boost.org/trac/boost/ticket/11711 has been fixed in boost 1.60 so the tests need to reflect that.

Also per https://svn.boost.org/trac/boost/ticket/11710 empty polygons are now considered invalid, and hence not simple.