### PR TITLE
If there're overviews, just use them for rendering

### DIFF
--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -878,9 +878,10 @@ featureset_ptr pgraster_datasource::features_with_context(query const& q,process
         std::string table_with_bbox;
         std::string col = geometryColumn_;
 
-        if ( use_overviews_ ) {
-          std::string sch = schema_;
-          std::string tab = mapnik::sql_utils::unquote_double(raster_table_);
+        if ( use_overviews_ && !overviews_.empty()) {
+          std::string sch = overviews_[0].schema;
+          std::string tab = overviews_[0].table;
+          col = overviews_[0].column;
           const double scale = std::min(px_gw, px_gh);
           std::vector<pgraster_overview>::const_reverse_iterator i;
           for (i=overviews_.rbegin(); i!=overviews_.rend(); ++i) {


### PR DESCRIPTION
The current code falls back to the base table for small scales.

That approach has some drawbacks cause it forces the original table to
share some conditions with its overviews (same SRID, alginment, scale
constraints) for the rendering to work properly.

What we propose is to always fall back to the highest resolution
overview (lowest scale), rather than the original table, in order to
avoid coupling the original table with the constraints imposed by
rendering and still have them linked (in postgis raster metadata).

Please note this approach is not 100% compatible as the base table
won't be used. This should be no big deal because overviews can have
an arbitrary resolution/scale.