### PR TITLE
Raster resample division by zero

### DIFF
--- a/include/mapnik/span_image_filter.hpp
+++ b/include/mapnik/span_image_filter.hpp
@@ -79,16 +79,19 @@ public:
         {
             base_type::interpolator().coordinates(&x, &y);
 
-            int src_x = x >> agg::image_subpixel_shift;
-            int src_y = y >> agg::image_subpixel_shift;
-            const value_type* pix = reinterpret_cast<const value_type*>(base_type::source().span(src_x, src_y, 1));
-            if (nodata_value_ && *nodata_value_ == *pix)
+            if (nodata_value_)
             {
-                span->v = *nodata_value_;
-                span->a = base_mask;
-                ++span;
-                ++base_type::interpolator();
-                continue;
+                int src_x = x >> agg::image_subpixel_shift;
+                int src_y = y >> agg::image_subpixel_shift;
+                const value_type* pix = reinterpret_cast<const value_type*>(base_type::source().span(src_x, src_y, 1));
+                if (*nodata_value_ == *pix)
+                {
+                    span->v = *nodata_value_;
+                    span->a = base_mask;
+                    ++span;
+                    ++base_type::interpolator();
+                    continue;
+                }
             }
 
             x += base_type::filter_dx_int() - radius_x;

--- a/include/mapnik/span_image_filter.hpp
+++ b/include/mapnik/span_image_filter.hpp
@@ -131,19 +131,27 @@ public:
                 fg_ptr = reinterpret_cast<const value_type*>(base_type::source().next_y());
             }
 
-            fg /= total_weight;
-            if (fg < std::numeric_limits<value_type>::min())
+            if (total_weight == 0)
             {
-                span->v = std::numeric_limits<value_type>::min();
-            }
-            else if (fg > std::numeric_limits<value_type>::max())
-            {
-                span->v = std::numeric_limits<value_type>::max();
+                span->v = *nodata_value_;
             }
             else
             {
-                span->v = static_cast<value_type>(fg);
+                fg /= total_weight;
+                if (fg < std::numeric_limits<value_type>::min())
+                {
+                    span->v = std::numeric_limits<value_type>::min();
+                }
+                else if (fg > std::numeric_limits<value_type>::max())
+                {
+                    span->v = std::numeric_limits<value_type>::max();
+                }
+                else
+                {
+                    span->v = static_cast<value_type>(fg);
+                }
             }
+
             span->a = base_mask;
 
             ++span;

--- a/include/mapnik/span_image_filter.hpp
+++ b/include/mapnik/span_image_filter.hpp
@@ -81,7 +81,7 @@ public:
 
             int src_x = x >> agg::image_subpixel_shift;
             int src_y = y >> agg::image_subpixel_shift;
-            const value_type* pix = reinterpret_cast<const value_type*>(base_type::source().span(src_x, src_y, 0));
+            const value_type* pix = reinterpret_cast<const value_type*>(base_type::source().span(src_x, src_y, 1));
             if (nodata_value_ && *nodata_value_ == *pix)
             {
                 span->v = *nodata_value_;

--- a/include/mapnik/span_image_filter.hpp
+++ b/include/mapnik/span_image_filter.hpp
@@ -30,6 +30,8 @@
 
 #include <limits>
 
+#include <mapnik/safe_cast.hpp>
+
 namespace mapnik
 {
 
@@ -140,19 +142,7 @@ public:
             }
             else
             {
-                fg /= total_weight;
-                if (fg < std::numeric_limits<value_type>::min())
-                {
-                    span->v = std::numeric_limits<value_type>::min();
-                }
-                else if (fg > std::numeric_limits<value_type>::max())
-                {
-                    span->v = std::numeric_limits<value_type>::max();
-                }
-                else
-                {
-                    span->v = static_cast<value_type>(fg);
-                }
+                span->v = safe_cast<value_type>(fg / total_weight);
             }
 
             span->a = base_mask;


### PR DESCRIPTION
Addresses https://github.com/mapnik/node-mapnik/issues/600.

It turned out to be a quite serious issue. The problem was not the `Floating point exception` itself, but accessing memory out of the source image bounds caused by a very stupid mistake. See the first commit.

I also added commit with explicit check for zero in the place where `Floating point exception` was thrown. It's not necessarily needed, but I rather added it as I feel that Mapnik's policy is not to throw whatsoever.

