### PR TITLE
replace agg::pod_bvector with std::deque for svg path attributes

### DIFF
--- a/include/mapnik/cairo/cairo_render_vector.hpp
+++ b/include/mapnik/cairo/cairo_render_vector.hpp
@@ -26,19 +26,14 @@
 #define MAPNIK_CAIRO_RENDER_VECTOR_HPP
 
 // mapnik
-#include <mapnik/svg/svg_path_adapter.hpp>
-
-namespace agg { struct trans_affine; }
+#include <mapnik/marker.hpp>
 
 namespace mapnik {
 
 class cairo_context;
-struct pixel_position;
-template <typename T> class box2d;
-namespace svg { struct path_attributes; }
 
-void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          agg::pod_bvector<svg::path_attributes> const & attributes,
+void render_vector_marker(cairo_context & context, svg_path_adapter & svg_path,
+                          svg_attribute_type const& attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity);
 

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -27,12 +27,8 @@
 #include <mapnik/image.hpp>
 #include <mapnik/svg/svg_storage.hpp>
 #include <mapnik/svg/svg_path_adapter.hpp>
+#include <mapnik/svg/svg_path_attributes.hpp>
 #include <mapnik/util/variant.hpp>
-
-#pragma GCC diagnostic push
-#include <mapnik/warning_ignore_agg.hpp>
-#include "agg_array.h"
-#pragma GCC diagnostic pop
 
 // stl
 #include <deque>
@@ -42,10 +38,8 @@ namespace mapnik
 {
 
 struct image_any;
-namespace svg { struct path_attributes; }
 
 using svg::svg_path_adapter;
-
 using svg_attribute_type = std::deque<svg::path_attributes>;
 using svg_storage_type = svg::svg_storage<svg::svg_path_storage, svg_attribute_type>;
 using svg_path_ptr = std::shared_ptr<svg_storage_type>;

--- a/include/mapnik/marker.hpp
+++ b/include/mapnik/marker.hpp
@@ -35,6 +35,7 @@
 #pragma GCC diagnostic pop
 
 // stl
+#include <deque>
 #include <memory>
 
 namespace mapnik
@@ -45,7 +46,7 @@ namespace svg { struct path_attributes; }
 
 using svg::svg_path_adapter;
 
-using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
+using svg_attribute_type = std::deque<svg::path_attributes>;
 using svg_storage_type = svg::svg_storage<svg::svg_path_storage, svg_attribute_type>;
 using svg_path_ptr = std::shared_ptr<svg_storage_type>;
 using image_ptr = std::shared_ptr<image_any>;

--- a/include/mapnik/marker_helpers.hpp
+++ b/include/mapnik/marker_helpers.hpp
@@ -29,7 +29,7 @@
 #include <mapnik/geometry_centroid.hpp>
 #include <mapnik/symbolizer.hpp>
 #include <mapnik/svg/svg_path_attributes.hpp>
-#include <mapnik/marker.hpp> // for svg_storage_type
+#include <mapnik/marker.hpp> // svg_attribute_type, svg_storage_type
 #include <mapnik/markers_placement.hpp>
 #include <mapnik/attribute.hpp>
 #include <mapnik/box2d.hpp>
@@ -49,8 +49,6 @@
 namespace mapnik {
 
 struct clip_poly_tag;
-
-using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
 
 template <typename Detector>
 struct vector_markers_dispatch : util::noncopyable

--- a/include/mapnik/svg/svg_renderer_agg.hpp
+++ b/include/mapnik/svg/svg_renderer_agg.hpp
@@ -103,7 +103,7 @@ private:
 };
 
 template <typename VertexSource, typename AttributeSource, typename ScanlineRenderer, typename PixelFormat>
-class svg_renderer_agg : util::noncopyable
+class renderer_agg : util::noncopyable
 {
 public:
     using curved_type = agg::conv_curve<VertexSource>;
@@ -122,7 +122,7 @@ public:
     using vertex_source_type = VertexSource;
     using attribute_source_type = AttributeSource;
 
-    svg_renderer_agg(VertexSource & source, AttributeSource const& attributes)
+    renderer_agg(VertexSource & source, AttributeSource const& attributes)
         : source_(source),
           curved_(source_),
           curved_dashed_(curved_),

--- a/src/agg/agg_renderer.cpp
+++ b/src/agg/agg_renderer.cpp
@@ -376,7 +376,6 @@ struct agg_render_marker_visitor
         using pixfmt_comp_type = agg::pixfmt_custom_blend_rgba<blender_type, agg::rendering_buffer>;
         using renderer_base = agg::renderer_base<pixfmt_comp_type>;
         using renderer_type = agg::renderer_scanline_aa_solid<renderer_base>;
-        using svg_attribute_type = agg::pod_bvector<mapnik::svg::path_attributes>;
 
         ras_ptr_->reset();
         if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
@@ -403,14 +402,12 @@ struct agg_render_marker_visitor
         mtx *= agg::trans_affine_scaling(common_.scale_factor_);
         // render the marker at the center of the marker box
         mtx.translate(pos_.x, pos_.y);
-        using namespace mapnik::svg;
-        vertex_stl_adapter<svg_path_storage> stl_storage(marker.get_data()->source());
+        svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(marker.get_data()->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_agg<svg_path_adapter,
-                         svg_attribute_type,
-                         renderer_type,
-                         pixfmt_comp_type> svg_renderer(svg_path,
-                                                        marker.get_data()->attributes());
+        svg::renderer_agg<svg_path_adapter,
+                          svg_attribute_type,
+                          renderer_type,
+                          pixfmt_comp_type> svg_renderer(svg_path, marker.get_data()->attributes());
 
         // https://github.com/mapnik/mapnik/issues/1316
         // https://github.com/mapnik/mapnik/issues/1866

--- a/src/agg/process_group_symbolizer.cpp
+++ b/src/agg/process_group_symbolizer.cpp
@@ -75,11 +75,10 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
         using pixfmt_comp_type = agg::pixfmt_custom_blend_rgba<blender_type, buf_type>;
         using renderer_base = agg::renderer_base<pixfmt_comp_type>;
         using renderer_type = agg::renderer_scanline_aa_solid<renderer_base>;
-        using svg_attribute_type = agg::pod_bvector<svg::path_attributes>;
-        using svg_renderer_type = svg::svg_renderer_agg<svg_path_adapter,
-                                                        svg_attribute_type,
-                                                        renderer_type,
-                                                        pixfmt_comp_type>;
+        using svg_renderer_type = svg::renderer_agg<svg_path_adapter,
+                                                    svg_attribute_type,
+                                                    renderer_type,
+                                                    pixfmt_comp_type>;
         ras_ptr_->reset();
         buf_type render_buffer(buf_->bytes(), buf_->width(), buf_->height(), buf_->row_size());
         pixfmt_comp_type pixf(render_buffer);

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -109,7 +109,6 @@ void agg_renderer<T0,T1>::process(markers_symbolizer const& sym,
                               feature_impl & feature,
                               proj_transform const& prj_trans)
 {
-    using namespace mapnik::svg;
     using color_type = agg::rgba8;
     using order_type = agg::order_rgba;
     using blender_type = agg::comp_op_adaptor_rgba_pre<color_type, order_type>; // comp blender
@@ -117,11 +116,10 @@ void agg_renderer<T0,T1>::process(markers_symbolizer const& sym,
     using pixfmt_comp_type = agg::pixfmt_custom_blend_rgba<blender_type, buf_type>;
     using renderer_base = agg::renderer_base<pixfmt_comp_type>;
     using renderer_type = agg::renderer_scanline_aa_solid<renderer_base>;
-    using svg_attribute_type = agg::pod_bvector<path_attributes>;
-    using svg_renderer_type = svg_renderer_agg<svg_path_adapter,
-                                               svg_attribute_type,
-                                               renderer_type,
-                                               pixfmt_comp_type>;
+    using svg_renderer_type = svg::renderer_agg<svg_path_adapter,
+                                                svg_attribute_type,
+                                                renderer_type,
+                                                pixfmt_comp_type>;
 
     ras_ptr->reset();
 

--- a/src/cairo/cairo_render_vector.cpp
+++ b/src/cairo/cairo_render_vector.cpp
@@ -32,17 +32,15 @@
 namespace mapnik
 {
 
-void render_vector_marker(cairo_context & context, svg::svg_path_adapter & svg_path,
-                          agg::pod_bvector<svg::path_attributes> const & attributes,
+void render_vector_marker(cairo_context & context, svg_path_adapter & svg_path,
+                          svg_attribute_type const& attributes,
                           box2d<double> const& bbox, agg::trans_affine const& tr,
                           double opacity)
 {
-    using namespace mapnik::svg;
     agg::trans_affine transform;
 
-    for(unsigned i = 0; i < attributes.size(); ++i)
+    for (auto const& attr : attributes)
     {
-        mapnik::svg::path_attributes const& attr = attributes[i];
         if (!attr.visibility_flag)
             continue;
         cairo_save_restore guard(context);

--- a/src/cairo/cairo_renderer.cpp
+++ b/src/cairo/cairo_renderer.cpp
@@ -233,7 +233,7 @@ struct cairo_render_marker_visitor
                 marker_tr *= tr_;
             }
             marker_tr *= agg::trans_affine_scaling(common_.scale_factor_);
-            agg::pod_bvector<svg::path_attributes> const & attributes = vmarker->attributes();
+            auto const& attributes = vmarker->attributes();
             svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(vmarker->source());
             svg::svg_path_adapter svg_path(stl_storage);
             marker_tr.translate(pos_.x, pos_.y);

--- a/src/grid/grid_renderer.cpp
+++ b/src/grid/grid_renderer.cpp
@@ -172,14 +172,12 @@ struct grid_render_marker_visitor
         mtx *= agg::trans_affine_scaling(common_.scale_factor_);
         // render the marker at the center of the marker box
         mtx.translate(pos_.x, pos_.y);
-        using namespace mapnik::svg;
-        vertex_stl_adapter<svg_path_storage> stl_storage(marker.get_data()->source());
+        svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(marker.get_data()->source());
         svg_path_adapter svg_path(stl_storage);
-        svg_renderer_agg<svg_path_adapter,
-            agg::pod_bvector<path_attributes>,
-            renderer_type,
-            pixfmt_type> svg_renderer(svg_path,
-                                                marker.get_data()->attributes());
+        svg::renderer_agg<svg_path_adapter,
+                          svg_attribute_type,
+                          renderer_type,
+                          pixfmt_type> svg_renderer(svg_path, marker.get_data()->attributes());
 
         svg_renderer.render_id(*ras_ptr_, sl, renb, feature_.id(), mtx, opacity_, bbox);
     }

--- a/src/grid/process_group_symbolizer.cpp
+++ b/src/grid/process_group_symbolizer.cpp
@@ -72,20 +72,17 @@ struct thunk_renderer : render_thunk_list_dispatch
         using buf_type = grid_rendering_buffer;
         using pixfmt_type = typename grid_renderer_base_type::pixfmt_type;
         using renderer_type = agg::renderer_scanline_bin_solid<grid_renderer_base_type>;
-
-        using namespace mapnik::svg;
-        using svg_attribute_type = agg::pod_bvector<path_attributes>;
-        using svg_renderer_type = svg_renderer_agg<svg_path_adapter,
-                                                   svg_attribute_type,
-                                                   renderer_type,
-                                                   pixfmt_type>;
+        using svg_renderer_type = svg::renderer_agg<svg_path_adapter,
+                                                    svg_attribute_type,
+                                                    renderer_type,
+                                                    pixfmt_type>;
 
         buf_type render_buf(pixmap_.raw_data(), common_.width_, common_.height_, common_.width_);
         ras_.reset();
         pixfmt_type pixf(render_buf);
         grid_renderer_base_type renb(pixf);
         renderer_type ren(renb);
-        vertex_stl_adapter<svg_path_storage> stl_storage(thunk.src_->source());
+        svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(thunk.src_->source());
         svg_path_adapter svg_path(stl_storage);
         svg_renderer_type svg_renderer(svg_path, thunk.attrs_);
         agg::trans_affine offset_tr = thunk.tr_;

--- a/src/grid/process_markers_symbolizer.cpp
+++ b/src/grid/process_markers_symbolizer.cpp
@@ -141,13 +141,10 @@ void grid_renderer<T>::process(markers_symbolizer const& sym,
     using buf_type = grid_rendering_buffer;
     using pixfmt_type = typename grid_renderer_base_type::pixfmt_type;
     using renderer_type = agg::renderer_scanline_bin_solid<grid_renderer_base_type>;
-
-    using namespace mapnik::svg;
-    using svg_attribute_type = agg::pod_bvector<path_attributes>;
-    using svg_renderer_type = svg_renderer_agg<svg_path_adapter,
-                                               svg_attribute_type,
-                                               renderer_type,
-                                               pixfmt_type>;
+    using svg_renderer_type = svg::renderer_agg<svg_path_adapter,
+                                                svg_attribute_type,
+                                                renderer_type,
+                                                pixfmt_type>;
 
     buf_type render_buf(pixmap_.raw_data(), common_.width_, common_.height_, common_.width_);
     ras_ptr->reset();

--- a/src/marker_helpers.cpp
+++ b/src/marker_helpers.cpp
@@ -94,7 +94,7 @@ bool push_explicit_style(svg_attribute_type const& src,
         for(unsigned i = 0; i < src.size(); ++i)
         {
             dst.push_back(src[i]);
-            mapnik::svg::path_attributes & attr = dst.last();
+            mapnik::svg::path_attributes & attr = dst.back();
             if (!attr.visibility_flag)
                 continue;
             success = true;

--- a/src/renderer_common/render_pattern.cpp
+++ b/src/renderer_common/render_pattern.cpp
@@ -62,13 +62,12 @@ void render_pattern<image_rgba8>(rasterizer & ras,
     pixfmt pixf(buf);
     renderer_base renb(pixf);
 
-    mapnik::svg::vertex_stl_adapter<mapnik::svg::svg_path_storage> stl_storage(marker.get_data()->source());
-    mapnik::svg::svg_path_adapter svg_path(stl_storage);
-    mapnik::svg::svg_renderer_agg<mapnik::svg::svg_path_adapter,
-                                  agg::pod_bvector<mapnik::svg::path_attributes>,
-                                  renderer_solid,
-                                  pixfmt > svg_renderer(svg_path,
-                                                        marker.get_data()->attributes());
+    svg::vertex_stl_adapter<svg::svg_path_storage> stl_storage(marker.get_data()->source());
+    svg_path_adapter svg_path(stl_storage);
+    svg::renderer_agg<svg_path_adapter,
+                      svg_attribute_type,
+                      renderer_solid,
+                      pixfmt> svg_renderer(svg_path, marker.get_data()->attributes());
 
     svg_renderer.render(ras, sl, renb, mtx, opacity, bbox);
 }

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -1046,8 +1046,7 @@ void parse_linear_gradient(svg_parser & parser, rapidxml::xml_node<char> const* 
     parser.gradient_map_[parser.temporary_gradient_.first] = parser.temporary_gradient_.second;
 }
 
-svg_parser::svg_parser(svg_converter<svg_path_adapter,
-                       agg::pod_bvector<mapnik::svg::path_attributes> > & path)
+svg_parser::svg_parser(svg_converter_type & path)
     : path_(path),
       is_defs_(false) {}
 

--- a/utils/svg2png/svg2png.cpp
+++ b/utils/svg2png/svg2png.cpp
@@ -95,8 +95,9 @@ struct main_marker_visitor
 
         mapnik::svg::vertex_stl_adapter<mapnik::svg::svg_path_storage> stl_storage(marker.get_data()->source());
         mapnik::svg::svg_path_adapter svg_path(stl_storage);
-        mapnik::svg::svg_renderer_agg<mapnik::svg::svg_path_adapter,
-            agg::pod_bvector<mapnik::svg::path_attributes>,
+        mapnik::svg::renderer_agg<
+            mapnik::svg_path_adapter,
+            mapnik::svg_attribute_type,
             renderer_solid,
             agg::pixfmt_rgba32_pre > svg_renderer_this(svg_path,
                                                        marker.get_data()->attributes());


### PR DESCRIPTION
Should fix #3453 

Along the way I stripped a few `using namespace svg` that seemed overkill to bring 2-3 names.
