### PR TITLE
Compile image_filter_grammar separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ src/json/libmapnik-json.a:
 		src/css_color_grammar.os \
 		src/expression_grammar.os \
 		src/transform_expression_grammar.os \
-		src/image_filter_types.os \
+		src/image_filter_grammar.os \
 		src/agg/process_markers_symbolizer.os \
 		src/agg/process_group_symbolizer.os \
 		src/grid/process_markers_symbolizer.os \

--- a/src/build.py
+++ b/src/build.py
@@ -154,6 +154,7 @@ source = Split(
     well_known_srs.cpp
     params.cpp
     image_filter_types.cpp
+    image_filter_grammar.cpp
     miniz_png.cpp
     color.cpp
     conversions.cpp

--- a/src/image_filter_grammar.cpp
+++ b/src/image_filter_grammar.cpp
@@ -1,0 +1,29 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2016 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#include <mapnik/image_filter_grammar.hpp>
+#include <mapnik/image_filter_grammar_impl.hpp>
+#include <mapnik/image_filter_types.hpp>
+#include <string>
+#include <vector>
+
+template struct mapnik::image_filter_grammar<std::string::const_iterator,std::vector<mapnik::filter::filter_type>>;

--- a/src/image_filter_types.cpp
+++ b/src/image_filter_types.cpp
@@ -22,7 +22,6 @@
 // mapnik
 #include <mapnik/image_filter_types.hpp>
 #include <mapnik/image_filter_grammar.hpp>
-#include <mapnik/image_filter_grammar_impl.hpp>
 
 #pragma GCC diagnostic push
 #include <mapnik/warning_ignore.hpp>


### PR DESCRIPTION
I did not do this originally (when porting many grammars to be split between `.hpp` and `_impl.hpp`) because `image_filter_grammar_impl.hpp` is only used in one place. The logic goes: if the grammar is only used in one cpp file then compiling it separately will only add to overall compile times without saving much in terms of peak memory (because including `image_filter_grammar_impl.hpp` inside `src/image_filter_types.cpp` does not lead to a compile any more intensive that compiling `image_filter_grammar_impl.hpp` alone).

However on appveyor we are consistently hitting:

```
C1060: compiler is out of heap space (compiling source file ..\..\src\image_filter_types.cpp)
```

I have a small hope that this change will require slightly less memory and might help appveyor squeak by. We'll see.