### PR TITLE
Add "preunion_rasters" parameter for pgraster plugin

### DIFF
--- a/plugins/input/pgraster/README
+++ b/plugins/input/pgraster/README
@@ -14,6 +14,8 @@ with the following differences:
 
  - "clip_rasters" boolean introduced, defaults to false
 
+ - "preunion_rasters" boolean introduced, defaults to false
+
  - "band" introduced, with same semantic of the GDAL driver
 
 Credits

--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -84,6 +84,7 @@ pgraster_datasource::pgraster_datasource(parameters const& params)
       srid_(*params.get<value_integer>("srid", 0)),
       band_(*params.get<value_integer>("band", 0)),
       extent_initialized_(false),
+      preunion_rasters_(*params.get<mapnik::boolean_type>("preunion_rasters", false)),
       prescale_rasters_(*params.get<mapnik::boolean_type>("prescale_rasters", false)),
       use_overviews_(*params.get<mapnik::boolean_type>("use_overviews", false)),
       clip_rasters_(*params.get<mapnik::boolean_type>("clip_rasters", false)),
@@ -920,6 +921,8 @@ featureset_ptr pgraster_datasource::features_with_context(query const& q,process
 
         s << "SELECT ST_AsBinary(";
 
+        if (preunion_rasters_) s << "ST_Union(";
+
         if (band_) s << "ST_Band(";
 
         if (prescale_rasters_) s << "ST_Resize(";
@@ -946,6 +949,8 @@ featureset_ptr pgraster_datasource::features_with_context(query const& q,process
         }
 
         if (band_) s << ", " << band_ << ")";
+
+        if (preunion_rasters_) s << ")";
 
         s << ") AS geom";
 

--- a/plugins/input/pgraster/pgraster_datasource.hpp
+++ b/plugins/input/pgraster/pgraster_datasource.hpp
@@ -124,6 +124,7 @@ private:
     std::vector<pgraster_overview> overviews_;
     mutable bool extent_initialized_;
     mutable mapnik::box2d<double> extent_;
+    bool preunion_rasters_;
     bool prescale_rasters_;
     bool use_overviews_;
     bool clip_rasters_;


### PR DESCRIPTION
The parameter ("pre-union rasters") changes the PostGIS query to always return a single raster.
It is effective as a workaround for bug #2375 (visible source tile boundaries).

It would make much more sense to fix the bug than to provide a workaround, to be honest, anyway the parameter doesn't do any harm (defaults to false).