### PR TITLE
Cleanup defaulted constructors and assignment operators, noexcept specifiers

### DIFF
--- a/include/mapnik/feature.hpp
+++ b/include/mapnik/feature.hpp
@@ -90,7 +90,7 @@ private:
 using context_type = context<std::map<std::string,std::size_t> >;
 using context_ptr = std::shared_ptr<context_type>;
 
-static const value default_feature_value;
+static const value default_feature_value{};
 
 class MAPNIK_DECL feature_impl : private util::noncopyable
 {

--- a/include/mapnik/geometry.hpp
+++ b/include/mapnik/geometry.hpp
@@ -45,9 +45,6 @@ struct point
     point(mapnik::coord<double, 2> const& c)
         : x(c.x), y(c.y) {}
 
-    point(point const& other) = default;
-    point(point && other) noexcept = default;
-    point & operator=(point const& other) = default;
     friend inline bool operator== (point<T> const& a, point<T> const& b)
     {
         return a.x == b.x && a.y == b.y;
@@ -65,12 +62,8 @@ template <typename T>
 struct line_string : std::vector<point<T> >
 {
     line_string() = default;
-    line_string (std::size_t size)
+    explicit line_string(std::size_t size)
         : std::vector<point<T> >(size) {}
-    line_string (line_string && other) = default ;
-    line_string& operator=(line_string &&) = default;
-    line_string (line_string const& ) = default;
-    line_string& operator=(line_string const&) = default;
     inline std::size_t num_points() const { return std::vector<point<T>>::size(); }
     inline void add_coord(T x, T y) { std::vector<point<T>>::template emplace_back(x,y);}
 };
@@ -79,17 +72,12 @@ template <typename T>
 struct linear_ring : line_string<T>
 {
     linear_ring() = default;
-    linear_ring(std::size_t size)
+    explicit linear_ring(std::size_t size)
         : line_string<T>(size) {}
-    linear_ring (linear_ring && other) = default ;
-    linear_ring& operator=(linear_ring &&) = default;
     linear_ring(line_string<T> && other)
-        : line_string<T>(other) {}
-    linear_ring (linear_ring const& ) = default;
+        : line_string<T>(std::move(other)) {}
     linear_ring(line_string<T> const& other)
         : line_string<T>(other) {}
-    linear_ring& operator=(linear_ring const&) = default;
-
 };
 
 template <typename T>
@@ -102,7 +90,6 @@ struct polygon
     using rings_container = InteriorRings<T>;
     rings_container interior_rings;
 
-    polygon() = default;
     inline void set_exterior_ring(linear_ring<T> && ring)
     {
         exterior_ring = std::move(ring);

--- a/include/mapnik/image.hpp
+++ b/include/mapnik/image.hpp
@@ -54,9 +54,6 @@ template <std::size_t max_size>
 struct image_dimensions
 {
     image_dimensions(int width, int height);
-    image_dimensions(image_dimensions const& other) = default;
-    image_dimensions(image_dimensions && other) = default;
-    image_dimensions& operator= (image_dimensions rhs);
     std::size_t width() const;
     std::size_t height() const;
 private:

--- a/include/mapnik/image_any.hpp
+++ b/include/mapnik/image_any.hpp
@@ -55,8 +55,9 @@ struct MAPNIK_DECL image_any : image_base
               bool painted = false);
 
     template <typename T>
-        image_any(T && _data) noexcept
-        : image_base(std::move(_data)) {}
+        image_any(T && _data)
+        noexcept(std::is_nothrow_constructible<image_base, T && >::value)
+        : image_base(std::forward<T>(_data)) {}
 
     unsigned char const* bytes() const;
     unsigned char* bytes();

--- a/include/mapnik/image_impl.hpp
+++ b/include/mapnik/image_impl.hpp
@@ -44,14 +44,6 @@ image_dimensions<max_size>::image_dimensions(int width, int height)
 }
 
 template <std::size_t max_size>
-image_dimensions<max_size>& image_dimensions<max_size>::operator= (image_dimensions rhs)
-{
-    std::swap(width_, rhs.width_);
-    std::swap(height_, rhs.height_);
-    return *this;
-}
-
-template <std::size_t max_size>
 std::size_t image_dimensions<max_size>::width() const
 {
     return width_;

--- a/include/mapnik/image_null.hpp
+++ b/include/mapnik/image_null.hpp
@@ -48,9 +48,6 @@ public:
           bool /*initialize*/ = true,
           bool /*premultiplied*/ = false,
           bool /*painted*/ = false) {}
-    image(image<null_t> const&) {}
-    image(image<null_t> &&) noexcept {}
-    image<null_t>& operator=(image<null_t>) { return *this; }
     bool operator==(image<null_t> const&) const { return true; }
     bool operator<(image<null_t> const&) const { return false; }
 

--- a/include/mapnik/image_view.hpp
+++ b/include/mapnik/image_view.hpp
@@ -37,11 +37,7 @@ public:
     static constexpr std::size_t pixel_size = sizeof(pixel_type);
 
     image_view(std::size_t x, std::size_t y, std::size_t width, std::size_t height, T const& data);
-    ~image_view();
 
-    image_view(image_view<T> const& rhs);
-    image_view(image_view<T> && other) noexcept;
-    image_view<T>& operator=(image_view<T> rhs) = delete;
     bool operator==(image_view<T> const& rhs) const;
     bool operator<(image_view<T> const& rhs) const;
 

--- a/include/mapnik/image_view_any.hpp
+++ b/include/mapnik/image_view_any.hpp
@@ -47,8 +47,9 @@ struct MAPNIK_DECL image_view_any : image_view_base
     image_view_any() = default;
 
     template <typename T>
-    image_view_any(T && data) noexcept
-        : image_view_base(std::move(data)) {}
+    image_view_any(T && data)
+        noexcept(std::is_nothrow_constructible<image_view_base, T && >::value)
+        : image_view_base(std::forward<T>(data)) {}
 
     std::size_t width() const;
     std::size_t height() const;

--- a/include/mapnik/image_view_impl.hpp
+++ b/include/mapnik/image_view_impl.hpp
@@ -43,25 +43,6 @@ image_view<T>::image_view(std::size_t x, std::size_t y, std::size_t width, std::
 }
 
 template <typename T>
-image_view<T>::~image_view() {}
-
-template <typename T>
-image_view<T>::image_view(image_view<T> const& rhs)
-    : x_(rhs.x_),
-      y_(rhs.y_),
-      width_(rhs.width_),
-      height_(rhs.height_),
-      data_(rhs.data_) {}
-
-template <typename T>
-image_view<T>::image_view(image_view<T> && other) noexcept
-    : x_(std::move(other.x_)),
-    y_(std::move(other.y_)),
-    width_(std::move(other.width_)),
-    height_(std::move(other.height_)),
-    data_(std::move(other.data_)) {}
-
-template <typename T>
 bool image_view<T>::operator==(image_view<T> const& rhs) const
 {
     return rhs.data_.bytes() == data_.bytes();

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -182,8 +182,9 @@ struct marker : marker_base
     marker() = default;
 
     template <typename T>
-    marker(T && _data) noexcept
-        : marker_base(std::move(_data)) {}
+    marker(T && _data)
+        noexcept(std::is_nothrow_constructible<marker_base, T && >::value)
+        : marker_base(std::forward<T>(_data)) {}
 
     double width() const
     {

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -58,17 +58,11 @@ public:
         bitmap_data_.set(0xff000000);
     }
 
-    marker_rgba8(image_rgba8 const & data)
+    explicit marker_rgba8(image_rgba8 const& data)
         : bitmap_data_(data) {}
 
-    marker_rgba8(image_rgba8 && data)
+    explicit marker_rgba8(image_rgba8 && data) noexcept
         : bitmap_data_(std::move(data)) {}
-
-    marker_rgba8(marker_rgba8 const& rhs)
-        : bitmap_data_(rhs.bitmap_data_) {}
-
-    marker_rgba8(marker_rgba8 && rhs) noexcept
-        : bitmap_data_(std::move(rhs.bitmap_data_)) {}
 
     box2d<double> bounding_box() const
     {
@@ -99,16 +93,10 @@ private:
 struct marker_svg
 {
 public:
-    marker_svg() { }
+    marker_svg() = default;
 
-    marker_svg(mapnik::svg_path_ptr data)
+    explicit marker_svg(mapnik::svg_path_ptr data) noexcept
         : vector_data_(data) {}
-
-    marker_svg(marker_svg const& rhs)
-        : vector_data_(rhs.vector_data_) {}
-
-    marker_svg(marker_svg && rhs) noexcept
-        : vector_data_(rhs.vector_data_) {}
 
     inline box2d<double> bounding_box() const
     {
@@ -140,7 +128,6 @@ private:
 
 struct marker_null
 {
-    marker_null() = default;
 public:
     inline box2d<double> bounding_box() const
     {

--- a/include/mapnik/params.hpp
+++ b/include/mapnik/params.hpp
@@ -50,7 +50,8 @@ struct value_holder : value_holder_base
 
     // perfect forwarding
     template <typename T>
-    value_holder(T && obj) noexcept
+    value_holder(T && obj)
+        noexcept(std::is_nothrow_constructible<value_holder_base, T && >::value)
         : value_holder_base(std::forward<T>(obj))
     {}
 };

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -98,10 +98,8 @@ using value_base_type = util::variant<value_bool,
 
 struct strict_value : value_base_type
 {
-    // default ctor
-    strict_value()
-        : value_base_type() {}
-    // copy ctor
+    strict_value() = default;
+
     strict_value(const char* val)
         : value_base_type(val) {}
 
@@ -109,13 +107,15 @@ struct strict_value : value_base_type
     strict_value(T const& obj)
         : value_base_type(typename detail::mapnik_value_type<T>::type(obj))
     {}
-    // move ctor
-    template <typename T>
-    strict_value(T && obj) noexcept
-        : value_base_type(std::move(obj)) {}
 
+    template <typename T>
+    strict_value(T && obj)
+        noexcept(std::is_nothrow_constructible<value_base_type, T && >::value)
+        : value_base_type(std::forward<T>(obj))
+    {}
 };
-}
+
+} // namespace detail
 
 struct MAPNIK_DECL symbolizer_base
 {

--- a/include/mapnik/value.hpp
+++ b/include/mapnik/value.hpp
@@ -754,17 +754,36 @@ class value : public value_base
     friend const value operator%(value const&,value const&);
 
 public:
-    value () noexcept //-- comment out for VC++11
-        : value_base(value_null()) {}
+    value() = default;
 
-    template <typename T>
-    value ( T const& val)
-        : value_base(typename detail::mapnik_value_type<T>::type(val)) {}
+    // conversion from type T is done via a temporary of type U, which
+    // is determined by mapnik_value_type;
+    // enable_if< decay<T> != value > is necessary to avoid ill-formed
+    // recursion in noexcept specifier; and it also prevents using this
+    // constructor where implicitly-declared copy/move should be used
+    // (e.g. value(value&))
+    template <typename T,
+              typename U = typename std::enable_if<
+                                !detail::is_same_decay<T, value>::value,
+                                detail::mapnik_value_type_decay<T>
+                            >::type::type>
+    value(T && val)
+        noexcept(noexcept(U(std::forward<T>(val))) &&
+                 std::is_nothrow_constructible<value_base, U && >::value)
+        : value_base(U(std::forward<T>(val))) {}
 
-    template <typename T>
-    value ( T && val)
-        noexcept(std::is_nothrow_move_constructible<typename std::remove_const<T>::type>::value)
-        : value_base(std::move(typename detail::mapnik_value_type<T>::type(val))) {}
+    template <typename T,
+              typename U = typename std::enable_if<
+                                !detail::is_same_decay<T, value>::value,
+                                detail::mapnik_value_type_decay<T>
+                            >::type::type>
+    value& operator=(T && val)
+        noexcept(noexcept(U(std::forward<T>(val))) &&
+                 std::is_nothrow_assignable<value_base, U && >::value)
+    {
+        value_base::operator=(U(std::forward<T>(val)));
+        return *this;
+    }
 
     bool operator==(value const& other) const
     {

--- a/include/mapnik/value_types.hpp
+++ b/include/mapnik/value_types.hpp
@@ -227,6 +227,13 @@ struct mapnik_value_type<T, typename std::enable_if<detail::is_value_unicode_str
     using type = mapnik::value_unicode_string const&;
 };
 
+template <typename T>
+using mapnik_value_type_decay = mapnik_value_type<typename std::decay<T>::type>;
+
+template <typename T, typename U>
+using is_same_decay = std::is_same<typename std::decay<T>::type,
+                                   typename std::decay<U>::type>;
+
 } // namespace detail
 
 } // namespace mapnik

--- a/include/mapnik/vertex.hpp
+++ b/include/mapnik/vertex.hpp
@@ -61,28 +61,11 @@ struct vertex<T,2>
     vertex(coord_type x_,coord_type y_,unsigned cmd_)
         : x(x_),y(y_),cmd(cmd_) {}
 
-    vertex(vertex<T,2> && rhs) noexcept
-        : x(std::move(rhs.x)),
-          y(std::move(rhs.y)),
-          cmd(std::move(rhs.cmd)) {}
-
-    vertex(vertex<T,2> const& rhs)
-        : x(rhs.x),
-          y(rhs.y),
-          cmd(rhs.cmd) {}
-
     template <typename T2>
     vertex(vertex<T2,2> const& rhs)
         : x(coord_type(rhs.x)),
           y(coord_type(rhs.y)),
           cmd(rhs.cmd) {}
-
-
-    vertex<T,2>& operator=(vertex<T,2> rhs)
-    {
-        swap(rhs);
-        return *this;
-    }
 
     template <typename T2>
     vertex<T,2>& operator=(vertex<T2,2> const& rhs)


### PR DESCRIPTION
Refs #3274 

- remove explicitly-defaulted functions that don't need to be -- they'll be defined by the compiler
- rectify `noexcept` specifiers on conversion-from-forwarding-reference constructors, and replace some `std::move` that should've been `std::forward`
- attempt to give `mapnik::value` perfectly forwarding conversion constructor and assignment :hammer:
