### PR TITLE
rsync ccache for travis osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,15 @@ matrix:
       compiler: clang
       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
       osx_image: xcode7.2 # upgrades clang from 6 -> 7
-      env: JOBS=8 MASON_PUBLISH=true HEAVY_JOBS=3
+      env: MASON_PUBLISH=true CXX="ccache clang++" JOBS=8 HEAVY_JOBS=3
     - os: osx
       compiler: clang
       osx_image: xcode7.2 # upgrades clang from 6 -> 7
-      env: JOBS=8 COVERAGE=true HEAVY_JOBS=3
+      env: COVERAGE=true CXX="ccache clang++" JOBS=8 HEAVY_JOBS=3
 
 before_install:
  - source scripts/travis-common.sh
+ - source scripts/travis-rcache.sh
  - export PYTHONUSERBASE=$(pwd)/mason_packages/.link
  - export PATH=${PYTHONUSERBASE}/bin:${PATH}
  - export COVERAGE=${COVERAGE:-false}
@@ -60,11 +61,12 @@ before_install:
  - export BENCH=${BENCH:-false}
  - if [[ ${TRAVIS_BRANCH} != 'master' ]]; then export MASON_PUBLISH=false; fi
  - if [[ ${TRAVIS_PULL_REQUEST} != 'false' ]]; then export MASON_PUBLISH=false; fi
- - git_submodule_update --init --depth=10
+ - git_submodule_update --init --depth=50 'deps/mapbox/variant'
 
 install:
  - on 'linux' export PYTHONPATH=${PYTHONUSERBASE}/lib/python2.7/site-packages
  - on 'osx' export PYTHONPATH=${PYTHONUSERBASE}/lib/python/site-packages
+ - on 'osx' brew install ccache
  - on 'osx' brew rm postgis --force
  - on 'osx' brew install postgis --force
  - on 'osx' pg_ctl -w start -l postgres.log --pgdata /usr/local/var/postgres
@@ -76,14 +78,15 @@ install:
 before_script:
  - source bootstrap.sh
  - commit_message_parse
+ - on 'osx' rcache_download || true # failure is not fatal
 
 script:
  - export SCONSFLAGS='--debug=time'
  - configure BENCHMARK=${BENCH}
  - make
- - make test
- - enabled ${COVERAGE} coverage
- - enabled ${BENCH} make bench
+ - good && elapsed_minutes -lt 40 && download_test_data && make test
+ - good && elapsed_minutes -lt 45 && enabled ${COVERAGE} coverage
+ - good && elapsed_minutes -lt 45 && enabled ${BENCH} make bench
 
 after_success:
  - if enabled ${MASON_PUBLISH}; then
@@ -91,3 +94,7 @@ after_success:
      ./mason_latest.sh link &&
      ./mason_latest.sh publish;
    fi
+
+before_cache:
+ - on 'osx' ccache --show-stats --max-size 100M --cleanup
+ - on 'osx' rcache_upload

--- a/scripts/travis-common.sh
+++ b/scripts/travis-common.sh
@@ -1,5 +1,19 @@
 #! /bin/bash
 
+# elapsed_minutes
+#   - outputs the number of minutes elapsed since this file was sourced
+# elapsed_minutes OP VALUE
+#   - shortcut for: test `elapsed_minutes` OP VALUE
+our_start_time=$(date +%s)
+elapsed_minutes () {
+    local now=$(date +%s)
+    local elapsed=$(( (now - our_start_time) / 60 ))
+    case $# in
+        0) echo $elapsed;;
+        *) test $elapsed "$@";;
+    esac
+}
+
 # enabled VALUE
 #   - if VALUE is empty or falsy, returns 1 (false)
 #   - otherwise returns 0 (true)
@@ -12,6 +26,15 @@ enabled () {
         ''|'0'|[Ff]alse|[Nn]o) test $# -ne 0;;
         *) test $# -eq 0 || "$@";;
     esac
+}
+
+# good
+#   - if all build commands executed so far succeeded, returns 0
+#   - otherwise returns 1
+#   - this tests the conjunction of all previous command results,
+#     not just the immediately preceding one
+good () {
+    return ${TRAVIS_TEST_RESULT:-0}
 }
 
 # on NAME
@@ -106,4 +129,12 @@ coverage () {
         --exclude scons --exclude test --exclude demo --exclude docs \
         --exclude fonts --exclude utils \
         > /dev/null
+}
+
+download_test_data () {
+    if commit_message_contains '[skip tests]'; then
+        return 1
+    else
+        git_submodule_update --init --depth=10
+    fi
 }

--- a/scripts/travis-rcache.sh
+++ b/scripts/travis-rcache.sh
@@ -1,0 +1,90 @@
+#! /bin/bash
+#
+# Given the following values set by Travis:
+#   TRAVIS_REPO_SLUG = lightmare/mapnik
+#   TRAVIS_BRANCH = experimental
+#   TRAVIS_JOB_NUMBER = 89.3
+#
+# And these set in repository settings on Travis:
+#   RCACHE_REMOTE = host::prefix
+#   RCACHE_PASSWORD = puzzles
+#
+# rcache variables will default to:
+#   RCACHE_MODULE = host::prefix:lightmare
+#   RCACHE_USER = lightmare
+#   RCACHE_REPO = mapnik
+#   RCACHE_TAG = 3
+#
+# ccache directory will be rsynced with:
+#   host::prefix:lightmare/mapnik/experimental/3
+#
+# If RCACHE_PASSWORD is empty, cache won't be uploaded.
+# If RCACHE_REMOTE is empty, RCACHE_MODULE must be supplied.
+# RCACHE_TAG may be used to make several jobs share a cache.
+#
+
+: ${RCACHE_DIR:=$HOME/.rcache}
+: ${RCACHE_TAG:=${TRAVIS_JOB_NUMBER##*.}}
+: ${RCACHE_REPO:=${TRAVIS_REPO_SLUG#*/}}
+: ${RCACHE_USER:=${TRAVIS_REPO_SLUG%%/*}}
+: ${RCACHE_MODULE:=${RCACHE_REMOTE:+$RCACHE_REMOTE:$RCACHE_USER}}
+
+rcache_download () {
+    test -n "$RCACHE_MODULE" || return
+    export CCACHE_COMPRESS=1
+    export CCACHE_DIR="$RCACHE_DIR/$RCACHE_REPO/$TRAVIS_BRANCH/$RCACHE_TAG"
+    RCACHE_REMOTE_BRANCH_EXISTS=0
+
+    # try to download cache for the current branch (or merge-base)
+    rcache_download_branch "$TRAVIS_BRANCH" &&
+        RCACHE_REMOTE_BRANCH_EXISTS=1 &&
+        return
+
+    # if that fails, try to download cache for master
+    test "$TRAVIS_BRANCH" != "master" &&
+        rcache_download_branch "master"
+}
+
+rcache_download_branch () {
+    local rbranch="$1"
+    shift
+    mkdir -p "$RCACHE_DIR/$RCACHE_REPO/$TRAVIS_BRANCH"
+
+    # RCACHE_PASSWORD, being an encrypted environment variable, is not
+    # available to pull requests from forks. That's why there is rsync
+    # user "travis-ci" with un-encrypted password and read-only access.
+    RSYNC_PASSWORD="ic+sivart" \
+    rsync -auz --relative --no-implied-dirs --human-readable --stats \
+        "travis-ci@$RCACHE_MODULE/$RCACHE_REPO/$rbranch/./$RCACHE_TAG/" \
+        "$RCACHE_DIR/$RCACHE_REPO/$TRAVIS_BRANCH/"
+}
+
+rcache_upload () {
+    test -n "$RCACHE_MODULE" || return
+    test -n "$RCACHE_PASSWORD" || return
+
+    if test "$TRAVIS_BRANCH" = "master"; then
+        RSYNC_PASSWORD="$RCACHE_PASSWORD" \
+        rsync -auz --relative --no-implied-dirs --human-readable --stats \
+            --del --delete-excluded --exclude="tmp" \
+            "$RCACHE_DIR/./$RCACHE_REPO/$TRAVIS_BRANCH/$RCACHE_TAG/" \
+            "$RCACHE_USER@$RCACHE_MODULE/"
+    else
+        # We can only leverage --link-dest if we sync relative to the
+        # branch directory, which must exist on the remote side before
+        # the transfer.
+        if test "$RCACHE_REMOTE_BRANCH_EXISTS" != 1; then
+            RSYNC_PASSWORD="$RCACHE_PASSWORD" \
+            rsync -du --relative --no-implied-dirs \
+                "$RCACHE_DIR/./$RCACHE_REPO/$TRAVIS_BRANCH" \
+                "$RCACHE_USER@$RCACHE_MODULE/"
+        fi
+
+        RSYNC_PASSWORD="$RCACHE_PASSWORD" \
+        rsync -auz --relative --no-implied-dirs --human-readable --stats \
+            --del --delete-excluded --exclude="tmp" \
+            --link-dest="../master/" \
+            "$RCACHE_DIR/$RCACHE_REPO/$TRAVIS_BRANCH/./$RCACHE_TAG/" \
+            "$RCACHE_USER@$RCACHE_MODULE/$RCACHE_REPO/$TRAVIS_BRANCH/"
+    fi
+}


### PR DESCRIPTION
First a few notes about `.travis.yml` changes
 - in `before_install` only `deps/mapbox/variant` submodule is updated
 - in `script` after `make`, test data is downloaded (remaining submodules updated) and `make test` run only if previous `make` succeeded *and less than 40 minutes elapsed*
 - coveralls and benchmarks are only run if everything succeeded and we're below 45 minutes

This effectively means that a build that would've successfully finished in 47 minutes will now probably skip the last two steps and thus fail. On the other hand, a build that would've been killed while in the middle of running tests or benchmarks will skip those and thus have a chance to upload cache -- which should help subsequent builds finish sooner (including re-running this one).

Required repository settings on travis:
 - secret environment variable `RCACHE_PASSWORD`
 - public environment variable `RCACHE_MODULE` or `RCACHE_REMOTE`
   - `RCACHE_MODULE` should be a double-colon path to rsync daemon
   - if you don't specify `RCACHE_MODULE`, it will be composed as `RCACHE_REMOTE:user`, with user obtained from `TRAVIS_REPO_SLUG`

I created a module for user "mapnik" on my cache store, will send details to @springmeyer. If you want to bake your own, it needs to be set up such that:
 - the given module is readable by user "travis-ci" using password "ic+sivart"
 - cache can be uploaded as the user obtained from `TRAVIS_REPO_SLUG` using `RCACHE_PASSWORD`

Example `/etc/rsyncd.conf` (rsync 3.1 or newer required for colon-options in `auth users`)
```conf
secrets file = /www/travis-cache/rsyncd.secrets
#hosts allow = 208.78.110.199
#hosts deny =
max connections = 10

use chroot = yes
read only = yes
list = yes
uid = nobody
gid = nogroup

refuse options = checksum partial partial-dir

[travis-cache:lightmare]
        comment = cache for builds on travis
        path = /www/travis-cache/lightmare
        log file = /www/travis-cache/lightmare.log
        auth users = lightmare:rw *:ro

[travis-cache:mapnik]
        comment = cache for builds on travis
        path = /www/travis-cache/mapnik
        log file = /www/travis-cache/mapnik.log
        auth users = mapnik:rw *:ro
```
