### PR TITLE
work around initialization data race in gdal/gtiff

### DIFF
--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -82,25 +82,7 @@ gdal_datasource::gdal_datasource(parameters const& params)
     shared_dataset_ = *params.get<mapnik::boolean_type>("shared", false);
     band_ = *params.get<mapnik::value_integer>("band", -1);
 
-#if GDAL_VERSION_NUM >= 1600
-    if (shared_dataset_)
-    {
-        auto ds = GDALOpenShared(dataset_name_.c_str(), GA_ReadOnly);
-        dataset_.reset(static_cast<GDALDataset*>(ds));
-    }
-    else
-#endif
-    {
-        auto ds = GDALOpen(dataset_name_.c_str(), GA_ReadOnly);
-        dataset_.reset(static_cast<GDALDataset*>(ds));
-    }
-
-    if (! dataset_)
-    {
-        throw datasource_exception(CPLGetLastErrorMsg());
-    }
-
-    MAPNIK_LOG_DEBUG(gdal) << "gdal_featureset: opened Dataset=" << dataset_.get();
+    open_dataset(dataset_name_.c_str(), shared_dataset_);
 
     nbands_ = dataset_->GetRasterCount();
     width_ = dataset_->GetRasterXSize();
@@ -185,12 +167,74 @@ gdal_datasource::gdal_datasource(parameters const& params)
 
     MAPNIK_LOG_DEBUG(gdal) << "gdal_datasource: Raster Size=" << width_ << "," << height_;
     MAPNIK_LOG_DEBUG(gdal) << "gdal_datasource: Raster Extent=" << extent_;
-
 }
 
 gdal_datasource::~gdal_datasource()
 {
-    MAPNIK_LOG_DEBUG(gdal) << "gdal_featureset: Closing Dataset=" << dataset_.get();
+    MAPNIK_LOG_DEBUG(gdal) << "gdal_datasource: Closing Dataset=" << dataset_.get();
+}
+
+// check whether a workaround is needed for these
+//
+//      https://github.com/mapnik/mapnik/issues/3093
+//      https://github.com/mapnik/mapnik/issues/3339
+//
+// the culprit was fixed in GDAL 2.0.2
+//
+//      https://trac.osgeo.org/gdal/wiki/Release/2.0.2-News
+//      https://trac.osgeo.org/gdal/changeset/31110
+//
+#define WORKAROUND_XTIFFInitialize_RACE \
+        ( defined(MAPNIK_THREADSAFE) && \
+          ( !defined(GDAL_COMPUTE_VERSION) || \
+            GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,0,2) ) )
+
+#if WORKAROUND_XTIFFInitialize_RACE
+static std::atomic<bool> xtiff_initialized(false);
+static std::mutex xtiff_mutex;
+#endif
+
+void gdal_datasource::open_dataset(char const* name, bool shared)
+{
+#if WORKAROUND_XTIFFInitialize_RACE
+    std::unique_lock<std::mutex> lock(xtiff_mutex);
+    if (xtiff_initialized)
+    {
+        lock.unlock();
+    }
+#endif
+
+    GDALDatasetH ds;
+
+#if GDAL_VERSION_NUM >= 1600
+    if (shared)
+    {
+        ds = GDALOpenShared(name, GA_ReadOnly);
+    }
+    else
+#endif
+    {
+        ds = GDALOpen(name, GA_ReadOnly);
+    }
+
+    if (ds == nullptr)
+    {
+        throw datasource_exception(CPLGetLastErrorMsg());
+    }
+
+#if WORKAROUND_XTIFFInitialize_RACE
+    if (!xtiff_initialized)
+    {
+        auto driver = GDALGetDatasetDriver(ds);
+        auto desc = GDALGetDescription(driver);
+        xtiff_initialized = (std::strcmp(desc, "GTiff") == 0);
+        lock.unlock();
+    }
+#endif
+
+    MAPNIK_LOG_DEBUG(gdal) << "gdal_datasource: opened Dataset=" << ds;
+
+    dataset_.reset(static_cast<GDALDataset*>(ds));
 }
 
 datasource::datasource_t gdal_datasource::type() const

--- a/plugins/input/gdal/gdal_datasource.hpp
+++ b/plugins/input/gdal/gdal_datasource.hpp
@@ -55,7 +55,11 @@ public:
     boost::optional<mapnik::datasource_geometry_t> get_geometry_type() const;
     mapnik::layer_descriptor get_descriptor() const;
 private:
-    std::unique_ptr<GDALDataset, decltype(&GDALClose)> dataset_;
+    using dataset_ptr = std::unique_ptr<GDALDataset, decltype(&GDALClose)>;
+
+    void open_dataset(char const* name, bool shared);
+
+    dataset_ptr dataset_;
     mapnik::box2d<double> extent_;
     std::string dataset_name_;
     int band_;


### PR DESCRIPTION
Hopefully fixes #3339 #3093 

It's not pretty, but seems to work. I've had

``` sh
./visual-test-run --jobs=20 --agg $(for x in {1..20}; do echo tiff-alpha-gdal; done)
```

running in a loop for an hour (4 processors); previously this quite reliably blew up in a few iterations.

@BergWerkGIS - can you please test on windows whether this actually fixes #3093 ?
