### PR TITLE
move some shell code from .travis.yml to separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
       env: JOBS=8 COVERAGE=true HEAVY_JOBS=3
 
 before_install:
+ - source scripts/travis-common.sh
  - export PYTHONUSERBASE=$(pwd)/mason_packages/.link
  - export PATH=${PYTHONUSERBASE}/bin:${PATH}
  - export COVERAGE=${COVERAGE:-false}
@@ -59,57 +60,34 @@ before_install:
  - export BENCH=${BENCH:-false}
  - if [[ ${TRAVIS_BRANCH} != 'master' ]]; then export MASON_PUBLISH=false; fi
  - if [[ ${TRAVIS_PULL_REQUEST} != 'false' ]]; then export MASON_PUBLISH=false; fi
- - git submodule update --init --depth=10 ||
-     git submodule foreach 'test "$sha1" = "`git rev-parse HEAD`" ||
-                            git ls-remote origin "refs/pull/*/head" |
-                            while read hash ref; do
-                                if test "$hash" = "$sha1"; then
-                                    git config --add remote.origin.fetch "+$ref:$ref";
-                                fi
-                            done'
- - git submodule update --init --depth=10
+ - git_submodule_update --init --depth=10
 
 install:
- - if [[ $(uname -s) == 'Linux' ]]; then
-     export PYTHONPATH=${PYTHONUSERBASE}/lib/python2.7/site-packages;
-   else
-     brew rm postgis --force;
-     brew install postgis --force;
-     pg_ctl -w start -l postgres.log --pgdata /usr/local/var/postgres;
-     createuser -s postgres;
-     export PYTHONPATH=${PYTHONUSERBASE}/lib/python/site-packages;
-   fi
- - psql -c 'create database template_postgis;' -U postgres;
- - psql -c 'create extension postgis;' -d template_postgis -U postgres;
- - if [[ ${COVERAGE} == true ]]; then
-     if [[ ! $(which pip) ]]; then easy_install --user pip && export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}; fi;
-     pip install --user cpp-coveralls;
-   fi
+ - on 'linux' export PYTHONPATH=${PYTHONUSERBASE}/lib/python2.7/site-packages
+ - on 'osx' export PYTHONPATH=${PYTHONUSERBASE}/lib/python/site-packages
+ - on 'osx' brew rm postgis --force
+ - on 'osx' brew install postgis --force
+ - on 'osx' pg_ctl -w start -l postgres.log --pgdata /usr/local/var/postgres
+ - on 'osx' createuser -s postgres
+ - psql -c 'create database template_postgis;' -U postgres
+ - psql -c 'create extension postgis;' -d template_postgis -U postgres
+ - enabled ${COVERAGE} pip install --user cpp-coveralls
+
+before_script:
+ - source bootstrap.sh
+ - commit_message_parse
 
 script:
- - source bootstrap.sh
- - if [[ ${COVERAGE} == true ]]; then
-     ./configure PGSQL2SQLITE=False SVG2PNG=False SAMPLE_INPUT_PLUGINS=False SVG_RENDERER=False BENCHMARK=${BENCH} CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' CUSTOM_CFLAGS='--coverage' DEBUG=True;
-   elif [[ ${MASON_PUBLISH} == true ]]; then
-     export MASON_NAME=mapnik;
-     export MASON_VERSION=latest;
-     export MASON_LIB_FILE=lib/libmapnik-wkt.a;
-     source ./.mason/mason.sh;
-     ./configure BENCHMARK=${BENCH} PREFIX=${MASON_PREFIX} PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True RUNTIME_LINK='static';
-   else
-     ./configure BENCHMARK=${BENCH};
-   fi
- - SCONSFLAGS='--debug=time' make
- - make test || TEST_RESULT=$?
- - if [[ ${COVERAGE} == true ]]; then
-     ./mason_packages/.link/bin/cpp-coveralls --build-root . --gcov-options '\-lp' --exclude mason_packages --exclude .sconf_temp --exclude benchmark --exclude deps --exclude scons --exclude test --exclude demo --exclude docs --exclude fonts --exclude utils > /dev/null; 
-   fi
- - if [[ ${BENCH} == True ]]; then
-     make bench;
-   fi
- - if [[ ${TEST_RESULT:-0} != 0 ]]; then exit $TEST_RESULT ; fi;
- - if [[ ${MASON_PUBLISH} == true ]]; then
-     ./mason_latest.sh build;
-     ./mason_latest.sh link;
+ - export SCONSFLAGS='--debug=time'
+ - configure BENCHMARK=${BENCH}
+ - make
+ - make test
+ - enabled ${COVERAGE} coverage
+ - enabled ${BENCH} make bench
+
+after_success:
+ - if enabled ${MASON_PUBLISH}; then
+     ./mason_latest.sh build &&
+     ./mason_latest.sh link &&
      ./mason_latest.sh publish;
    fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -112,7 +112,6 @@ CPP_TESTS = True
 PGSQL2SQLITE = True
 XMLPARSER = 'ptree'
 SVG2PNG = True
-SAMPLE_INPUT_PLUGINS = True
 "
 }
 

--- a/scripts/travis-common.sh
+++ b/scripts/travis-common.sh
@@ -1,0 +1,109 @@
+#! /bin/bash
+
+# enabled VALUE
+#   - if VALUE is empty or falsy, returns 1 (false)
+#   - otherwise returns 0 (true)
+# enabled VALUE COMMAND ...
+#   - if VALUE is empty or falsy, returns 0 (true)
+#   - otherwise runs COMMAND and returns its result
+enabled () {
+    local value="$1"; shift
+    case $value in
+        ''|'0'|[Ff]alse|[Nn]o) test $# -ne 0;;
+        *) test $# -eq 0 || "$@";;
+    esac
+}
+
+# on NAME
+#   - if NAME == $TRAVIS_OS_NAME, returns 0 (true)
+#   - otherwise returns 1 (false)
+# on NAME COMMAND ...
+#   - if NAME == $TRAVIS_OS_NAME, runs COMMAND and returns its result
+#   - otherwise returns 0 (true)
+on () {
+    local name="$1"; shift
+    case $name in
+        $TRAVIS_OS_NAME) test $# -eq 0 || "$@";;
+        *) test $# -ne 0;;
+    esac
+}
+
+git_submodule_update () {
+    git submodule update "$@" && return
+    # failed, search pull requests for matching commits
+    git submodule foreach \
+        '
+        test "$sha1" = "`git rev-parse HEAD`" ||
+        git ls-remote origin "refs/pull/*/head" |
+        while read hash ref; do
+            if test "$hash" = "$sha1"; then
+                git config --add remote.origin.fetch "+$ref:$ref";
+            fi
+        done
+        '
+    # try again with added fetch refs
+    git submodule update "$@"
+}
+
+# install and call pip
+pip () {
+    if ! which pip >/dev/null; then
+        easy_install --user pip && \
+        export PATH="$HOME/Library/Python/2.7/bin:$PATH"
+    fi
+    command pip "$@"
+}
+
+# commit_message_contains TEXT
+#   - returns 0 (true) if TEXT is found in commit message
+#   - case-insensitive, plain-text search, not regex
+commit_message_contains () {
+    git log -1 --pretty='%B' "$TRAVIS_COMMIT" | grep -qiFe "$*"
+}
+
+commit_message_parse () {
+    if commit_message_contains '[skip tests]'; then
+        config_override "CPP_TESTS = False"
+    fi
+    if commit_message_contains '[skip utils]'; then
+        config_override "MAPNIK_INDEX = False"
+        config_override "MAPNIK_RENDER = False"
+        config_override "PGSQL2SQLITE = False"
+        config_override "SHAPEINDEX = False"
+        config_override "SVG2PNG = False"
+    fi
+}
+
+config_override () {
+    echo "Appending to config.py:" "$@"
+    echo "$@" >> ./config.py
+}
+
+configure () {
+    if enabled ${COVERAGE}; then
+        ./configure "$@" PGSQL2SQLITE=False SVG2PNG=False SVG_RENDERER=False \
+            CUSTOM_LDFLAGS='--coverage' CUSTOM_CXXFLAGS='--coverage' \
+            CUSTOM_CFLAGS='--coverage' DEBUG=True
+    elif enabled ${MASON_PUBLISH}; then
+        export MASON_NAME=mapnik
+        export MASON_VERSION=latest
+        export MASON_LIB_FILE=lib/libmapnik-wkt.a
+        source ./.mason/mason.sh
+        ./configure "$@" PREFIX=${MASON_PREFIX} \
+            PATH_REPLACE='' MAPNIK_BUNDLED_SHARE_DIRECTORY=True \
+            RUNTIME_LINK='static'
+    else
+        ./configure "$@"
+    fi
+    # print final config values, sorted and indented
+    sort -sk1,1 ./config.py | sed -e 's/^/	/'
+}
+
+coverage () {
+    ./mason_packages/.link/bin/cpp-coveralls \
+        --build-root . --gcov-options '\-lp' --exclude mason_packages \
+        --exclude .sconf_temp --exclude benchmark --exclude deps \
+        --exclude scons --exclude test --exclude demo --exclude docs \
+        --exclude fonts --exclude utils \
+        > /dev/null
+}


### PR DESCRIPTION
- refs #3291 


`scripts/travis-common.sh` contains only functions, is sourced `before_install`

 - moved 3 long if-blocks from `.travis.yml` to functions
   - git_submodule_update
   - configure
   - coverage

 - added utility functions for short one-line conditionals within `.travis.yml`
   - `on 'OSNAME'` https://github.com/mapnik/mapnik/commit/efb06d2060f6305d29a8122bd93ae5e73a3d08a5#diff-354f30a63fb0907d4ad57269548329e3R66
   - `enabled $ENVVAR` https://github.com/mapnik/mapnik/commit/efb06d2060f6305d29a8122bd93ae5e73a3d08a5#diff-354f30a63fb0907d4ad57269548329e3R74

 - added the ability to `[skip tests]` and `[skip utils]` via commit message
   - this may be used to populate cache when full build runs overtime
   - skipping any of these should be safe as it will fail `make test` and thus prevent mason publish

 - moved mason publish block to `after_success` step, with `&&` between commands rather than just `;`

 - removed obsolete `SAMPLE_INPUT_PLUGINS` config option
