### PR TITLE
skip tests in save_map_test.py that use unavailable input plugins

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -8,7 +8,7 @@ failures=$((failures+$?))
 
 echo "*** Running C++ tests..."
 for FILE in tests/cpp_tests/*-bin; do 
-	${FILE} -q -d .;
+  ${FILE} -q -d .;
   failures=$((failures+$?))
 done
 

--- a/tests/python_tests/datasource_test.py
+++ b/tests/python_tests/datasource_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 import os, mapnik
 
 def setup():
@@ -99,9 +99,10 @@ def test_hit_grid():
         """ encode a list of strings with run-length compression """
         return ["%d:%s" % (len(list(group)), name) for name, group in groupby(l)]
 
-    m = mapnik.Map(256,256);
-    try:
-        mapnik.load_map(m,'../data/good_maps/agg_poly_gamma_map.xml');
+    xmlfile = '../data/good_maps/agg_poly_gamma_map.xml'
+    if datasources_available(xmlfile):
+        m = mapnik.Map(256, 256)
+        mapnik.load_map(m, xmlfile)
         m.zoom_all()
         join_field = 'NAME'
         fg = [] # feature grid
@@ -117,10 +118,6 @@ def test_hit_grid():
         hit_list = '|'.join(rle_encode(fg))
         eq_(hit_list[:16],'730:|2:Greenland')
         eq_(hit_list[-12:],'1:Chile|812:')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(str(e))
 
 
 if __name__ == '__main__':

--- a/tests/python_tests/layer_modification_test.py
+++ b/tests/python_tests/layer_modification_test.py
@@ -28,9 +28,9 @@ def test_adding_datasource_to_layer():
 
 </Map>
 '''
-    m = mapnik.Map(256, 256)
+    if 'shape' in mapnik.DatasourceCache.plugin_names():
+        m = mapnik.Map(256, 256)
 
-    try:
         mapnik.load_map_from_string(m, map_string)
 
         # validate it loaded fine
@@ -65,10 +65,6 @@ def test_adding_datasource_to_layer():
         # test that assignment
         eq_(m.layers[0].srs,'+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
         eq_(lyr.srs,'+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
 
 if __name__ == "__main__":
     setup()

--- a/tests/python_tests/load_map_test.py
+++ b/tests/python_tests/load_map_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 
 import os, sys, glob, mapnik
 
@@ -30,20 +30,27 @@ def test_broken_files():
     mapnik.logger.set_severity(default_logging_severity)
 
 def test_good_files():
-    good_files = glob.glob("../data/good_maps/*.xml")
+    all_files = glob.glob("../data/good_maps/*.xml")
 
-    failures = [];
+    good_files = list()
+    for xmlfile in all_files:
+        missing_plugins = set()
+        have_inputs = datasources_available(xmlfile, missing_plugins)
+        if have_inputs:
+            good_files.append(xmlfile)
+        else:
+            print 'Notice: skipping load_map_test for %s due to unavailable input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
+
+    failures = []
+    strict = True
     for filename in good_files:
         try:
             m = mapnik.Map(512, 512)
-            strict = True
             mapnik.load_map(m, filename, strict)
             base_path = os.path.dirname(filename)
-            mapnik.load_map_from_string(m,open(filename,'rb').read(),strict,base_path)
+            mapnik.load_map_from_string(m, open(filename, 'rb').read(), strict, base_path)
         except RuntimeError, e:
-            # only test datasources that we have installed
-            if not 'Could not create datasource' in str(e):
-                failures.append('Failed to load valid map (%s)!' % filename)
+            failures.append('Failed to load valid map %s (%s)!' % (filename, str(e)))
     eq_(len(failures),0,'\n'+'\n'.join(failures))
 
 if __name__ == "__main__":

--- a/tests/python_tests/object_test.py
+++ b/tests/python_tests/object_test.py
@@ -378,9 +378,9 @@ def test_map_init_from_string():
       </Layer>
     </Map>'''
 
-    m = mapnik.Map(600, 300)
-    eq_(m.base, '')
-    try:
+    if 'shape' in mapnik.DatasourceCache.plugin_names():
+        m = mapnik.Map(600, 300)
+        eq_(m.base, '')
         mapnik.load_map_from_string(m, map_string)
         eq_(m.base, './')
         mapnik.load_map_from_string(m, map_string, False, "") # this "" will have no effect
@@ -395,10 +395,6 @@ def test_map_init_from_string():
         m.base = 'foo'
         mapnik.load_map_from_string(m, map_string, True, ".")
         eq_(m.base, '.')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
 
 # Color initialization
 @raises(Exception) # Boost.Python.ArgumentError

--- a/tests/python_tests/render_test.py
+++ b/tests/python_tests/render_test.py
@@ -5,7 +5,7 @@ from nose.tools import *
 import tempfile
 import os, mapnik
 from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 
 def setup():
     # All of the paths used are relative, if we run the tests
@@ -104,16 +104,15 @@ def get_paired_images(w,h,mapfile):
     return im,im2
 
 def test_render_from_serialization():
-    try:
-        im,im2 = get_paired_images(100,100,'../data/good_maps/building_symbolizer.xml')
-        eq_(im.tostring(),im2.tostring())
+    xmlfile = '../data/good_maps/building_symbolizer.xml'
+    if datasources_available(xmlfile):
+        im, im2 = get_paired_images(100, 100, xmlfile)
+        eq_(im.tostring(), im2.tostring())
 
-        im,im2 = get_paired_images(100,100,'../data/good_maps/polygon_symbolizer.xml')
-        eq_(im.tostring(),im2.tostring())
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
+    xmlfile = '../data/good_maps/polygon_symbolizer.xml'
+    if datasources_available(xmlfile):
+        im, im2 = get_paired_images(100, 100, xmlfile)
+        eq_(im.tostring(), im2.tostring())
 
 def test_render_points():
     if not mapnik.has_cairo(): return

--- a/tests/python_tests/save_map_test.py
+++ b/tests/python_tests/save_map_test.py
@@ -5,16 +5,32 @@ from utilities import execution_path, run_all
 import tempfile
 
 import os, sys, glob, mapnik
+from xml.etree import ElementTree
 
 def setup():
     # All of the paths used are relative, if we run the tests
     # from another directory we need to chdir()
     os.chdir(execution_path('.'))
 
-def compare_map(xml):
+def compare_map(xmlfile):
+    have_inputs = True
+    missing_plugins = set()
+    e = ElementTree.parse(xmlfile)
+    data_source_type_params = e.findall(".//Layer/Datasource/Parameter[@name=\"type\"]")
+    if data_source_type_params is not None and len(data_source_type_params) > 0:
+        for p in data_source_type_params:
+            dstype = p.text
+            if dstype not in mapnik.DatasourceCache.plugin_names():
+                have_inputs = False
+                missing_plugins.add(dstype)
+
+    if not have_inputs:
+        print 'Notice: skipping map comparison for %s due to missing input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
+        return False
+
     m = mapnik.Map(256, 256)
-    absolute_base = os.path.abspath(os.path.dirname(xml))
-    mapnik.load_map(m, xml, False, absolute_base)
+    absolute_base = os.path.abspath(os.path.dirname(xmlfile))
+    mapnik.load_map(m, xmlfile, False, absolute_base)
     (handle, test_map) = tempfile.mkstemp(suffix='.xml', prefix='mapnik-temp-map1-')
     os.close(handle)
     (handle, test_map2) = tempfile.mkstemp(suffix='.xml', prefix='mapnik-temp-map2-')
@@ -23,13 +39,13 @@ def compare_map(xml):
         os.remove(test_map)
     mapnik.save_map(m, test_map)
     new_map = mapnik.Map(256, 256)
-    mapnik.load_map(new_map, test_map,False,absolute_base)
+    mapnik.load_map(new_map, test_map, False, absolute_base)
     open(test_map2,'w').write(mapnik.save_map_to_string(new_map))
     diff = ' diff %s %s' % (os.path.abspath(test_map),os.path.abspath(test_map2))
     try:
         eq_(open(test_map).read(),open(test_map2).read())
     except AssertionError, e:
-        raise AssertionError('serialized map "%s" not the same after being reloaded, \ncompare with command:\n\n$%s' % (xml,diff))
+        raise AssertionError('serialized map "%s" not the same after being reloaded, \ncompare with command:\n\n$%s' % (xmlfile, diff))
 
     if os.path.exists(test_map):
         os.remove(test_map)


### PR DESCRIPTION
This change modifies the "save_map_test" python test to bypass maps that depend on input plugin types that are not included in the build configuration.

This of course could bypass valuable tests for specific rendering capabilities that aren't tested elsewhere. This is an inherent drawback in the current test structure, however, that couples feature tests to specific input plugins (e.g. map test "M" tests a combination of feature "A" and plugin "X", and feature "A" is not tested elsewhere). Solving that coupling was beyond the scope of ensuring tests of different build configurations completed successfully.
