### PR TITLE
remove to_utf8, instead use UnicodeString::toUTF8String

### DIFF
--- a/include/mapnik/value.hpp
+++ b/include/mapnik/value.hpp
@@ -43,30 +43,7 @@
 #include <unicode/unistr.h>
 #include <unicode/ustring.h>
 
-namespace mapnik  {
-
-inline void to_utf8(mapnik::value_unicode_string const& input, std::string & target)
-{
-    if (input.isEmpty()) return;
-
-    const int BUF_SIZE = 256;
-    char buf [BUF_SIZE];
-    int len;
-
-    UErrorCode err = U_ZERO_ERROR;
-    u_strToUTF8(buf, BUF_SIZE, &len, input.getBuffer(), input.length(), &err);
-    if (err == U_BUFFER_OVERFLOW_ERROR || err == U_STRING_NOT_TERMINATED_WARNING )
-    {
-        const std::unique_ptr<char[]> buf_ptr(new char [len+1]);
-        err = U_ZERO_ERROR;
-        u_strToUTF8(buf_ptr.get() , len + 1, &len, input.getBuffer(), input.length(), &err);
-        target.assign(buf_ptr.get() , static_cast<std::size_t>(len));
-    }
-    else
-    {
-        target.assign(buf, static_cast<std::size_t>(len));
-    }
-}
+namespace mapnik {
 
 using value_base = util::variant<value_null, value_bool, value_integer,value_double, value_unicode_string>;
 
@@ -582,7 +559,7 @@ struct convert<value_double>
     value_double operator() (value_unicode_string const& val) const
     {
         std::string utf8;
-        to_utf8(val,utf8);
+        val.toUTF8String(utf8);
         return operator()(utf8);
     }
 
@@ -621,7 +598,7 @@ struct convert<value_integer>
     value_integer operator() (value_unicode_string const& val) const
     {
         std::string utf8;
-        to_utf8(val,utf8);
+        val.toUTF8String(utf8);
         return operator()(utf8);
     }
 
@@ -646,7 +623,7 @@ struct convert<std::string>
     std::string operator() (value_unicode_string const& val) const
     {
         std::string utf8;
-        to_utf8(val,utf8);
+        val.toUTF8String(utf8);
         return utf8;
     }
 
@@ -664,7 +641,7 @@ struct convert<std::string>
 
     std::string operator() (value_null const&) const
     {
-        return "";
+        return std::string();
     }
 };
 
@@ -694,17 +671,12 @@ struct to_unicode_impl
 
     value_unicode_string operator() (value_bool val) const
     {
-        if (val) {
-            std::string str("true");
-            return value_unicode_string(str.c_str());
-        }
-        std::string str("false");
-        return value_unicode_string(str.c_str());
+        return value_unicode_string(val ? "true" : "false");
     }
 
     value_unicode_string operator() (value_null const&) const
     {
-        return value_unicode_string("");
+        return value_unicode_string();
     }
 };
 

--- a/src/expression_node.cpp
+++ b/src/expression_node.cpp
@@ -37,6 +37,14 @@
 namespace mapnik
 {
 
+#if defined(BOOST_REGEX_HAS_ICU)
+static void fromUTF32toUTF8(std::basic_string<UChar32> const& src, std::string & dst)
+{
+    int32_t len = safe_cast<int32_t>(src.length());
+    value_unicode_string::fromUTF32(src.data(), len).toUTF8String(dst);
+}
+#endif
+
 struct _regex_match_impl : util::noncopyable {
 #if defined(BOOST_REGEX_HAS_ICU)
     _regex_match_impl(value_unicode_string const& ustr) :
@@ -94,10 +102,7 @@ std::string regex_match_node::to_string() const
     str_ +=".match('";
     auto const& pattern = impl_.get()->pattern_;
 #if defined(BOOST_REGEX_HAS_ICU)
-    std::string utf8;
-    value_unicode_string ustr = value_unicode_string::fromUTF32( &pattern.str()[0], safe_cast<int>(pattern.str().length()));
-    to_utf8(ustr,utf8);
-    str_ += utf8;
+    fromUTF32toUTF8(pattern.str(), str_);
 #else
     str_ += pattern.str();
 #endif
@@ -141,13 +146,9 @@ std::string regex_replace_node::to_string() const
     auto const& pattern = impl_.get()->pattern_;
     auto const& format = impl_.get()->format_;
 #if defined(BOOST_REGEX_HAS_ICU)
-    std::string utf8;
-    value_unicode_string ustr = value_unicode_string::fromUTF32( &pattern.str()[0], safe_cast<int>(pattern.str().length()));
-    to_utf8(ustr,utf8);
-    str_ += utf8;
+    fromUTF32toUTF8(pattern.str(), str_);
     str_ +="','";
-    to_utf8(format ,utf8);
-    str_ += utf8;
+    format.toUTF8String(str_);
 #else
     str_ += pattern.str();
     str_ +="','";


### PR DESCRIPTION
 - removes `mapnik::to_utf8`
 - the substitute used isn't exactly equivalent
   - `to_utf8` called `u_strToUTF8`, replaced destination string (:bug:)
   - `UnicodeString::toUTF8String` calls `u_strToUTF8WithSub`, appends to destination string

According to the docs `toUTF8String` is @stable ICU 4.2.

Additionally there are some minor string construction optimizations.

(:bug:) but didn't clear it if source was empty