### PR TITLE
various benchmark framework tweaks

### DIFF
--- a/benchmark/bench_framework.hpp
+++ b/benchmark/bench_framework.hpp
@@ -186,6 +186,34 @@ int run(T const& test_runner, std::string const& name)
     return 0;
 }
 
+struct sequencer
+{
+    sequencer(int argc, char** argv)
+      : exit_code_(0)
+    {
+        benchmark::handle_args(argc, argv, params_);
+    }
+
+    int done() const
+    {
+        return exit_code_;
+    }
+
+    template <typename Test, typename... Args>
+    sequencer & run(std::string const& name, Args && ...args)
+    {
+        // Test instance lifetime is confined to this function
+        Test test_runner(params_, std::forward<Args>(args)...);
+        // any failing test run will make exit code non-zero
+        exit_code_ |= benchmark::run(test_runner, name);
+        return *this; // allow chaining calls
+    }
+
+protected:
+    mapnik::parameters params_;
+    int exit_code_;
+};
+
 }
 
 #endif // __MAPNIK_BENCH_FRAMEWORK_HPP__

--- a/benchmark/bench_framework.hpp
+++ b/benchmark/bench_framework.hpp
@@ -9,7 +9,7 @@
 
 // stl
 #include <chrono>
-#include <iomanip>
+#include <cstdio> // snprintf
 #include <iostream>
 #include <set>
 #include <sstream>
@@ -96,11 +96,7 @@ int run(T const& test_runner, std::string const& name)
         {
             std::chrono::high_resolution_clock::time_point start;
             std::chrono::high_resolution_clock::duration elapsed;
-            std::stringstream s;
-            s << name << ":"
-                << std::setw(45 - (int)s.tellp()) << std::right
-                << " t:" << test_runner.threads()
-                << " i:" << test_runner.iterations();
+
             if (test_runner.threads() > 0)
             {
                 using thread_group = std::vector<std::unique_ptr<std::thread> >;
@@ -120,9 +116,15 @@ int run(T const& test_runner, std::string const& name)
                 test_runner();
                 elapsed = std::chrono::high_resolution_clock::now() - start;
             }
-            s << std::setw(65 - (int)s.tellp()) << std::right
-                << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() << " milliseconds\n";
-            std::clog << s.str();
+
+            char msg[200];
+            std::snprintf(msg, sizeof(msg),
+                    "%-43s %3zu threads %9zu iters %6.0f milliseconds",
+                    name.c_str(),
+                    test_runner.threads(),
+                    test_runner.iterations(),
+                    std::chrono::duration<double, std::milli>(elapsed).count());
+            std::clog << msg << "\n";
         }
         return 0;
     }

--- a/benchmark/test_array_allocation.cpp
+++ b/benchmark/test_array_allocation.cpp
@@ -231,33 +231,6 @@ public:
     }
 };
 
-class test3d : public benchmark::test_case
-{
-public:
-    uint32_t size_;
-    std::vector<uint8_t> array_;
-    test3d(mapnik::parameters const& params)
-     : test_case(params),
-       size_(*params.get<mapnik::value_integer>("size",256*256)),
-       array_(size_,0) { }
-    bool validate() const
-    {
-        return true;
-    }
-    bool operator()() const
-    {
-         for (std::size_t i=0;i<iterations_;++i) {
-             std::deque<uint8_t> data(size_);
-             for (std::size_t i=0;i<size_;++i) {
-                 if (data[i] != 0) {
-                     throw std::runtime_error("found non zero value");
-                 }
-             }
-         }
-         return true;
-    }
-};
-
 class test4 : public benchmark::test_case
 {
 public:

--- a/benchmark/test_array_allocation.cpp
+++ b/benchmark/test_array_allocation.cpp
@@ -359,62 +359,21 @@ public:
 
 int main(int argc, char** argv)
 {
-    int return_value = 0;
-    mapnik::parameters params;
-    benchmark::handle_args(argc,argv,params);
-    {
-        test4 test_runner4(params);
-        return_value = return_value | run(test_runner4,"calloc");
-    }
-    {
-        test1 test_runner(params);
-        return_value = return_value | run(test_runner,"malloc/memcpy");
-    }
-    {
-        test1b test_runner(params);
-        return_value = return_value | run(test_runner,"malloc/memset");
-    }
-    {
-        test1c test_runner(params);
-        return_value = return_value | run(test_runner,"operator new/std::fill");
-    }
-    {
-        test2 test_runner(params);
-        return_value = return_value | run(test_runner,"operator new/memcpy");
-    }
-    {
-        test3 test_runner(params);
-        return_value = return_value | run(test_runner,"vector(N)");
-    }
-    {
-        test3b test_runner(params);
-        return_value = return_value | run(test_runner,"vector/resize");
-    }
-    {
-        test3c test_runner(params);
-        return_value = return_value | run(test_runner,"vector/assign");
-    }
-    {
-        test3d test_runner(params);
-        return_value = return_value | run(test_runner,"deque(N)");
-    }
-    {
-        test5 test_runner(params);
-        return_value = return_value | run(test_runner,"std::string range");
-    }
-    {
-        test5b test_runner(params);
-        return_value = return_value | run(test_runner,"std::string &[0]");
-    }
-    {
-        test6 test_runner(params);
-        return_value = return_value | run(test_runner,"valarray");
-    }
+    return benchmark::sequencer(argc, argv)
+        .run<test4>("calloc")
+        .run<test1>("malloc/memcpy")
+        .run<test1b>("malloc/memset")
+        .run<test1c>("operator new/std::fill")
+        .run<test2>("operator new/memcpy")
+        .run<test3>("vector(N)")
+        .run<test3b>("vector/resize")
+        .run<test3c>("vector/assign")
+        .run<test3d>("deque(N)")
+        .run<test5>("std::string range")
+        .run<test5b>("std::string &[0]")
+        .run<test6>("valarray")
 #if BOOST_VERSION >= 105400
-    {
-        test7 test_runner(params);
-        return_value = return_value | run(test_runner,"static_vector");
-    }
+        .run<test7>("static_vector")
 #endif
-    return return_value;
+        .done();
 }

--- a/benchmark/test_numeric_cast_vs_static_cast.cpp
+++ b/benchmark/test_numeric_cast_vs_static_cast.cpp
@@ -73,16 +73,8 @@ public:
 
 int main(int argc, char** argv)
 {
-    mapnik::parameters params;
-    benchmark::handle_args(argc,argv,params);
-    int return_value = 0;
-    {
-        test_static test_runner(params);
-        return_value = return_value | run(test_runner,"static_cast");
-    }
-    {
-        test_numeric test_runner(params);
-        return_value = return_value | run(test_runner,"numeric_cast");
-    }
-    return return_value;
+    return benchmark::sequencer(argc, argv)
+        .run<test_static>("static_cast")
+        .run<test_numeric>("numeric_cast")
+        .done();
 }

--- a/benchmark/test_png_encoding1.cpp
+++ b/benchmark/test_png_encoding1.cpp
@@ -19,8 +19,8 @@ public:
             out.clear();
             out = mapnik::save_to_string(im_,"png8:m=h:z=1");
         }
+        return true;
     }
-    return true;
 };
 
 BENCHMARK(test,"encoding blank png")

--- a/benchmark/test_png_encoding2.cpp
+++ b/benchmark/test_png_encoding2.cpp
@@ -30,8 +30,8 @@ public:
             out.clear();
             out = mapnik::save_to_string(*im_,"png8:m=h:z=1");
         }
+        return true;
     }
-    return true;
 };
 
 BENCHMARK(test,"encoding multicolor png")

--- a/benchmark/test_polygon_clipping_rendering.cpp
+++ b/benchmark/test_polygon_clipping_rendering.cpp
@@ -51,30 +51,10 @@ int main(int argc, char** argv)
     mapnik::box2d<double> z1(-20037508.3428,-8317435.0606,20037508.3428,18399242.7298);
     // bbox for 16/10491/22911.png
     mapnik::box2d<double> z16(-13622912.929097254,6026906.8062295765,-13621689.93664469,6028129.79868214);
-    int return_value = 0;
-    {
-        test test_runner(params,
-                          "benchmark/data/polygon_rendering_clip.xml",
-                          z1);
-        return_value = return_value | run(test_runner,"polygon clip render z1");
-    }
-    {
-        test test_runner(params,
-                          "benchmark/data/polygon_rendering_no_clip.xml",
-                          z1);
-        return_value = return_value | run(test_runner,"polygon noclip render z1");
-    }
-    {
-        test test_runner(params,
-                          "benchmark/data/polygon_rendering_clip.xml",
-                          z16);
-        return_value = return_value | run(test_runner,"polygon clip render z16");
-    }
-    {
-        test test_runner(params,
-                          "benchmark/data/polygon_rendering_no_clip.xml",
-                          z16);
-        return_value = return_value | run(test_runner,"polygon noclip render z16");
-    }
-    return return_value;
+    return benchmark::sequencer(argc, argv)
+        .run<test>("polygon clip render z1", "benchmark/data/polygon_rendering_clip.xml", z1)
+        .run<test>("polygon noclip render z1", "benchmark/data/polygon_rendering_no_clip.xml", z1)
+        .run<test>("polygon clip render z16", "benchmark/data/polygon_rendering_clip.xml", z16)
+        .run<test>("polygon noclip render z16", "benchmark/data/polygon_rendering_no_clip.xml", z16)
+        .done();
 }

--- a/benchmark/test_proj_transform1.cpp
+++ b/benchmark/test_proj_transform1.cpp
@@ -59,42 +59,16 @@ public:
 // echo -180 -60 | cs2cs -f "%.10f" +init=epsg:4326 +to +init=epsg:3857
 int main(int argc, char** argv)
 {
-    mapnik::parameters params;
-    benchmark::handle_args(argc,argv,params);
     mapnik::box2d<double> from(-180,-80,180,80);
     mapnik::box2d<double> to(-20037508.3427892476,-15538711.0963092316,20037508.3427892476,15538711.0963092316);
     std::string from_str("+init=epsg:4326");
     std::string to_str("+init=epsg:3857");
     std::string from_str2("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs");
     std::string to_str2("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over");
-    int return_value = 0;
-    test test_runner(params,
-                     from_str,
-                     to_str,
-                     from,
-                     to,
-                     true);
-    return_value = return_value | run(test_runner,"lonlat->merc epsg");
-    test test_runner2(params,
-                     from_str2,
-                     to_str2,
-                     from,
-                     to,
-                     true);
-    return_value = return_value | run(test_runner2,"lonlat->merc literal");
-    test test_runner3(params,
-                     to_str,
-                     from_str,
-                     to,
-                     from,
-                     true);
-    return_value = return_value | run(test_runner3,"merc->lonlat epsg");
-    test test_runner4(params,
-                     to_str2,
-                     from_str2,
-                     to,
-                     from,
-                     true);
-    return_value = return_value | run(test_runner4,"merc->lonlat literal");
-    return return_value;
+    return benchmark::sequencer(argc, argv)
+        .run<test>("lonlat->merc epsg", from_str, to_str, from, to, true)
+        .run<test>("lonlat->merc literal", from_str2, to_str2, from, to, true)
+        .run<test>("merc->lonlat epsg", to_str, from_str, to, from, true)
+        .run<test>("merc->lonlat literal", to_str2, from_str2, to, from, true)
+        .done();
 }


### PR DESCRIPTION
This changes a few minor things in benchmarks:
 - fixes (read: completely changes) output formatting
   - with gcc it looked like this:
```
// before
std::getline:                                           t:0 i:1000000083 milliseconds
csv_utils::getline_csv:                                           t:0 i:1000000073 milliseconds
std::getline:                                           t:30 i:33333343 milliseconds
csv_utils::getline_csv:                                           t:30 i:33333342 milliseconds

// after
std::getline                                  0 threads   10M iters     86 milliseconds 8553ps/iter
csv_utils::getline_csv                        0 threads   10M iters     84 milliseconds 8396ps/iter
std::getline                                 30 threads  333k iters     47 milliseconds
csv_utils::getline_csv                       30 threads  333k iters     43 milliseconds
```
 - adds option `--log-severity=debug|warn|error|none`
   - when mapnik was compiled with spammy default log severity, benchmarks were basically measuring console throughput :dash: and no way to turn it off
 - adds option `--min-duration=SECONDS`
   - the test loop will run repeatedly until that amount of time elapses
   - may help getting smoother averages when the specified number of iterations finishes too fast
 - adds a chain & ball class for running tests in sequence
   - I modified some existing benchmarks that run multiple tests to show it off :tada: 

