### PR TITLE
register gdal once at plugin load

### DIFF
--- a/include/mapnik/plugin.hpp
+++ b/include/mapnik/plugin.hpp
@@ -39,6 +39,7 @@ class PluginInfo : util::noncopyable
 {
 public:
     using callable_returning_string = const char* (*) ();
+    using callable_returning_void = void (*) ();
     PluginInfo (std::string const& filename,
                 std::string const& library_name);
     ~PluginInfo();

--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -50,7 +50,6 @@ extern "C" MAPNIK_EXP void on_plugin_load()
 {
     // initialize gdal formats
     std::call_once(once_flag,[](){
-        std::clog << "calling once gdal\n";
         GDALAllRegister();
     });
 }

--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -44,11 +44,15 @@ using mapnik::featureset_ptr;
 using mapnik::layer_descriptor;
 using mapnik::datasource_exception;
 
+static std::once_flag once_flag;
 
-static bool GDALAllRegister_once_()
+extern "C" MAPNIK_EXP void on_plugin_load()
 {
-    static bool const quiet_unused = (GDALAllRegister(), true);
-    return quiet_unused;
+    // initialize gdal formats
+    std::call_once(once_flag,[](){
+        std::clog << "calling once gdal\n";
+        GDALAllRegister();
+    });
 }
 
 gdal_datasource::gdal_datasource(parameters const& params)
@@ -59,8 +63,6 @@ gdal_datasource::gdal_datasource(parameters const& params)
       nodata_tolerance_(*params.get<double>("nodata_tolerance",1e-12))
 {
     MAPNIK_LOG_DEBUG(gdal) << "gdal_datasource: Initializing...";
-
-    GDALAllRegister_once_();
 
 #ifdef MAPNIK_STATS
     mapnik::progress_timer __stats__(std::clog, "gdal_datasource::init");

--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -66,7 +66,6 @@ extern "C" MAPNIK_EXP void on_plugin_load()
     // initialize ogr formats
     // NOTE: in GDAL >= 2.0 this is the same as GDALAllRegister()
     std::call_once(once_flag,[](){
-        std::clog << "calling once ogr\n";
         OGRRegisterAll();
     });
 }

--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -59,6 +59,17 @@ using mapnik::datasource_exception;
 using mapnik::filter_in_box;
 using mapnik::filter_at_point;
 
+static std::once_flag once_flag;
+
+extern "C" MAPNIK_EXP void on_plugin_load()
+{
+    // initialize ogr formats
+    // NOTE: in GDAL >= 2.0 this is the same as GDALAllRegister()
+    std::call_once(once_flag,[](){
+        std::clog << "calling once ogr\n";
+        OGRRegisterAll();
+    });
+}
 
 ogr_datasource::ogr_datasource(parameters const& params)
     : datasource(params),
@@ -86,10 +97,6 @@ void ogr_datasource::init(mapnik::parameters const& params)
 #ifdef MAPNIK_STATS
     mapnik::progress_timer __stats__(std::clog, "ogr_datasource::init");
 #endif
-
-    // initialize ogr formats
-    // NOTE: in GDAL >= 2.0 this is the same as GDALAllRegister()
-    OGRRegisterAll();
 
     boost::optional<std::string> file = params.get<std::string>("file");
     boost::optional<std::string> string = params.get<std::string>("string");

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -60,6 +60,10 @@ PluginInfo::PluginInfo(std::string const& filename,
           {
                 callable_returning_string name = reinterpret_cast<callable_returning_string>(dlsym(module_->dl, library_name.c_str()));
                 if (name) name_ = name();
+                callable_returning_void init_once = reinterpret_cast<callable_returning_void>(dlsym(module_->dl, "on_plugin_load"));;
+                if (init_once) {
+                    init_once();
+                }
           }
 #else
   #ifdef MAPNIK_HAS_DLCFN
@@ -68,6 +72,10 @@ PluginInfo::PluginInfo(std::string const& filename,
           {
                 callable_returning_string name = reinterpret_cast<callable_returning_string>(dlsym(module_->dl, library_name.c_str()));
                 if (name) name_ = name();
+                callable_returning_void init_once = reinterpret_cast<callable_returning_void>(dlsym(module_->dl, "on_plugin_load"));;
+                if (init_once) {
+                    init_once();
+                }
           }
   #else
           throw std::runtime_error("no support for loading dynamic objects (Mapnik not compiled with -DMAPNIK_HAS_DLCFN)");


### PR DESCRIPTION
Improves upon #3340 and applies to `ogr_datasource` as well as `gdal_datasource`.

- refs #3093 #3339 #3340