### PR TITLE
fix shapefiles encoding in demo for C++

### DIFF
--- a/demo/c++/rundemo.cpp
+++ b/demo/c++/rundemo.cpp
@@ -230,7 +230,7 @@ int main ( int, char** )
             parameters p;
             p["type"]="shape";
             p["file"]="demo/data/boundaries";
-            p["encoding"]="latin1";
+            p["encoding"]="utf8";
 
             layer lyr("Provinces");
             lyr.set_datasource(datasource_cache::instance().create(p));
@@ -295,7 +295,7 @@ int main ( int, char** )
             parameters p;
             p["type"]="shape";
             p["file"]="demo/data/popplaces";
-            p["encoding"] = "latin1";
+            p["encoding"] = "utf8";
             layer lyr("Populated Places");
             lyr.set_srs(srs_lcc);
             lyr.set_datasource(datasource_cache::instance().create(p));


### PR DESCRIPTION
Mapnik builds without `boost_regex_icu` (see #3440) and the C++ demo does not run:

```
/mapnik# demo/c++/rundemo `mapnik-config --prefix`                                                                                                                                         
 running demo ... 
### std::exception: could not create converter for latin1
```

With the PR changes plus demo data shapefiles converted to UTF8, it works.

For the latter, run the following in `mapnik/demo/data`:

```sh
ogr2ogr boundaries.shp boundaries.shp -lco ENCODING=UTF-8
ogr2ogr boundaries_l.shp boundaries_l.shp -lco ENCODING=UTF-8                                                                                                      
ogr2ogr ontdrainage.shp ontdrainage.shp -lco ENCODING=UTF-8                                                                                                        
ogr2ogr popplaces.shp popplaces.shp -lco ENCODING=UTF-8                                                                                                            
ogr2ogr qcdrainage.shp qcdrainage.shp -lco ENCODING=UTF-8                                                                                                          
ogr2ogr roads.shp roads.shp -lco ENCODING=UTF-8
```

(credit to @BergWerkGIS in #3037)