### PR TITLE
Lazily demultiply part one -- saving

### DIFF
--- a/deps/agg/include/agg_pixfmt_rgba.h
+++ b/deps/agg/include/agg_pixfmt_rgba.h
@@ -56,7 +56,6 @@ template<class ColorT, class Order> struct multiplier_rgba
         }
     }
 
-
     //--------------------------------------------------------------------
     static AGG_INLINE void demultiply(value_type* p)
     {
@@ -75,6 +74,64 @@ template<class ColorT, class Order> struct multiplier_rgba
             p[Order::G] = value_type((g > ColorT::base_mask) ? ColorT::base_mask : g);
             p[Order::B] = value_type((b > ColorT::base_mask) ? ColorT::base_mask : b);
         }
+    }
+};
+
+//========================================================multiplier2_rgba
+template<class ColorT, class Order, class Order2 = Order> struct multiplier2_rgba
+{
+    typedef typename ColorT::value_type value_type;
+    typedef typename ColorT::calc_type calc_type;
+
+    //--------------------------------------------------------------------
+    static AGG_INLINE void premultiply(value_type* p, const value_type* q)
+    {
+        calc_type a = q[Order2::A];
+        if(a < ColorT::base_mask)
+        {
+            if(a == 0)
+            {
+                p[Order::R] = p[Order::G] = p[Order::B] = p[Order::A] = 0;
+                return;
+            }
+            p[Order::R] = value_type((q[Order2::R] * a + ColorT::base_mask) >> ColorT::base_shift);
+            p[Order::G] = value_type((q[Order2::G] * a + ColorT::base_mask) >> ColorT::base_shift);
+            p[Order::B] = value_type((q[Order2::B] * a + ColorT::base_mask) >> ColorT::base_shift);
+        }
+        else
+        {
+            p[Order::R] = q[Order2::R];
+            p[Order::G] = q[Order2::G];
+            p[Order::B] = q[Order2::B];
+        }
+        p[Order::A] = value_type(a);
+    }
+
+    //--------------------------------------------------------------------
+    static AGG_INLINE void demultiply(value_type* p, const value_type* q)
+    {
+        calc_type a = q[Order2::A];
+        if(a < ColorT::base_mask)
+        {
+            if(a == 0)
+            {
+                p[Order::R] = p[Order::G] = p[Order::B] = p[Order::A] = 0;
+                return;
+            }
+            calc_type r = (calc_type(q[Order2::R]) * ColorT::base_mask) / a;
+            calc_type g = (calc_type(q[Order2::G]) * ColorT::base_mask) / a;
+            calc_type b = (calc_type(q[Order2::B]) * ColorT::base_mask) / a;
+            p[Order::R] = value_type((r > ColorT::base_mask) ? ColorT::base_mask : r);
+            p[Order::G] = value_type((g > ColorT::base_mask) ? ColorT::base_mask : g);
+            p[Order::B] = value_type((b > ColorT::base_mask) ? ColorT::base_mask : b);
+        }
+        else
+        {
+            p[Order::R] = q[Order2::R];
+            p[Order::G] = q[Order2::G];
+            p[Order::B] = q[Order2::B];
+        }
+        p[Order::A] = value_type(a);
     }
 };
 

--- a/include/mapnik/image.hpp
+++ b/include/mapnik/image.hpp
@@ -106,6 +106,7 @@ public:
     std::size_t height() const;
     std::size_t size() const;
     std::size_t row_size() const;
+    std::size_t row_stride() const;
     void set(pixel_type const& t);
     pixel_type const* data() const;
     pixel_type* data();

--- a/include/mapnik/image_impl.hpp
+++ b/include/mapnik/image_impl.hpp
@@ -188,6 +188,12 @@ inline std::size_t image<T>::row_size() const
 }
 
 template <typename T>
+inline std::size_t image<T>::row_stride() const
+{
+    return dimensions_.width() * pixel_size;
+}
+
+template <typename T>
 inline void image<T>::set(pixel_type const& t)
 {
     std::fill(pData_, pData_ + dimensions_.width() * dimensions_.height(), t);

--- a/include/mapnik/image_util.hpp
+++ b/include/mapnik/image_util.hpp
@@ -27,6 +27,7 @@
 #include <mapnik/config.hpp>
 #include <mapnik/pixel_types.hpp>
 #include <mapnik/image_compositing.hpp>
+#include <mapnik/image_null.hpp>
 
 #pragma GCC diagnostic push
 #include <mapnik/warning_ignore.hpp>
@@ -128,6 +129,34 @@ MAPNIK_DECL void set_premultiplied_alpha(image_any & image, bool status);
 
 template <typename T>
 MAPNIK_DECL void set_premultiplied_alpha(T & image, bool status);
+
+//----------------------------------------------------------------------
+// copy_image
+
+template <typename ImageT>
+ImageT copy_image(ImageT const& src)
+{
+    return src;
+}
+
+template <typename ImageT>
+ImageT copy_image(image_view<ImageT> const& src)
+{
+    ImageT dst(src.width(), src.height(), false, src.get_premultiplied());
+    for (std::size_t y = 0; y < src.height(); ++y)
+    {
+        dst.set_row(y, src.get_row(y), src.width());
+    }
+    return dst;
+}
+
+template <> inline
+image_null copy_image(image_view<image_null> const& src)
+{
+    return image_null();
+}
+
+MAPNIK_DECL image_any copy_image(image_view_any const& src);
 
 // IS SOLID
 MAPNIK_DECL bool is_solid (image_any const& image);

--- a/include/mapnik/image_view.hpp
+++ b/include/mapnik/image_view.hpp
@@ -48,6 +48,7 @@ public:
     pixel_type const& operator() (std::size_t i, std::size_t j) const;
     std::size_t size() const;
     std::size_t row_size() const;
+    std::size_t row_stride() const;
     pixel_type const* get_row(std::size_t row) const;
     pixel_type const* get_row(std::size_t row, std::size_t x0) const;
     T const& data() const;

--- a/include/mapnik/image_view_any.hpp
+++ b/include/mapnik/image_view_any.hpp
@@ -44,12 +44,17 @@ using image_view_base = util::variant<image_view_null,
 
 struct MAPNIK_DECL image_view_any : image_view_base
 {
+    // inherit constructors from variant, in particular conversions
+    // from alternatives
+    using image_view_base::image_view_base;
+
     image_view_any() = default;
 
-    template <typename T>
-    image_view_any(T && data)
-        noexcept(std::is_nothrow_constructible<image_view_base, T && >::value)
-        : image_view_base(std::forward<T>(data)) {}
+    // construct from view coordinates and image
+    template <typename ImageT>
+    image_view_any(std::size_t x, std::size_t y, std::size_t width, std::size_t height,
+                   ImageT const& data)
+        : image_view_base(image_view<ImageT>(x, y, width, height, data)) {}
 
     std::size_t width() const;
     std::size_t height() const;

--- a/include/mapnik/image_view_impl.hpp
+++ b/include/mapnik/image_view_impl.hpp
@@ -97,6 +97,12 @@ inline std::size_t image_view<T>::row_size() const
 }
 
 template <typename T>
+inline std::size_t image_view<T>::row_stride() const
+{
+    return data_.row_stride();
+}
+
+template <typename T>
 inline typename image_view<T>::pixel_type const* image_view<T>::get_row(std::size_t row) const
 {
     return data_.get_row(row + y_) + x_;

--- a/include/mapnik/image_view_null.hpp
+++ b/include/mapnik/image_view_null.hpp
@@ -23,6 +23,7 @@
 #ifndef MAPNIK_IMAGE_VIEW_NULL_HPP
 #define MAPNIK_IMAGE_VIEW_NULL_HPP
 
+#include <mapnik/image_null.hpp>
 #include <mapnik/image_view.hpp>
 
 //stl

--- a/include/mapnik/tiff_io.hpp
+++ b/include/mapnik/tiff_io.hpp
@@ -186,11 +186,16 @@ struct tag_setter
         : output_(output),
           config_(config) {}
 
-    template <typename T>
-    void operator() (T const&) const
+    template <typename ImageT>
+    void operator() (ImageT const&) const
     {
-        // Assume this would be null type
         throw image_writer_exception("Could not write TIFF - unknown image type provided");
+    }
+
+    template <typename ImageT>
+    void operator() (image_view<ImageT> const& view) const
+    {
+        (*this)(view.data());
     }
 
     inline void operator() (image_rgba8 const& data) const

--- a/src/image_util.cpp
+++ b/src/image_util.cpp
@@ -548,7 +548,21 @@ private:
     bool const status_;
 };
 
+struct copy_image_visitor
+{
+    template <typename ImageT>
+    image_any operator()(image_view<ImageT> const& src)
+    {
+        return copy_image(src);
+    }
+};
+
 } // end detail ns
+
+MAPNIK_DECL image_any copy_image(image_view_any const& src)
+{
+    return util::apply_visitor(detail::copy_image_visitor(), src);
+}
 
 MAPNIK_DECL bool premultiply_alpha(image_any & image)
 {

--- a/src/image_util_jpeg.cpp
+++ b/src/image_util_jpeg.cpp
@@ -83,7 +83,14 @@ void process_rgba8_jpeg(T const& image, std::string const& type, std::ostream & 
 {
 #if defined(HAVE_JPEG)
     int quality = detail::parse_jpeg_quality(type);
-    save_as_jpeg(stream, quality, image);
+    unsigned buf_rows = 1;
+    if (image.width() <= 1024) {
+        buf_rows = 8;
+        // the width limit of 1024 is arbitrary, while the number of
+        // buf_rows is 8 because jpeg encoding operates on 8x8 blocks;
+        // with these values save_as_jpeg will allocate ~24kB buffer
+    }
+    save_as_jpeg(stream, quality, image, buf_rows);
 #else
     throw image_writer_exception("jpeg output is not enabled in your build of Mapnik");
 #endif

--- a/src/image_util_png.cpp
+++ b/src/image_util_png.cpp
@@ -205,6 +205,37 @@ void png_saver_pal::operator()<image_view_null> (image_view_null const& image) c
     throw image_writer_exception("null image views not supported for png");
 }
 
+#if defined(HAVE_PNG)
+template <typename T>
+static void save_as_png8_reduce(std::ostream & stream, T const& image, png_options const& opts)
+{
+    if (image.get_premultiplied())
+    {
+        auto demul = copy_image(image);
+        mapnik::demultiply_alpha(demul);
+        if (opts.use_hextree)
+        {
+            save_as_png8_hex(stream, demul, opts);
+        }
+        else
+        {
+            save_as_png8_oct(stream, demul, opts);
+        }
+    }
+    else
+    {
+        if (opts.use_hextree)
+        {
+            save_as_png8_hex(stream, image, opts);
+        }
+        else
+        {
+            save_as_png8_oct(stream, image, opts);
+        }
+    }
+}
+#endif
+
 template <typename T>
 void process_rgba8_png_pal(T const& image,
                           std::string const& t,
@@ -220,14 +251,7 @@ void process_rgba8_png_pal(T const& image,
     }
     else if (opts.paletted)
     {
-        if (opts.use_hextree)
-        {
-            save_as_png8_hex(stream, image, opts);
-        }
-        else
-        {
-            save_as_png8_oct(stream, image, opts);
-        }
+        save_as_png8_reduce(stream, image, opts);
     }
     else
     {
@@ -248,14 +272,7 @@ void process_rgba8_png(T const& image,
     handle_png_options(t, opts);
     if (opts.paletted)
     {
-        if (opts.use_hextree)
-        {
-            save_as_png8_hex(stream, image, opts);
-        }
-        else
-        {
-            save_as_png8_oct(stream, image, opts);
-        }
+        save_as_png8_reduce(stream, image, opts);
     }
     else
     {

--- a/test/catch_tmp.hpp
+++ b/test/catch_tmp.hpp
@@ -1,0 +1,82 @@
+#ifndef TEST_CATCH_TMP_HPP
+#define TEST_CATCH_TMP_HPP
+
+#include <boost/filesystem/convenience.hpp>
+
+struct catch_temporary_path
+{
+    using path = boost::filesystem::path;
+
+    static path base_dir;
+    static bool keep_temporary_files;
+
+    static path absolute(path const& p)
+    {
+        return boost::filesystem::absolute(p, base_dir);
+    }
+
+    static catch_temporary_path create_dir(std::string const& p)
+    {
+        auto abs = absolute(p);
+        bool created = boost::filesystem::create_directory(abs);
+        return catch_temporary_path(abs, created);
+    }
+
+    catch_temporary_path()
+        : remove_(false) {}
+
+    catch_temporary_path(char const* p, bool r = true)
+        : path_(absolute(p)), remove_(r) {}
+
+    catch_temporary_path(std::string const& p, bool r = true)
+        : path_(absolute(p)), remove_(r) {}
+
+    catch_temporary_path(path const& p, bool r = true)
+        : path_(absolute(p)), remove_(r) {}
+
+    catch_temporary_path(catch_temporary_path && other)
+        : remove_(other.remove_)
+    {
+        path_.swap(other.path_);
+        other.remove_ = false;
+    }
+
+    ~catch_temporary_path()
+    {
+        if (remove_ && !path_.empty() && !keep_temporary_files)
+        {
+            boost::system::error_code ec; // ignored
+            boost::filesystem::remove(path_, ec); // nothrow
+        }
+    }
+
+    catch_temporary_path & operator=(catch_temporary_path && other)
+    {
+        path_.swap(other.path_);
+        std::swap(remove_, other.remove_);
+        return *this;
+    }
+
+    path const* operator->() const
+    {
+        return &path_;
+    }
+
+    operator path const& () const
+    {
+        return path_;
+    }
+
+    operator std::string () const
+    {
+        return path_.string();
+    }
+
+private: // noncopyable
+    catch_temporary_path(catch_temporary_path const& ) = delete;
+    catch_temporary_path & operator=(catch_temporary_path const& ) = delete;
+    path path_;
+    bool remove_;
+};
+
+#endif // TEST_CATCH_TMP_HPP

--- a/test/unit/imaging/image_io_test.cpp
+++ b/test/unit/imaging/image_io_test.cpp
@@ -62,6 +62,7 @@ static std::vector<file_format_info> const supported_types
 #if defined(HAVE_WEBP)
     file_format_info("webp", "webp"),
     file_format_info("webp", "webp:lossless=1"),
+    file_format_info("webp", "webp:preprocessing=2"), // pseudo-random dithering
 #endif
 }};
 

--- a/test/unit/run.cpp
+++ b/test/unit/run.cpp
@@ -2,30 +2,49 @@
 #include "catch.hpp"
 
 #include <string>
+#include <mapnik/debug.hpp>
 #include <mapnik/util/fs.hpp>
 #include <mapnik/datasource_cache.hpp>
 #include <boost/filesystem/convenience.hpp>
 
 #include "cleanup.hpp" // run_cleanup()
 
-std::string plugin_path;
+static std::string plugin_path;
+static std::string working_dir;
 
-inline void set_plugin_path(Catch::ConfigData&, std::string const& _plugin_path ) {
+static void set_log_severity(Catch::ConfigData&, std::string const& severity)
+{
+    if (severity == "debug")
+        mapnik::logger::set_severity(mapnik::logger::debug);
+    else if (severity == "warn")
+        mapnik::logger::set_severity(mapnik::logger::warn);
+    else if (severity == "error")
+        mapnik::logger::set_severity(mapnik::logger::error);
+    else if (severity == "none")
+        mapnik::logger::set_severity(mapnik::logger::none);
+    else
+        std::clog << "unknonw log severity '" << severity << "'\n";
+}
+
+static void set_plugin_path(Catch::ConfigData&, std::string const& _plugin_path)
+{
     plugin_path = _plugin_path;
 }
 
-std::string working_dir;
-
-inline void set_working_dir(Catch::ConfigData&, std::string const& _working_dir ) {
+static void set_working_dir(Catch::ConfigData&, std::string const& _working_dir)
+{
     working_dir = _working_dir;
 }
-
 
 int main (int argc, char* const argv[])
 {
     Catch::Session session;
 
     auto & cli = session.cli();
+
+    cli["--log"]
+        .describe("mapnik log severity")
+        .bind(&set_log_severity, "debug|warn|error|none");
 
     cli["-p"]["--plugins"]
         .describe("path to mapnik plugins")


### PR DESCRIPTION
This is the first bunch of commits towards #2923. These implement on-the-fly alpha demultiplication during image saving, so that when it's eventually removed from the renderer, savers will seamlessly consume premultiplied images and demultiply if needed.

Notes
 - TIFF supports premultiplied, so there's no conversion needed. The only change I made to tiff was that I enabled saving directly from image view

 - PNG with palette -- I didn't feel like demultiplying in several places (color reduction and encoding), so I just create a copy, demultiply and save that. This is not optimal, and might need a real on-the-fly implementation, or a warning "you should demultiply before saving indexed png for better performance"

 - WebP code was quite confusing, I tried to simplify it and also make sure that `RGB->YUV` conversion is consistent -- because when `pic.use_argb == 0`, `WebPPictureImportRGBA` does the conversion right away, but ignores `config.preprocessing`. Therefore I always set `pic.use_argb = 1`, for both lossy and lossless -- this is less efficient in the non-premultiplied lossy case, but it's the only way to ensure `config.preprocessing` setting is honored.
