### PR TITLE
Fix markdown issue in C++ demo README

### DIFF
--- a/demo/c++/README.md
+++ b/demo/c++/README.md
@@ -52,11 +52,11 @@ If you do not have svn installed you can grab gyp from:
 
 Simply type:
 
-   make
+    make
 
 Then to run do:
 
-   ./rundemo `mapnik-config --prefix`
+    ./rundemo `mapnik-config --prefix`
 
 On OS X you can also create an xcode project:
 


### PR DESCRIPTION
Commands were rendered incorrectly due to missing spaces, causing that `mapnik-config --prefix` was rendered without backticks, which are necessary.