### PR TITLE
Add support for MAPNIK_LOG_SEVERITY env variable

### DIFF
--- a/utils/mapnik-render/mapnik-render.cpp
+++ b/utils/mapnik-render/mapnik-render.cpp
@@ -30,6 +30,22 @@ int main (int argc,char** argv)
     mapnik::logger logger;
     logger.set_severity(mapnik::logger::error);
 
+    const char *envsev = std::getenv("MAPNIK_LOG_SEVERITY");
+    if ( envsev != nullptr)
+    {
+      if ( ! strncmp(envsev, "deb", 3) )
+        logger.set_severity(mapnik::logger::debug);
+      else if ( ! strncmp(envsev, "warn", 4) )
+        logger.set_severity(mapnik::logger::warn);
+      else if ( ! strncmp(envsev, "err", 3) )
+        logger.set_severity(mapnik::logger::error);
+      else
+        MAPNIK_LOG_ERROR("logger") <<
+              "Invalid value for MAPNIK_LOG_SEVERITY"
+              " environment variable, expected "
+              "'debug', 'warning' or 'error'";
+    }
+
     try
     {
         po::options_description desc("mapnik-render utility");


### PR DESCRIPTION
In the current PR it is only within mapnik-render that MAPNIK_LOG_SEVERITY is used, but I think it should be done directly within the logger itself. If you like the approach, I could look into it.

For now my immediate need is to set verbosity while debugging, and I'm using mapnik-render for debugging...