### PR TITLE
restrict barewords (unquoted strings) in expression grammar

### DIFF
--- a/test/unit/core/expressions_test.cpp
+++ b/test/unit/core/expressions_test.cpp
@@ -62,6 +62,9 @@ TEST_CASE("expressions")
 
     properties_type prop = {{ "foo"   , tr.transcode("bar") },
                             { "name"  , tr.transcode("Québec")},
+                            { "grass" , tr.transcode("grow")},
+                            { "wind"  , tr.transcode("blow")},
+                            { "sky"   , tr.transcode("is blue")},
                             { "double", mapnik::value_double(1.23456)},
                             { "int"   , mapnik::value_integer(123)},
                             { "bool"  , mapnik::value_bool(true)},
@@ -134,6 +137,20 @@ TEST_CASE("expressions")
     // logical
     TRY_CHECK(eval(" [int] = 123 and [double] = 1.23456 && [bool] = true and [null] = null && [foo] = 'bar' ") == true);
     TRY_CHECK(eval(" [int] = 456 or [foo].match('foo') || length([foo]) = 3 ") == true);
+    TRY_CHECK(eval(" not true  and not true  ") == eval(" (not true ) and (not true ) "));
+    TRY_CHECK(eval(" not true  or  not true  ") == eval(" (not true ) or  (not true ) "));
+    TRY_CHECK(eval(" not false and not false ") == eval(" (not false) and (not false) "));
+    TRY_CHECK(eval(" not false or  not false ") == eval(" (not false) or  (not false) "));
+
+    // test not/and/or precedence using combinations of "not EQ1 OP1 not EQ2 OP2 not EQ3"
+    TRY_CHECK(eval(" not [grass] = 'grow' and not [wind] = 'blow' and not [sky] = 'is blue' ") == false);
+    TRY_CHECK(eval(" not [grass] = 'grow' and not [wind] = 'blow' or  not [sky] = 'is blue' ") == false);
+    TRY_CHECK(eval(" not [grass] = 'grow' or  not [wind] = 'blow' and not [sky] = 'is blue' ") == false);
+    TRY_CHECK(eval(" not [grass] = 'grow' or  not [wind] = 'blow' or  not [sky] = 'is blue' ") == false);
+    TRY_CHECK(eval(" not [grass] = 'grew' and not [wind] = 'blew' and not [sky] = 'was blue' ") == true);
+    TRY_CHECK(eval(" not [grass] = 'grew' and not [wind] = 'blew' or  not [sky] = 'was blue' ") == true);
+    TRY_CHECK(eval(" not [grass] = 'grew' or  not [wind] = 'blew' and not [sky] = 'was blue' ") == true);
+    TRY_CHECK(eval(" not [grass] = 'grew' or  not [wind] = 'blew' or  not [sky] = 'was blue' ") == true);
 
     // relational
     TRY_CHECK(eval(" [int] > 100 and [int] gt 100.0 and [double] < 2 and [double] lt 2.0 ") == true);


### PR DESCRIPTION
It's not barewords per se that break the logical `not` operator, it's [this line](https://github.com/mapnik/mapnik/commit/6a51c6e7f6fe784d93332fd48657b2dde77ce020#diff-1e2ad6c59a4d7152bb76fc8547a9a796L191) actually -- `not expr` is not a `primary_expr`, this line makes `not x op y` be parsed as `not (x op y)`, in other words, giving `not` the lowest possible precedence.

But as I wrote in #3214, barewords are not future-proof, their use should be restricted and it's easier to just remove them.

Btw, in current master, this check passes:
```c++
TRY_CHECK(eval(" not not = not not ") == true);
```
The expression is parsed as `not ('not' = not 'not')`. The first `not` is grabbed by the evil line I linked above, the second is tried by that line, but `= not not` fails to match `expr` so it backtracks and matches `ustring`. The third `not` is grabbed by the evil line again, and the last by `ustring`. The second alternative in the `not_expr` rule higher in the grammar is never used.
