### PR TITLE
simplify image_filter_grammar

### DIFF
--- a/include/mapnik/image_filter_grammar.hpp
+++ b/include/mapnik/image_filter_grammar.hpp
@@ -20,8 +20,8 @@
  *
  *****************************************************************************/
 
-#ifndef MAPNIK_IMAGE_FILITER_GRAMMAR_HPP
-#define MAPNIK_IMAGE_FILITER_GRAMMAR_HPP
+#ifndef MAPNIK_IMAGE_FILTER_GRAMMAR_HPP
+#define MAPNIK_IMAGE_FILTER_GRAMMAR_HPP
 
 // mapnik
 #include <mapnik/config.hpp>
@@ -66,21 +66,29 @@ template <typename Iterator, typename ContType>
 struct image_filter_grammar :
         qi::grammar<Iterator, ContType(), qi::ascii::space_type>
 {
+    using alternative_type = qi::rule<Iterator, ContType(), qi::ascii::space_type>;
+
     image_filter_grammar();
+
     qi::rule<Iterator, ContType(), qi::ascii::space_type> start;
-    qi::rule<Iterator, ContType(), qi::ascii::space_type> filter;
-    qi::rule<Iterator, qi::locals<int,int>, void(ContType&), qi::ascii::space_type> agg_blur_filter;
-    qi::rule<Iterator, qi::locals<double,double,double,double,double,double,double,double>,
-             void(ContType&), qi::ascii::space_type> scale_hsla_filter;
-    qi::rule<Iterator, qi::locals<mapnik::filter::colorize_alpha, mapnik::filter::color_stop>, void(ContType&), qi::ascii::space_type> colorize_alpha_filter;
+    qi::rule<Iterator, ContType(), qi::ascii::space_type,
+                                   qi::locals<alternative_type*>> filter;
     qi::rule<Iterator, qi::ascii::space_type> no_args;
+    qi::symbols<char, alternative_type*> alternatives;
     qi::uint_parser< unsigned, 10, 1, 3 > radius_;
     css_color_grammar<Iterator> css_color_;
-    qi::rule<Iterator,void(mapnik::filter::color_stop &),qi::ascii::space_type> color_stop_offset;
+    qi::rule<Iterator, filter::color_stop(), qi::ascii::space_type> color_stop_;
+    qi::rule<Iterator, double(), qi::ascii::space_type> color_stop_offset;
     phoenix::function<percent_offset_impl> percent_offset;
-    qi::rule<Iterator, qi::locals<color>, void(ContType&), qi::ascii::space_type> color_to_alpha_filter;
+
+private:
+    alternative_type & add(std::string const& symbol);
+
+    static constexpr unsigned max_alternatives = 16;
+    unsigned num_alternatives = 0;
+    alternative_type alternative_storage[max_alternatives];
 };
 
-}
+} // namespace mapnik
 
-#endif // MAPNIK_IMAGE_FILITER_PARSER_HPP
+#endif // MAPNIK_IMAGE_FILTER_GRAMMAR_HPP

--- a/test/unit/imaging/image_filter.cpp
+++ b/test/unit/imaging/image_filter.cpp
@@ -434,8 +434,11 @@ SECTION("test colorize-alpha - parsing correct input") {
 
     std::string s("colorize-alpha(#0000ff 0%, #00ff00 100%)");
     std::vector<mapnik::filter::filter_type> f;
-    CHECK(parse_image_filters(s, f));
+    REQUIRE(parse_image_filters(s, f));
     mapnik::filter::colorize_alpha const & ca = mapnik::util::get<mapnik::filter::colorize_alpha>(f.front());
+    CHECK(ca.size() == 2);
+
+    CHECKED_IF(ca.size() > 0)
     {
         mapnik::filter::color_stop const & s2 = ca[0];
         CHECK( s2.color.alpha() == 0xff );
@@ -445,6 +448,7 @@ SECTION("test colorize-alpha - parsing correct input") {
         CHECK( s2.offset == 0.0 );
     }
 
+    CHECKED_IF(ca.size() > 1)
     {
         mapnik::filter::color_stop const & s2 = ca[1];
         CHECK( s2.color.alpha() == 0xff );


### PR DESCRIPTION
~~The important part is the extern explicit instantiation declaration in the second commit, it removes the need to include `_grammar_impl.hpp` from `test/unit/imaging/image_filter.cpp` and thus cuts its compile time in half: 5-6 minutes [before](https://travis-ci.org/lightmare/mapnik/jobs/106030393#L1446), 2-3 minutes [after](https://travis-ci.org/lightmare/mapnik/jobs/106041585#L1392).~~
edit: solved better by @artemp in https://github.com/mapnik/mapnik/commit/13af423046c9d7fe56a9f02688876d5e3b33da6d?w=1

~~The first commit contains only minor simplifications I made before figuring out the extern cuts it.
These (for me locally, linux/clang) reduced `src/image_filter_grammar.cpp` compilation time from 17.5s to 16s, and memory usage from 608MB to 573MB.~~