### PR TITLE
revert virtual functions in markers_placement_finder

### DIFF
--- a/include/mapnik/markers_placements/basic.hpp
+++ b/include/mapnik/markers_placements/basic.hpp
@@ -54,17 +54,6 @@ public:
     {
     }
 
-    virtual ~markers_basic_placement()
-    {
-        // empty but necessary
-    }
-
-    // Start again at first marker. Returns the same list of markers only works when they were NOT added to the detector.
-    virtual void rewind() = 0;
-
-    // Get next point where the marker should be placed. Returns true if a place is found, false if none is found.
-    virtual bool get_point(double &x, double &y, double &angle, bool ignore_placement) = 0;
-
 protected:
     markers_placement_params const& params_;
 

--- a/include/mapnik/markers_placements/point.hpp
+++ b/include/mapnik/markers_placements/point.hpp
@@ -40,8 +40,7 @@ public:
           detector_(detector),
           done_(false)
     {
-        // no need to rewind locator here, markers_placement_finder
-        // does that after construction
+        locator_.rewind(0);
     }
 
     // Start again at first marker. Returns the same list of markers only works when they were NOT added to the detector.


### PR DESCRIPTION
I don't like repeating the placement-type switch in every function, that's why I chose virtual functions. But the fact is, #3338 increased compiled library size by 10%, and this PR cuts that back (18.5MB -> 16.6MB for me). So this looks like the lesser of two evils.

Interestingly, for me it also reduces `src/marker_helpers.cpp` compile time with GCC from ~69s to ~59s, while Clang stays around ~42s.

For reference, I also tried hand-writing `apply_visitor` for the union in `markers_placement_finder`: https://github.com/lightmare/mapnik/commit/24ac60f02a987c4eca4cb9088d09f5baf2dea9f4. However, that one increased GCC memory consumption by ~100MB; compile time and library size were roughly the same as with this PR.
