### PR TITLE
Fix reading nodata value for data rasters

### DIFF
--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -269,15 +269,13 @@ mapnik::raster_ptr read_grayscale_band(mapnik::box2d<double> const& bbox,
   image.set(0xffffffff);
 
 
-  int val;
-  int nodataval;
   uint8_t * data = image.bytes();
   int ps = 4; // sizeof(image::pixel_type)
   int off;
-  nodataval = reader(); // nodata value, need to read anyway
+  int nodataval = reader();
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
-      val = reader();
+      int val = reader();
       // Apply harsh type clipping rules ala GDAL
       if ( val < 0 ) val = 0;
       if ( val > 255 ) val = 255;
@@ -297,7 +295,7 @@ mapnik::raster_ptr read_grayscale_band(mapnik::box2d<double> const& bbox,
     }
   }
   mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(bbox, image, 1.0);
-  if ( hasnodata ) raster->set_nodata(val);
+  if ( hasnodata ) raster->set_nodata(nodataval);
   return raster;
 }
 

--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -183,8 +183,8 @@ mapnik::raster_ptr read_data_band(mapnik::box2d<double> const& bbox,
 {
   mapnik::image_gray32f image(width, height);
   float* data = image.data();
-  double val;
-  val = reader(); // nodata value, need to read anyway
+  double nodataval;
+  nodataval = reader(); // nodata value
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
       val = reader();
@@ -193,7 +193,7 @@ mapnik::raster_ptr read_data_band(mapnik::box2d<double> const& bbox,
     }
   }
   mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(bbox, image, 1.0);
-  if ( hasnodata ) raster->set_nodata(val);
+  if ( hasnodata ) raster->set_nodata(nodataval);
   return raster;
 }
 

--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -185,6 +185,7 @@ mapnik::raster_ptr read_data_band(mapnik::box2d<double> const& bbox,
   float* data = image.data();
   double nodataval;
   nodataval = reader(); // nodata value
+  double val;
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
       val = reader();

--- a/plugins/input/pgraster/pgraster_wkb_reader.cpp
+++ b/plugins/input/pgraster/pgraster_wkb_reader.cpp
@@ -183,12 +183,10 @@ mapnik::raster_ptr read_data_band(mapnik::box2d<double> const& bbox,
 {
   mapnik::image_gray32f image(width, height);
   float* data = image.data();
-  double nodataval;
-  nodataval = reader(); // nodata value
-  double val;
+  double nodataval = reader();
   for (int y=0; y<height; ++y) {
     for (int x=0; x<width; ++x) {
-      val = reader();
+      double val = reader();
       int off = y * width + x;
       data[off] = val;
     }


### PR DESCRIPTION
Without this commit the NODATA value for rasters is set to whatever value had the last pixel read (usually bottom-right one). Particularly funny with tiled rasters...