### PR TITLE
Fix DejaVu font directory

### DIFF
--- a/demo/c++/rundemo.cpp
+++ b/demo/c++/rundemo.cpp
@@ -55,7 +55,7 @@ int main ( int, char** )
     try {
         std::cout << " running demo ... \n";
         datasource_cache::instance().register_datasources("plugins/input/");
-        freetype_engine::register_font("fonts/dejavu-fonts-ttf-2.34/ttf/DejaVuSans.ttf");
+        freetype_engine::register_font("fonts/dejavu-fonts-ttf-2.35/ttf/DejaVuSans.ttf");
 
         Map m(800,600);
         m.set_background(parse_color("white"));


### PR DESCRIPTION
Fonts in Mapnik tree are now 2.35 not 2.34