### PR TITLE
concatenating strings & values

### DIFF
--- a/test/unit/core/expressions_test.cpp
+++ b/test/unit/core/expressions_test.cpp
@@ -182,4 +182,10 @@ TEST_CASE("expressions")
     // 'Québec' =~ m:^Q\S*$:
     TRY_CHECK(eval(" [name].match('^Q\\S*$') ") == true);
     TRY_CHECK(parse_and_dump(" [name].match('^Q\\S*$') ") == "[name].match('^Q\\S*$')");
+
+    // string & value concatenation
+    // this should evaluate as two strings concatenating, but currently fails
+    TRY_CHECK(eval("Hello + '!'") == eval("'Hello!'"));
+    // this should evaulate as a combination of an int value and string, but fails
+    TRY_CHECK(eval("[int]+m") == eval("'123m'"));
 }


### PR DESCRIPTION
A recent core change in Mapnik no longer allows unquoted strings in filter expressions and leads to the following error:

```
Error: Failed to parse expression: <expression>
```

Discovered in the Node Mapnik `3.4.18` bump which included a new version of Mapnik core. This has the potential to break styles in Mapbox Studio Classic, and we are seeing it raise issues for folks over at #3387 

This PR currently is a Work In Progress. It adds test that we will want to have passing before merging. Below are how an expression needs to exist for a test to properly pass, requiring fully quoted strings. Notice the `'Hello'` vs `Hello` and `'m'` vs `m`.

```C++
TRY_CHECK(eval("'Hello' + '!'") == eval("'Hello!'"));
TRY_CHECK(eval("[int]+'m'") == eval("'123m'"));
```

Sliding this over to @artemp for some :eyes: and potential fix.

cc/ @springmeyer @flippmoke @jakepruitt 