### PR TITLE
Scale factor improvements

### DIFF
--- a/include/mapnik/renderer_common/process_point_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_point_symbolizer.hpp
@@ -61,7 +61,7 @@ void render_point_symbolizer(point_symbolizer const &sym,
 
         agg::trans_affine tr;
         auto image_transform = get_optional<transform_type>(sym, keys::image_transform);
-        if (image_transform) evaluate_transform(tr, feature, common.vars_, *image_transform);
+        if (image_transform) evaluate_transform(tr, feature, common.vars_, *image_transform, common.scale_factor_);
 
         agg::trans_affine_translation recenter(-center.x, -center.y);
         agg::trans_affine recenter_tr = recenter * tr;

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -58,7 +58,7 @@ MAPNIK_DECL void evaluate_transform(agg::trans_affine& tr,
                                     feature_impl const& feature,
                                     attributes const& vars,
                                     transform_type const& trans_expr,
-                                    double scale_factor=1.0);
+                                    double scale_factor);
 
 struct enumeration_wrapper
 {

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -92,7 +92,7 @@ struct agg_renderer_process_visitor_l
         value_double opacity = get<value_double, keys::opacity>(sym_, feature_, common_.vars_);
         agg::trans_affine image_tr = agg::trans_affine_scaling(common_.scale_factor_);
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
-        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform);
+        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
         image_rgba8 image(bbox_image.width(), bbox_image.height());
         render_pattern<buffer_type>(*ras_ptr_, marker, image_tr, 1.0, image);

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -84,7 +84,7 @@ struct agg_renderer_process_visitor_p
     {
         agg::trans_affine image_tr = agg::trans_affine_scaling(common_.scale_factor_);
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
-        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform);
+        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
         mapnik::image_rgba8 image(bbox_image.width(), bbox_image.height());
         render_pattern<buffer_type>(*ras_ptr_, marker, image_tr, 1.0, image);

--- a/src/agg/process_text_symbolizer.cpp
+++ b/src/agg/process_text_symbolizer.cpp
@@ -63,7 +63,7 @@ void agg_renderer<T0,T1>::process(text_symbolizer const& sym,
     if (halo_transform)
     {
         agg::trans_affine halo_affine_transform;
-        evaluate_transform(halo_affine_transform, feature, common_.vars_, *halo_transform);
+        evaluate_transform(halo_affine_transform, feature, common_.vars_, *halo_transform, common_.scale_factor_);
         ren.set_halo_transform(halo_affine_transform);
     }
 

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -62,7 +62,7 @@ struct cairo_renderer_process_visitor_l
         mapnik::rasterizer ras;
         agg::trans_affine image_tr = agg::trans_affine_scaling(common_.scale_factor_);
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
-        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform);
+        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
         mapnik::image_rgba8 image(bbox_image.width(), bbox_image.height());
         render_pattern<image_rgba8>(ras, marker, image_tr, 1.0, image);

--- a/src/cairo/process_polygon_pattern_symbolizer.cpp
+++ b/src/cairo/process_polygon_pattern_symbolizer.cpp
@@ -96,7 +96,7 @@ void cairo_renderer<T>::process(polygon_pattern_symbolizer const& sym,
     value_double opacity = get<value_double, keys::opacity>(sym, feature, common_.vars_);
     agg::trans_affine image_tr = agg::trans_affine_scaling(common_.scale_factor_);
     auto image_transform = get_optional<transform_type>(sym, keys::image_transform);
-    if (image_transform) evaluate_transform(image_tr, feature, common_.vars_, *image_transform);
+    if (image_transform) evaluate_transform(image_tr, feature, common_.vars_, *image_transform, common_.scale_factor_);
 
     cairo_save_restore guard(context_);
     context_.set_operator(comp_op);

--- a/src/grid/process_text_symbolizer.cpp
+++ b/src/grid/process_text_symbolizer.cpp
@@ -60,7 +60,7 @@ void grid_renderer<T>::process(text_symbolizer const& sym,
     if (halo_transform)
     {
         agg::trans_affine halo_affine_transform;
-        evaluate_transform(halo_affine_transform, feature, common_.vars_, *halo_transform);
+        evaluate_transform(halo_affine_transform, feature, common_.vars_, *halo_transform, common_.scale_factor_);
         ren.set_halo_transform(halo_affine_transform);
     }
 

--- a/src/renderer_common/render_markers_symbolizer.cpp
+++ b/src/renderer_common/render_markers_symbolizer.cpp
@@ -159,7 +159,7 @@ struct render_marker_symbolizer_visitor
 
         if (auto image_transform = get_optional<transform_type>(sym_, keys::image_transform))
         {
-            evaluate_transform(image_tr, feature_, common_.vars_, *image_transform);
+            evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         }
 
         vector_dispatch_type rasterizer_dispatch(marker_ptr,
@@ -183,7 +183,7 @@ struct render_marker_symbolizer_visitor
 
         setup_transform_scaling(image_tr, mark.width(), mark.height(), feature_, common_.vars_, sym_);
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
-        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform);
+        if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         box2d<double> const& bbox = mark.bounding_box();
         mapnik::image_rgba8 const& marker = mark.get_data();
         // - clamp sizes to > 4 pixels of interactivity

--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -434,7 +434,7 @@ void text_symbolizer_helper::init_marker() const
     if (marker->is<marker_null>()) return;
     agg::trans_affine trans;
     auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
-    if (image_transform) evaluate_transform(trans, feature_, vars_, *image_transform);
+    if (image_transform) evaluate_transform(trans, feature_, vars_, *image_transform, scale_factor_);
     double width = marker->width();
     double height = marker->height();
     double px0 = - 0.5 * width;

--- a/src/text/text_line.cpp
+++ b/src/text/text_line.cpp
@@ -51,7 +51,7 @@ text_line::text_line(text_line && rhs)
 
 void text_line::add_glyph(glyph_info && glyph, double scale_factor_)
 {
-    line_height_ = std::max(line_height_, glyph.line_height() + glyph.format->line_spacing);
+    line_height_ = std::max(line_height_, glyph.line_height() + glyph.format->line_spacing * scale_factor_);
     double advance = glyph.advance();
     if (glyphs_.empty())
     {


### PR DESCRIPTION
I have encountered some issues with scale factor while trying to adapt resolution for printing.

#### Line spacing

[Line spacing](http://mapnik.org/mapnik-reference/#3.0.6/text-line-spacing) is in pixels thus should be adjusted by scale factor.

#### Transforms

There are several symbolizer properties that are explicitly documented as not supporting scale factor. All of them are transforms:
* [marker-transform](http://mapnik.org/mapnik-reference/#3.0.6/marker-transform)
* [shield-halo-transform](http://mapnik.org/mapnik-reference/#3.0.6/shield-halo-transform)
* [shield-transform](http://mapnik.org/mapnik-reference/#3.0.6/shield-transform)
* [point-transform](http://mapnik.org/mapnik-reference/#3.0.6/point-transform)
* [text-halo-transform](http://mapnik.org/mapnik-reference/#3.0.6/text-halo-transform)
* [text-transform](http://mapnik.org/mapnik-reference/#3.0.6/text-transform)

(A funny case is [text-transform](http://mapnik.org/mapnik-reference/#3.0.6/text-transform) which does string transforms.)

As you can see in [transform_processor](https://github.com/mapnik/mapnik/blob/d1b594e88614326da1124f135849a1cdcc5ada39/include/mapnik/transform_processor.hpp#L132-L137), only translations are multiplied by scale factor. That makes sense, because translation is the only transformation whose parameters are in pixels.

Missing scaling of translation is really a problem. Here is an example of markers placed along lines and translated by `transform="translate(0,-3.5)"` with `scale_factor = 1`:
![sf1](https://cloud.githubusercontent.com/assets/1950911/14985457/d2ee803c-1147-11e6-858b-5e26a30dd024.png)

With  `scale_factor = 0.5`, markers are detached from its leading lines, which is obvious, because the translation is twice as big as should be with given scale factor:
![sf2](https://cloud.githubusercontent.com/assets/1950911/14985456/d2ca05c2-1147-11e6-8823-dfcd695d77f8.png)

I think the same observation is valid also for the rest of the transforms. I removed the default value of `scale_factor` argument in [evaluate_transform()](https://github.com/mapnik/mapnik/blob/400e05585fc32a24138f7428d47b455d62a2d301/include/mapnik/symbolizer_base.hpp#L57-L61) and passed correct `scale_factor` value from all places where this function is called.






