### PR TITLE
validate usability of postgres connection during isOK

### DIFF
--- a/plugins/input/postgis/connection.hpp
+++ b/plugins/input/postgis/connection.hpp
@@ -145,7 +145,24 @@ public:
 
     bool isOK() const
     {
-        return (!closed_) && (PQstatus(conn_) != CONNECTION_BAD);
+        if (closed_ || (PQstatus(conn_) != CONNECTION_OK))
+        {
+            return false;
+        }
+        std::string pingcmd("SELECT 1");
+        PGresult *res = PQexec(conn_, pingcmd.c_str());
+        if (!res)
+        {
+            return false;
+        }
+        ExecStatusType status = PQresultStatus(res);
+        PQclear(res);
+        res = NULL;
+        if (status != PGRES_TUPLES_OK)
+        {
+            return false;
+        }
+        return true;
     }
 
     void close()


### PR DESCRIPTION
This change adds logic to the PostGIS input plugin to handle "stale" database connections. The connection pool will now be able to recognize connections that can no longer support queries, and will not return those connections to consumers, opting to create a new connection instead.