### PR TITLE
Nested layers, layer level comp-op and opacity

### DIFF
--- a/include/mapnik/agg_renderer.hpp
+++ b/include/mapnik/agg_renderer.hpp
@@ -35,6 +35,7 @@
 #include <mapnik/request.hpp>
 #include <mapnik/symbolizer_enumerations.hpp>
 #include <mapnik/renderer_common.hpp>
+#include <mapnik/image_util.hpp>
 // stl
 #include <memory>
 #include <stack>
@@ -58,6 +59,53 @@ namespace mapnik {
 }
 
 namespace mapnik {
+
+template <typename T>
+class buffer_stack
+{
+public:
+    buffer_stack(std::size_t width, std::size_t height)
+        : width_(width),
+          height_(height),
+          buffers_(),
+          position_(buffers_.begin())
+    {
+    }
+
+    T & push()
+    {
+        if (position_ == buffers_.begin())
+        {
+            buffers_.emplace_front(width_, height_);
+            position_ = buffers_.begin();
+        }
+        else
+        {
+            position_--;
+            mapnik::fill(*position_, 0); // fill with transparent colour
+        }
+        return *position_;
+    }
+
+    void pop()
+    {
+        if (position_ != buffers_.end())
+        {
+            position_++;
+        }
+    }
+
+    T & top() const
+    {
+        return *position_;
+    }
+
+private:
+    const std::size_t width_;
+    const std::size_t height_;
+    std::deque<T> buffers_;
+    typename std::deque<T>::iterator position_;
+};
 
 template <typename T0, typename T1=label_collision_detector4>
 class MAPNIK_DECL agg_renderer : public feature_style_processor<agg_renderer<T0> >,
@@ -162,7 +210,8 @@ protected:
 
 private:
     std::stack<std::reference_wrapper<buffer_type>> buffers_;
-    std::stack<buffer_type> internal_buffers_;
+    buffer_stack<buffer_type> internal_buffers_;
+    std::unique_ptr<buffer_type> inflated_buffer_;
     const std::unique_ptr<rasterizer> ras_ptr;
     gamma_method_enum gamma_method_;
     double gamma_;

--- a/include/mapnik/agg_renderer.hpp
+++ b/include/mapnik/agg_renderer.hpp
@@ -37,6 +37,7 @@
 #include <mapnik/renderer_common.hpp>
 // stl
 #include <memory>
+#include <stack>
 
 // fwd declaration to avoid dependence on agg headers
 namespace agg { struct trans_affine; }
@@ -160,15 +161,13 @@ protected:
     void draw_geo_extent(box2d<double> const& extent,mapnik::color const& color);
 
 private:
-    buffer_type & pixmap_;
-    std::shared_ptr<buffer_type> internal_buffer_;
-    mutable buffer_type * current_buffer_;
-    mutable bool style_level_compositing_;
+    std::stack<std::reference_wrapper<buffer_type>> buffers_;
+    std::stack<buffer_type> internal_buffers_;
     const std::unique_ptr<rasterizer> ras_ptr;
     gamma_method_enum gamma_method_;
     double gamma_;
     renderer_common common_;
-    void setup(Map const& m);
+    void setup(Map const & m, buffer_type & pixmap);
 };
 
 extern template class MAPNIK_DECL agg_renderer<image<rgba8_t>>;

--- a/include/mapnik/feature_style_processor.hpp
+++ b/include/mapnik/feature_style_processor.hpp
@@ -30,6 +30,7 @@
 #include <mapnik/feature_style_processor_context.hpp>
 
 // stl
+#include <vector>
 #include <set>
 #include <string>
 
@@ -93,6 +94,12 @@ private:
                       featureset_ptr features,
                       proj_transform const& prj_trans);
 
+    void prepare_layers(layer_rendering_material & parent_mat,
+                        std::vector<layer> const & layers,
+                        feature_style_context_map & ctx_map,
+                        Processor & p,
+                        double scale_denom);
+
     /*!
      * \brief prepare features for rendering asynchronously.
      */
@@ -111,6 +118,7 @@ private:
      * \brief render features list queued when they are available.
      */
     void render_material(layer_rendering_material const & mat, Processor & p );
+    void render_submaterials(layer_rendering_material const & mat, Processor & p);
 
     Map const& m_;
 };

--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -63,6 +63,7 @@ struct layer_rendering_material
     std::vector<feature_type_style const*> active_styles_;
     std::vector<featureset_ptr> featureset_ptr_list_;
     std::vector<rule_cache> rule_caches_;
+    std::vector<layer_rendering_material> materials_;
 
     layer_rendering_material(layer const& lay, projection const& dest)
         :
@@ -85,6 +86,41 @@ feature_style_processor<Processor>::feature_style_processor(Map const& m, double
 }
 
 template <typename Processor>
+void feature_style_processor<Processor>::prepare_layers(layer_rendering_material & parent_mat,
+                                                        std::vector<layer> const & layers,
+                                                        feature_style_context_map & ctx_map,
+                                                        Processor & p,
+                                                        double scale_denom)
+{
+    for (layer const& lyr : layers)
+    {
+        if (lyr.visible(scale_denom))
+        {
+            std::set<std::string> names;
+            layer_rendering_material mat(lyr, parent_mat.proj0_);
+
+            prepare_layer(mat,
+                          ctx_map,
+                          p,
+                          m_.scale(),
+                          scale_denom,
+                          m_.width(),
+                          m_.height(),
+                          m_.get_current_extent(),
+                          m_.buffer_size(),
+                          names);
+
+            // Store active material
+            if (!mat.active_styles_.empty())
+            {
+                prepare_layers(mat, lyr.layers(), ctx_map, p, scale_denom);
+                parent_mat.materials_.emplace_back(std::move(mat));
+            }
+        }
+    }
+}
+
+template <typename Processor>
 void feature_style_processor<Processor>::apply(double scale_denom)
 {
     Processor & p = static_cast<Processor&>(*this);
@@ -101,44 +137,16 @@ void feature_style_processor<Processor>::apply(double scale_denom)
     // in a second time, we fetch the results and
     // do the actual rendering
 
-    std::vector<layer_rendering_material> mat_list;
-
     // Define processing context map used by datasources
     // implementing asynchronous queries
     feature_style_context_map ctx_map;
 
-    for ( layer const& lyr : m_.layers() )
+    if (!m_.layers().empty())
     {
-        if (lyr.visible(scale_denom))
-        {
-            std::set<std::string> names;
-            layer_rendering_material mat(lyr, proj);
+        layer_rendering_material root_mat(m_.layers().front(), proj);
+        prepare_layers(root_mat, m_.layers(), ctx_map, p, scale_denom);
 
-            prepare_layer(mat,
-                          ctx_map,
-                          p,
-                          m_.scale(),
-                          scale_denom,
-                          m_.width(),
-                          m_.height(),
-                          m_.get_current_extent(),
-                          m_.buffer_size(),
-                          names);
-
-            // Store active material
-            if (!mat.active_styles_.empty())
-            {
-                mat_list.emplace_back(std::move(mat));
-            }
-        }
-    }
-
-    for ( layer_rendering_material const & mat : mat_list )
-    {
-        if (!mat.active_styles_.empty())
-        {
-            render_material(mat, p);
-        }
+        render_submaterials(root_mat, p);
     }
 
     p.end_map_processing(m_);
@@ -201,9 +209,12 @@ void feature_style_processor<Processor>::apply_to_layer(layer const& lay,
                   buffer_size,
                   names);
 
+    prepare_layers(mat, lay.layers(), ctx_map, p, scale_denom);
+
     if (!mat.active_styles_.empty())
     {
         render_material(mat,p);
+        render_submaterials(mat, p);
     }
 }
 
@@ -441,10 +452,27 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material 
     }
 }
 
+template <typename Processor>
+void feature_style_processor<Processor>::render_submaterials(layer_rendering_material const & parent_mat,
+                                                             Processor & p)
+{
+    for (layer_rendering_material const & mat : parent_mat.materials_)
+    {
+        if (!mat.active_styles_.empty())
+        {
+            p.start_layer_processing(mat.lay_, mat.layer_ext2_);
+
+            render_material(mat, p);
+            render_submaterials(mat, p);
+
+            p.end_layer_processing(mat.lay_);
+        }
+    }
+}
 
 template <typename Processor>
 void feature_style_processor<Processor>::render_material(layer_rendering_material const & mat,
-                                                         Processor & p )
+                                                         Processor & p)
 {
     std::vector<feature_type_style const*> const & active_styles = mat.active_styles_;
     std::vector<featureset_ptr> const & featureset_ptr_list = mat.featureset_ptr_list_;
@@ -459,8 +487,6 @@ void feature_style_processor<Processor>::render_material(layer_rendering_materia
         }
         return;
     }
-
-    p.start_layer_processing(mat.lay_, mat.layer_ext2_);
 
     layer const& lay = mat.lay_;
 
@@ -555,7 +581,6 @@ void feature_style_processor<Processor>::render_material(layer_rendering_materia
             ++i;
         }
     }
-    p.end_layer_processing(mat.lay_);
 }
 
 template <typename Processor>

--- a/include/mapnik/layer.hpp
+++ b/include/mapnik/layer.hpp
@@ -26,6 +26,7 @@
 // mapnik
 #include <mapnik/well_known_srs.hpp>
 #include <mapnik/geometry/box2d.hpp>
+#include <mapnik/image_compositing.hpp>
 
 // stl
 #include <vector>
@@ -95,6 +96,18 @@ public:
      *         (non-const version).
      */
     std::vector<std::string>& styles();
+
+    /*! \brief Add a child layer by copying it.
+     *  @param l The layer to add.
+     */
+    void add_layer(layer const& l);
+
+    /*! \brief Add a child layer by moving it.
+     *  @param l The layer to add.
+     */
+    void add_layer(layer && l);
+
+    std::vector<layer> const& layers() const;
 
     /*!
      * @param minimum_scale_denom The minimum scale denominator
@@ -197,6 +210,12 @@ public:
      */
     box2d<double> envelope() const;
 
+    // compositing
+    void set_comp_op(composite_mode_e comp_op);
+    boost::optional<composite_mode_e> comp_op() const;
+    void set_opacity(double opacity);
+    double get_opacity() const;
+
     void set_maximum_extent(box2d<double> const& box);
     boost::optional<box2d<double> > const&  maximum_extent() const;
     void reset_maximum_extent();
@@ -215,9 +234,12 @@ private:
     bool cache_features_;
     std::string group_by_;
     std::vector<std::string> styles_;
+    std::vector<layer> layers_;
     datasource_ptr ds_;
     boost::optional<int> buffer_size_;
     boost::optional<box2d<double> > maximum_extent_;
+    boost::optional<composite_mode_e> comp_op_;
+    double opacity_;
 };
 }
 

--- a/src/agg/agg_renderer.cpp
+++ b/src/agg/agg_renderer.cpp
@@ -71,47 +71,41 @@ namespace mapnik
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, T0 & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
     : feature_style_processor<agg_renderer>(m, scale_factor),
-      pixmap_(pixmap),
-      internal_buffer_(),
-      current_buffer_(&pixmap),
-      style_level_compositing_(false),
+      buffers_(),
+      internal_buffers_(),
       ras_ptr(new rasterizer),
       gamma_method_(GAMMA_POWER),
       gamma_(1.0),
       common_(m, attributes(), offset_x, offset_y, m.width(), m.height(), scale_factor)
 {
-    setup(m);
+    setup(m, pixmap);
 }
 
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, request const& req, attributes const& vars, T0 & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
     : feature_style_processor<agg_renderer>(m, scale_factor),
-      pixmap_(pixmap),
-      internal_buffer_(),
-      current_buffer_(&pixmap),
-      style_level_compositing_(false),
+      buffers_(),
+      internal_buffers_(),
       ras_ptr(new rasterizer),
       gamma_method_(GAMMA_POWER),
       gamma_(1.0),
       common_(m, req, vars, offset_x, offset_y, req.width(), req.height(), scale_factor)
 {
-    setup(m);
+    setup(m, pixmap);
 }
 
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, T0 & pixmap, std::shared_ptr<T1> detector,
                               double scale_factor, unsigned offset_x, unsigned offset_y)
     : feature_style_processor<agg_renderer>(m, scale_factor),
-      pixmap_(pixmap),
-      internal_buffer_(),
-      current_buffer_(&pixmap),
-      style_level_compositing_(false),
+      buffers_(),
+      internal_buffers_(),
       ras_ptr(new rasterizer),
       gamma_method_(GAMMA_POWER),
       gamma_(1.0),
       common_(m, attributes(), offset_x, offset_y, m.width(), m.height(), scale_factor, detector)
 {
-    setup(m);
+    setup(m, pixmap);
 }
 
 template <typename buffer_type>
@@ -157,9 +151,11 @@ struct setup_agg_bg_visitor
 };
 
 template <typename T0, typename T1>
-void agg_renderer<T0,T1>::setup(Map const &m)
+void agg_renderer<T0,T1>::setup(Map const &m, buffer_type & pixmap)
 {
-    mapnik::set_premultiplied_alpha(pixmap_, true);
+    buffers_.emplace(pixmap);
+
+    mapnik::set_premultiplied_alpha(pixmap, true);
     boost::optional<color> const& bg = m.background();
     if (bg)
     {
@@ -167,13 +163,13 @@ void agg_renderer<T0,T1>::setup(Map const &m)
         {
             mapnik::color bg_color = *bg;
             bg_color.premultiply();
-            mapnik::fill(pixmap_, bg_color);
+            mapnik::fill(pixmap, bg_color);
         }
         else
         {
             mapnik::color bg_color = *bg;
             bg_color.set_premultiplied(true);
-            mapnik::fill(pixmap_,bg_color);
+            mapnik::fill(pixmap, bg_color);
         }
     }
 
@@ -182,7 +178,7 @@ void agg_renderer<T0,T1>::setup(Map const &m)
     {
         // NOTE: marker_cache returns premultiplied image, if needed
         std::shared_ptr<mapnik::marker const> bg_marker = mapnik::marker_cache::instance().find(*image_filename,true);
-        setup_agg_bg_visitor<buffer_type> visitor(pixmap_,
+        setup_agg_bg_visitor<buffer_type> visitor(pixmap,
                                      common_,
                                      m.background_image_comp_op(),
                                      m.background_image_opacity());
@@ -204,7 +200,7 @@ void agg_renderer<T0,T1>::start_map_processing(Map const& map)
 template <typename T0, typename T1>
 void agg_renderer<T0,T1>::end_map_processing(Map const& map)
 {
-    mapnik::demultiply_alpha(pixmap_);
+    mapnik::demultiply_alpha(buffers_.top().get());
     MAPNIK_LOG_DEBUG(agg_renderer) << "agg_renderer: End map processing";
 }
 
@@ -226,28 +222,45 @@ void agg_renderer<T0,T1>::start_layer_processing(layer const& lay, box2d<double>
     {
         common_.query_extent_.clip(*maximum_extent);
     }
+
+    if (lay.comp_op() || lay.get_opacity() < 1.0)
+    {
+        internal_buffers_.emplace(common_.width_, common_.height_);
+        buffers_.emplace(internal_buffers_.top());
+        set_premultiplied_alpha(buffers_.top().get(), true);
+    }
+    else
+    {
+        buffers_.emplace(buffers_.top().get());
+    }
 }
 
 template <typename T0, typename T1>
-void agg_renderer<T0,T1>::end_layer_processing(layer const&)
+void agg_renderer<T0,T1>::end_layer_processing(layer const& lyr)
 {
     MAPNIK_LOG_DEBUG(agg_renderer) << "agg_renderer: End layer processing";
+
+    buffer_type & current_buffer = buffers_.top().get();
+    buffers_.pop();
+    buffer_type & previous_buffer = buffers_.top().get();
+
+    if (&current_buffer != &previous_buffer)
+    {
+        composite_mode_e comp_op = lyr.comp_op() ? *lyr.comp_op() : src_over;
+        composite(previous_buffer, current_buffer,
+                  comp_op, lyr.get_opacity(),
+                  -common_.t_.offset(),
+                  -common_.t_.offset());
+        internal_buffers_.pop();
+    }
 }
 
 template <typename T0, typename T1>
 void agg_renderer<T0,T1>::start_style_processing(feature_type_style const& st)
 {
     MAPNIK_LOG_DEBUG(agg_renderer) << "agg_renderer: Start processing style";
-    if (st.comp_op() || st.image_filters().size() > 0 || st.get_opacity() < 1)
-    {
-        style_level_compositing_ = true;
-    }
-    else
-    {
-        style_level_compositing_ = false;
-    }
 
-    if (style_level_compositing_)
+    if (st.comp_op() || st.image_filters().size() > 0 || st.get_opacity() < 1)
     {
         if (st.image_filters_inflate())
         {
@@ -266,81 +279,69 @@ void agg_renderer<T0,T1>::start_style_processing(feature_type_style const& st)
             unsigned target_width = common_.width_ + (offset * 2);
             unsigned target_height = common_.height_ + (offset * 2);
             ras_ptr->clip_box(-int(offset*2),-int(offset*2),target_width,target_height);
-            if (!internal_buffer_ ||
-               (internal_buffer_->width() < target_width ||
-                internal_buffer_->height() < target_height))
-            {
-                internal_buffer_ = std::make_shared<buffer_type>(target_width,target_height);
-            }
-            else
-            {
-                mapnik::fill(*internal_buffer_, 0); // fill with transparent colour
-            }
+            internal_buffers_.emplace(target_width, target_height);
         }
         else
         {
-            if (!internal_buffer_)
-            {
-                internal_buffer_ = std::make_shared<buffer_type>(common_.width_,common_.height_);
-            }
-            else
-            {
-                mapnik::fill(*internal_buffer_, 0); // fill with transparent colour
-            }
+            internal_buffers_.emplace(common_.width_, common_.height_);
             common_.t_.set_offset(0);
             ras_ptr->clip_box(0,0,common_.width_,common_.height_);
         }
-        current_buffer_ = internal_buffer_.get();
-        set_premultiplied_alpha(*current_buffer_,true);
+        buffers_.emplace(internal_buffers_.top());
+        set_premultiplied_alpha(buffers_.top().get(), true);
     }
     else
     {
         common_.t_.set_offset(0);
         ras_ptr->clip_box(0,0,common_.width_,common_.height_);
-        current_buffer_ = &pixmap_;
+        buffers_.emplace(buffers_.top().get());
     }
 }
 
 template <typename T0, typename T1>
 void agg_renderer<T0,T1>::end_style_processing(feature_type_style const& st)
 {
-    if (style_level_compositing_)
+    buffer_type & current_buffer = buffers_.top().get();
+    buffers_.pop();
+    buffer_type & previous_buffer = buffers_.top().get();
+    if (&current_buffer != &previous_buffer)
     {
         bool blend_from = false;
         if (st.image_filters().size() > 0)
         {
             blend_from = true;
-            mapnik::filter::filter_visitor<buffer_type> visitor(*current_buffer_, common_.scale_factor_);
+            mapnik::filter::filter_visitor<buffer_type> visitor(current_buffer, common_.scale_factor_);
             for (mapnik::filter::filter_type const& filter_tag : st.image_filters())
             {
                 util::apply_visitor(visitor, filter_tag);
             }
-            mapnik::premultiply_alpha(*current_buffer_);
+            mapnik::premultiply_alpha(current_buffer);
         }
         if (st.comp_op())
         {
-            composite(pixmap_, *current_buffer_,
+            composite(previous_buffer, current_buffer,
                       *st.comp_op(), st.get_opacity(),
                       -common_.t_.offset(),
                       -common_.t_.offset());
         }
         else if (blend_from || st.get_opacity() < 1.0)
         {
-            composite(pixmap_, *current_buffer_,
+            composite(previous_buffer, current_buffer,
                       src_over, st.get_opacity(),
                       -common_.t_.offset(),
                       -common_.t_.offset());
         }
+        internal_buffers_.pop();
     }
     if (st.direct_image_filters().size() > 0)
     {
         // apply any 'direct' image filters
-        mapnik::filter::filter_visitor<buffer_type> visitor(pixmap_, common_.scale_factor_);
+        mapnik::filter::filter_visitor<buffer_type> visitor(previous_buffer, common_.scale_factor_);
         for (mapnik::filter::filter_type const& filter_tag : st.direct_image_filters())
         {
             util::apply_visitor(visitor, filter_tag);
         }
-        mapnik::premultiply_alpha(pixmap_);
+        mapnik::premultiply_alpha(previous_buffer);
     }
     MAPNIK_LOG_DEBUG(agg_renderer) << "agg_renderer: End processing style";
 }
@@ -349,7 +350,7 @@ template <typename buffer_type>
 struct agg_render_marker_visitor
 {
     agg_render_marker_visitor(renderer_common & common,
-                              buffer_type * current_buffer,
+                              buffer_type & current_buffer,
                               std::unique_ptr<rasterizer> const& ras_ptr,
                               gamma_method_enum & gamma_method,
                               double & gamma,
@@ -386,10 +387,10 @@ struct agg_render_marker_visitor
             gamma_ = 1.0;
         }
         agg::scanline_u8 sl;
-        agg::rendering_buffer buf(current_buffer_->bytes(),
-                                  current_buffer_->width(),
-                                  current_buffer_->height(),
-                                  current_buffer_->row_size());
+        agg::rendering_buffer buf(current_buffer_.bytes(),
+                                  current_buffer_.width(),
+                                  current_buffer_.height(),
+                                  current_buffer_.row_size());
         pixfmt_comp_type pixf(buf);
         pixf.comp_op(static_cast<agg::comp_op_e>(comp_op_));
         renderer_base renb(pixf);
@@ -435,10 +436,10 @@ struct agg_render_marker_visitor
             gamma_ = 1.0;
         }
         agg::scanline_u8 sl;
-        agg::rendering_buffer buf(current_buffer_->bytes(),
-                                  current_buffer_->width(),
-                                  current_buffer_->height(),
-                                  current_buffer_->row_size());
+        agg::rendering_buffer buf(current_buffer_.bytes(),
+                                  current_buffer_.width(),
+                                  current_buffer_.height(),
+                                  current_buffer_.row_size());
         pixfmt_comp_type pixf(buf);
         pixf.comp_op(static_cast<agg::comp_op_e>(comp_op_));
         renderer_base renb(pixf);
@@ -453,7 +454,7 @@ struct agg_render_marker_visitor
         {
             double cx = 0.5 * width;
             double cy = 0.5 * height;
-            composite(*current_buffer_, marker.get_data(),
+            composite(current_buffer_, marker.get_data(),
                       comp_op_, opacity_,
                       std::floor(pos_.x - cx + .5),
                       std::floor(pos_.y - cy + .5));
@@ -517,7 +518,7 @@ struct agg_render_marker_visitor
 
   private:
     renderer_common & common_;
-    buffer_type * current_buffer_;
+    buffer_type & current_buffer_;
     std::unique_ptr<rasterizer> const& ras_ptr_;
     gamma_method_enum & gamma_method_;
     double & gamma_;
@@ -536,7 +537,7 @@ void agg_renderer<T0,T1>::render_marker(pixel_position const& pos,
                                     composite_mode_e comp_op)
 {
     agg_render_marker_visitor<buffer_type> visitor(common_,
-                                                   current_buffer_,
+                                                   buffers_.top().get(),
                                                    ras_ptr,
                                                    gamma_method_,
                                                    gamma_,
@@ -550,23 +551,24 @@ void agg_renderer<T0,T1>::render_marker(pixel_position const& pos,
 template <typename T0, typename T1>
 bool agg_renderer<T0,T1>::painted()
 {
-    return pixmap_.painted();
+    return buffers_.top().get().painted();
 }
 
 template <typename T0, typename T1>
 void agg_renderer<T0,T1>::painted(bool painted)
 {
-    pixmap_.painted(painted);
+    buffers_.top().get().painted(painted);
 }
 
 template <typename T0, typename T1>
 void agg_renderer<T0,T1>::debug_draw_box(box2d<double> const& box,
                                      double x, double y, double angle)
 {
-    agg::rendering_buffer buf(current_buffer_->bytes(),
-                              current_buffer_->width(),
-                              current_buffer_->height(),
-                              current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    agg::rendering_buffer buf(current_buffer.bytes(),
+                              current_buffer.width(),
+                              current_buffer.height(),
+                              current_buffer.row_size());
     debug_draw_box(buf, box, x, y, angle);
 }
 
@@ -619,13 +621,13 @@ void agg_renderer<T0,T1>::draw_geo_extent(box2d<double> const& extent, mapnik::c
     unsigned rgba = color.rgba();
     for (double x=x0; x<x1; x++)
     {
-        mapnik::set_pixel(pixmap_, x, y0, rgba);
-        mapnik::set_pixel(pixmap_, x, y1, rgba);
+        mapnik::set_pixel(buffers_.top().get(), x, y0, rgba);
+        mapnik::set_pixel(buffers_.top().get(), x, y1, rgba);
     }
     for (double y=y0; y<y1; y++)
     {
-        mapnik::set_pixel(pixmap_, x0, y, rgba);
-        mapnik::set_pixel(pixmap_, x1, y, rgba);
+        mapnik::set_pixel(buffers_.top().get(), x0, y, rgba);
+        mapnik::set_pixel(buffers_.top().get(), x1, y, rgba);
     }
 }
 

--- a/src/agg/process_building_symbolizer.cpp
+++ b/src/agg/process_building_symbolizer.cpp
@@ -62,7 +62,8 @@ void agg_renderer<T0,T1>::process(building_symbolizer const& sym,
     using ren_base = agg::renderer_base<agg::pixfmt_rgba32_pre>;
     using renderer = agg::renderer_scanline_aa_solid<ren_base>;
 
-    agg::rendering_buffer buf(current_buffer_->bytes(),current_buffer_->width(),current_buffer_->height(), current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    agg::rendering_buffer buf(current_buffer.bytes(), current_buffer.width(), current_buffer.height(), current_buffer.row_size());
     agg::pixfmt_rgba32_pre pixf(buf);
     ren_base renb(pixf);
 

--- a/src/agg/process_debug_symbolizer.cpp
+++ b/src/agg/process_debug_symbolizer.cpp
@@ -226,7 +226,7 @@ void agg_renderer<T0,T1>::process(debug_symbolizer const& sym,
 
     if (mode == DEBUG_SYM_MODE_RINGS)
     {
-        RingRenderer<buffer_type> renderer(*ras_ptr,*current_buffer_,common_.t_,prj_trans);
+        RingRenderer<buffer_type> renderer(*ras_ptr, buffers_.top().get(), common_.t_, prj_trans);
         render_ring_visitor<buffer_type> apply(renderer);
         mapnik::util::apply_visitor(apply,feature.get_geometry());
     }
@@ -234,13 +234,13 @@ void agg_renderer<T0,T1>::process(debug_symbolizer const& sym,
     {
         for (auto const& n : *common_.detector_)
         {
-            draw_rect(pixmap_, n.get().box);
+            draw_rect(buffers_.top().get(), n.get().box);
         }
     }
     else if (mode == DEBUG_SYM_MODE_VERTEX)
     {
         using apply_vertex_mode = apply_vertex_mode<buffer_type>;
-        apply_vertex_mode apply(pixmap_, common_.t_, prj_trans);
+        apply_vertex_mode apply(buffers_.top().get(), common_.t_, prj_trans);
         util::apply_visitor(geometry::vertex_processor<apply_vertex_mode>(apply), feature.get_geometry());
     }
 }

--- a/src/agg/process_dot_symbolizer.cpp
+++ b/src/agg/process_dot_symbolizer.cpp
@@ -119,7 +119,8 @@ void agg_renderer<T0,T1>::process(dot_symbolizer const& sym,
         gamma_method_ = GAMMA_POWER;
         gamma_ = 1.0;
     }
-    agg::rendering_buffer buf(current_buffer_->bytes(),current_buffer_->width(),current_buffer_->height(),current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    agg::rendering_buffer buf(current_buffer.bytes(), current_buffer.width(), current_buffer.height(), current_buffer.row_size());
     using blender_type = agg::comp_op_adaptor_rgba_pre<agg::rgba8, agg::order_rgba>;
     using pixfmt_comp_type = agg::pixfmt_custom_blend_rgba<blender_type, agg::rendering_buffer>;
     using renderer_base = agg::renderer_base<pixfmt_comp_type>;

--- a/src/agg/process_group_symbolizer.cpp
+++ b/src/agg/process_group_symbolizer.cpp
@@ -61,10 +61,10 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
 
     thunk_renderer(renderer_type &ren,
                    std::unique_ptr<rasterizer> const& ras_ptr,
-                   buffer_type *buf,
+                   buffer_type & buf,
                    renderer_common &common)
         : ren_(ren), ras_ptr_(ras_ptr), buf_(buf), common_(common),
-          tex_(*buf, HALO_RASTERIZER_FULL, src_over, src_over,
+          tex_(buf, HALO_RASTERIZER_FULL, src_over, src_over,
                common.scale_factor_, common.font_manager_.get_stroker())
     {}
 
@@ -80,7 +80,7 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
                                                         renderer_type,
                                                         pixfmt_comp_type>;
         ras_ptr_->reset();
-        buf_type render_buffer(buf_->bytes(), buf_->width(), buf_->height(), buf_->row_size());
+        buf_type render_buffer(buf_.bytes(), buf_.width(), buf_.height(), buf_.row_size());
         pixfmt_comp_type pixf(render_buffer);
         pixf.comp_op(static_cast<agg::comp_op_e>(thunk.comp_op_));
         renderer_base renb(pixf);
@@ -101,7 +101,7 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
         using renderer_base = agg::renderer_base<pixfmt_comp_type>;
 
         ras_ptr_->reset();
-        buf_type render_buffer(buf_->bytes(), buf_->width(), buf_->height(), buf_->row_size());
+        buf_type render_buffer(buf_.bytes(), buf_.width(), buf_.height(), buf_.row_size());
         pixfmt_comp_type pixf(render_buffer);
         pixf.comp_op(static_cast<agg::comp_op_e>(thunk.comp_op_));
         renderer_base renb(pixf);
@@ -135,7 +135,7 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
 private:
     renderer_type &ren_;
     std::unique_ptr<rasterizer> const& ras_ptr_;
-    buffer_type *buf_;
+    buffer_type & buf_;
     renderer_common &common_;
     text_renderer_type tex_;
 };
@@ -145,7 +145,7 @@ void agg_renderer<T0,T1>::process(group_symbolizer const& sym,
                                   mapnik::feature_impl & feature,
                                   proj_transform const& prj_trans)
 {
-    thunk_renderer<buffer_type> ren(*this, ras_ptr, current_buffer_, common_);
+    thunk_renderer<buffer_type> ren(*this, ras_ptr, buffers_.top().get(), common_);
 
     render_group_symbolizer(
         sym, feature, common_.vars_, prj_trans, clipping_extent(common_), common_,

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -61,14 +61,12 @@ template <typename buffer_type>
 struct agg_renderer_process_visitor_l
 {
     agg_renderer_process_visitor_l(renderer_common & common,
-                                 buffer_type & pixmap,
-                                 buffer_type * current_buffer,
+                                 buffer_type & current_buffer,
                                  std::unique_ptr<rasterizer> const& ras_ptr,
                                  line_pattern_symbolizer const& sym,
                                  mapnik::feature_impl & feature,
                                  proj_transform const& prj_trans)
         : common_(common),
-          pixmap_(pixmap),
           current_buffer_(current_buffer),
           ras_ptr_(ras_ptr),
           sym_(sym),
@@ -112,8 +110,8 @@ private:
         value_double simplify_tolerance = get<value_double, keys::simplify_tolerance>(sym_, feature_, common_.vars_);
         value_double smooth = get<value_double, keys::smooth>(sym_, feature_, common_.vars_);
 
-        agg::rendering_buffer buf(current_buffer_->bytes(),current_buffer_->width(),
-                                  current_buffer_->height(), current_buffer_->row_size());
+        agg::rendering_buffer buf(current_buffer_.bytes(), current_buffer_.width(),
+                                  current_buffer_.height(), current_buffer_.row_size());
         pixfmt_type pixf(buf);
         pixf.comp_op(static_cast<agg::comp_op_e>(get<composite_mode_e, keys::comp_op>(sym_, feature_, common_.vars_)));
         renderer_base ren_base(pixf);
@@ -134,7 +132,7 @@ private:
         box2d<double> clip_box = clipping_extent(common_);
         if (clip)
         {
-            double padding = (double)(common_.query_extent_.width()/pixmap_.width());
+            double padding = (double)(common_.query_extent_.width() / common_.width_);
             if (half_stroke > 1)
                 padding *= half_stroke;
             if (std::fabs(offset) > 0)
@@ -163,8 +161,7 @@ private:
     }
 
     renderer_common & common_;
-    buffer_type & pixmap_;
-    buffer_type * current_buffer_;
+    buffer_type & current_buffer_;
     std::unique_ptr<rasterizer> const& ras_ptr_;
     line_pattern_symbolizer const& sym_;
     mapnik::feature_impl & feature_;
@@ -189,8 +186,7 @@ void  agg_renderer<T0,T1>::process(line_pattern_symbolizer const& sym,
     }
     std::shared_ptr<mapnik::marker const> marker = marker_cache::instance().find(filename, true);
     agg_renderer_process_visitor_l<buffer_type> visitor(common_,
-                                         pixmap_,
-                                         current_buffer_,
+                                         buffers_.top().get(),
                                          ras_ptr,
                                          sym,
                                          feature,

--- a/src/agg/process_line_symbolizer.cpp
+++ b/src/agg/process_line_symbolizer.cpp
@@ -112,7 +112,8 @@ void agg_renderer<T0,T1>::process(line_symbolizer const& sym,
         gamma_ = gamma;
     }
 
-    agg::rendering_buffer buf(current_buffer_->bytes(),current_buffer_->width(),current_buffer_->height(), current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    agg::rendering_buffer buf(current_buffer.bytes(), current_buffer.width(), current_buffer.height(), current_buffer.row_size());
 
     using color_type = agg::rgba8;
     using order_type = agg::order_rgba;
@@ -139,7 +140,7 @@ void agg_renderer<T0,T1>::process(line_symbolizer const& sym,
     line_rasterizer_enum rasterizer_e = get<line_rasterizer_enum, keys::line_rasterizer>(sym, feature, common_.vars_);
     if (clip)
     {
-        double padding = static_cast<double>(common_.query_extent_.width()/pixmap_.width());
+        double padding = static_cast<double>(common_.query_extent_.width() / common_.width_);
         double half_stroke = 0.5 * width;
         if (half_stroke > 1)
         {

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -132,7 +132,8 @@ void agg_renderer<T0,T1>::process(markers_symbolizer const& sym,
         gamma_ = gamma;
     }
 
-    buf_type render_buffer(current_buffer_->bytes(), current_buffer_->width(), current_buffer_->height(), current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    buf_type render_buffer(current_buffer.bytes(), current_buffer.width(), current_buffer.height(), current_buffer.row_size());
     box2d<double> clip_box = clipping_extent(common_);
 
     using renderer_context_type = detail::agg_markers_renderer_context<svg_renderer_type,

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -62,7 +62,7 @@ template <typename buffer_type>
 struct agg_renderer_process_visitor_p
 {
     agg_renderer_process_visitor_p(renderer_common & common,
-                                   buffer_type * current_buffer,
+                                   buffer_type & current_buffer,
                                    std::unique_ptr<rasterizer> const& ras_ptr,
                                    gamma_method_enum & gamma_method,
                                    double & gamma,
@@ -99,8 +99,8 @@ struct agg_renderer_process_visitor_p
 private:
     void render(mapnik::image_rgba8 const& image) const
     {
-        agg::rendering_buffer buf(current_buffer_->bytes(), current_buffer_->width(),
-                                  current_buffer_->height(), current_buffer_->row_size());
+        agg::rendering_buffer buf(current_buffer_.bytes(), current_buffer_.width(),
+                                  current_buffer_.height(), current_buffer_.row_size());
         ras_ptr_->reset();
         value_double gamma = get<value_double, keys::gamma>(sym_, feature_, common_.vars_);
         gamma_method_enum gamma_method = get<gamma_method_enum, keys::gamma_method>(sym_, feature_, common_.vars_);
@@ -158,8 +158,8 @@ private:
             apply_local_alignment apply(common_.t_,prj_trans_, clip_box, x0, y0);
             util::apply_visitor(geometry::vertex_processor<apply_local_alignment>(apply), feature_.get_geometry());
 
-            offset_x = unsigned(current_buffer_->width() - x0);
-            offset_y = unsigned(current_buffer_->height() - y0);
+            offset_x = unsigned(current_buffer_.width() - x0);
+            offset_y = unsigned(current_buffer_.height() - y0);
         }
 
         span_gen_type sg(img_src, offset_x, offset_y);
@@ -194,7 +194,7 @@ private:
     }
 
     renderer_common & common_;
-    buffer_type * current_buffer_;
+    buffer_type & current_buffer_;
     std::unique_ptr<rasterizer> const& ras_ptr_;
     gamma_method_enum & gamma_method_;
     double & gamma_;
@@ -212,7 +212,7 @@ void agg_renderer<T0,T1>::process(polygon_pattern_symbolizer const& sym,
     if (filename.empty()) return;
     std::shared_ptr<mapnik::marker const> marker = marker_cache::instance().find(filename, true);
     agg_renderer_process_visitor_p<buffer_type> visitor(common_,
-                                                        current_buffer_,
+                                                        buffers_.top().get(),
                                                         ras_ptr,
                                                         gamma_method_,
                                                         gamma_,

--- a/src/agg/process_polygon_symbolizer.cpp
+++ b/src/agg/process_polygon_symbolizer.cpp
@@ -63,9 +63,10 @@ void agg_renderer<T0,T1>::process(polygon_symbolizer const& sym,
         gamma_ = gamma;
     }
 
-    box2d<double> clip_box = clipping_extent(common_);
-    agg::rendering_buffer buf(current_buffer_->bytes(),current_buffer_->width(),current_buffer_->height(), current_buffer_->row_size());
+    buffer_type & current_buffer = buffers_.top().get();
+    agg::rendering_buffer buf(current_buffer.bytes(), current_buffer.width(), current_buffer.height(), current_buffer.row_size());
 
+    box2d<double> clip_box = clipping_extent(common_);
     render_polygon_symbolizer<vertex_converter_type>(
         sym, feature, prj_trans, common_, clip_box, *ras_ptr,
         [&](color const &fill, double opacity) {

--- a/src/agg/process_raster_symbolizer.cpp
+++ b/src/agg/process_raster_symbolizer.cpp
@@ -55,7 +55,7 @@ void agg_renderer<T0,T1>::process(raster_symbolizer const& sym,
         sym, feature, prj_trans, common_,
         [&](image_rgba8 const & target, composite_mode_e comp_op, double opacity,
             int start_x, int start_y) {
-            composite(*current_buffer_, target,
+            composite(buffers_.top().get(), target,
                       comp_op, opacity, start_x, start_y);
         }
     );

--- a/src/agg/process_shield_symbolizer.cpp
+++ b/src/agg/process_shield_symbolizer.cpp
@@ -51,7 +51,7 @@ void  agg_renderer<T0,T1>::process(shield_symbolizer const& sym,
     halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym, keys::halo_rasterizer, feature, common_.vars_, HALO_RASTERIZER_FULL);
     composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
     composite_mode_e halo_comp_op = get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
-    agg_text_renderer<T0> ren(*current_buffer_,
+    agg_text_renderer<T0> ren(buffers_.top().get(),
                               halo_rasterizer,
                               comp_op,
                               halo_comp_op,

--- a/src/agg/process_text_symbolizer.cpp
+++ b/src/agg/process_text_symbolizer.cpp
@@ -52,7 +52,7 @@ void agg_renderer<T0,T1>::process(text_symbolizer const& sym,
     halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym, keys::halo_rasterizer,feature, common_.vars_, HALO_RASTERIZER_FULL);
     composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
     composite_mode_e halo_comp_op = get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
-    agg_text_renderer<T0> ren(*current_buffer_,
+    agg_text_renderer<T0> ren(buffers_.top().get(),
                               halo_rasterizer,
                               comp_op,
                               halo_comp_op,

--- a/src/cairo/cairo_renderer.cpp
+++ b/src/cairo/cairo_renderer.cpp
@@ -188,12 +188,25 @@ void cairo_renderer<T>::start_layer_processing(layer const& lay, box2d<double> c
         common_.detector_->clear();
     }
     common_.query_extent_ = query_extent;
+
+    if (lay.comp_op() || lay.get_opacity() < 1.0)
+    {
+        context_.push_group();
+    }
 }
 
 template <typename T>
-void cairo_renderer<T>::end_layer_processing(layer const&)
+void cairo_renderer<T>::end_layer_processing(layer const& lay)
 {
     MAPNIK_LOG_DEBUG(cairo_renderer) << "cairo_renderer: End layer processing";
+
+    if (lay.comp_op() || lay.get_opacity() < 1.0)
+    {
+        context_.pop_group();
+        composite_mode_e comp_op = lay.comp_op() ? *lay.comp_op() : src_over;
+        context_.set_operator(comp_op);
+        context_.paint(lay.get_opacity());
+    }
 }
 
 template <typename T>

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -42,9 +42,13 @@ layer::layer(std::string const& _name, std::string const& _srs)
       cache_features_(false),
       group_by_(),
       styles_(),
+      layers_(),
       ds_(),
       buffer_size_(),
-      maximum_extent_() {}
+      maximum_extent_(),
+      comp_op_(),
+      opacity_(1.0f)
+{}
 
 layer::layer(layer const& rhs)
     : name_(rhs.name_),
@@ -57,9 +61,13 @@ layer::layer(layer const& rhs)
       cache_features_(rhs.cache_features_),
       group_by_(rhs.group_by_),
       styles_(rhs.styles_),
+      layers_(rhs.layers_),
       ds_(rhs.ds_),
       buffer_size_(rhs.buffer_size_),
-      maximum_extent_(rhs.maximum_extent_) {}
+      maximum_extent_(rhs.maximum_extent_),
+      comp_op_(rhs.comp_op_),
+      opacity_(rhs.opacity_)
+{}
 
 layer::layer(layer && rhs)
     : name_(std::move(rhs.name_)),
@@ -72,9 +80,13 @@ layer::layer(layer && rhs)
       cache_features_(std::move(rhs.cache_features_)),
       group_by_(std::move(rhs.group_by_)),
       styles_(std::move(rhs.styles_)),
+      layers_(std::move(rhs.layers_)),
       ds_(std::move(rhs.ds_)),
       buffer_size_(std::move(rhs.buffer_size_)),
-      maximum_extent_(std::move(rhs.maximum_extent_)) {}
+      maximum_extent_(std::move(rhs.maximum_extent_)),
+      comp_op_(std::move(rhs.comp_op_)),
+      opacity_(std::move(rhs.opacity_))
+{}
 
 layer& layer::operator=(layer rhs)
 {
@@ -92,6 +104,8 @@ layer& layer::operator=(layer rhs)
     std::swap(this->ds_, rhs.ds_);
     std::swap(this->buffer_size_, rhs.buffer_size_);
     std::swap(this->maximum_extent_, rhs.maximum_extent_);
+    std::swap(this->comp_op_, rhs.comp_op_);
+    std::swap(this->opacity_, rhs.opacity_);
     return *this;
 }
 
@@ -109,7 +123,9 @@ bool layer::operator==(layer const& rhs) const
         (styles_ == rhs.styles_) &&
         ((ds_ && rhs.ds_) ? *ds_ == *rhs.ds_ : ds_ == rhs.ds_) &&
         (buffer_size_ == rhs.buffer_size_) &&
-        (maximum_extent_ == rhs.maximum_extent_);
+        (maximum_extent_ == rhs.maximum_extent_) &&
+        (comp_op_ == rhs.comp_op_) &&
+        (opacity_ == rhs.opacity_);
 }
 
 layer::~layer() {}
@@ -147,6 +163,21 @@ std::vector<std::string> const& layer::styles() const
 std::vector<std::string> & layer::styles()
 {
     return styles_;
+}
+
+void layer::add_layer(layer const& l)
+{
+    layers_.emplace_back(l);
+}
+
+void layer::add_layer(layer && l)
+{
+    layers_.push_back(std::move(l));
+}
+
+std::vector<layer> const& layer::layers() const
+{
+    return layers_;
 }
 
 void layer::set_minimum_scale_denominator(double minimum_scale_denom)
@@ -268,6 +299,26 @@ void layer::set_group_by(std::string const& column)
 std::string const& layer::group_by() const
 {
     return group_by_;
+}
+
+void layer::set_comp_op(composite_mode_e comp_op)
+{
+    comp_op_ = comp_op;
+}
+
+boost::optional<composite_mode_e> layer::comp_op() const
+{
+    return comp_op_;
+}
+
+void layer::set_opacity(double opacity)
+{
+    opacity_ = opacity;
+}
+
+double layer::get_opacity() const
+{
+    return opacity_;
 }
 
 }

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -104,7 +104,10 @@ public:
 private:
     void parse_map_include(Map & map, xml_node const& node);
     void parse_style(Map & map, xml_node const& node);
-    void parse_layer(Map & map, xml_node const& node);
+
+    template <typename Parent>
+    void parse_layer(Parent & parent, xml_node const& node);
+
     void parse_symbolizer_base(symbolizer_base &sym, xml_node const& node);
     void parse_fontset(Map & map, xml_node const & node);
     bool parse_font(font_set & fset, xml_node const& f);
@@ -559,7 +562,8 @@ bool map_parser::parse_font(font_set & fset, xml_node const& f)
     return false;
 }
 
-void map_parser::parse_layer(Map & map, xml_node const& node)
+template <typename Parent>
+void map_parser::parse_layer(Parent & parent, xml_node const& node)
 {
     std::string name;
     try
@@ -575,7 +579,7 @@ void map_parser::parse_layer(Map & map, xml_node const& node)
         name = node.get_attr("name", std::string("Unnamed"));
 
         // If no projection is given inherit from map
-        std::string srs = node.get_attr("srs", map.srs());
+        std::string srs = node.get_attr("srs", parent.srs());
         try
         {
             // create throwaway projection object here to ensure it is valid
@@ -679,6 +683,24 @@ void map_parser::parse_layer(Map & map, xml_node const& node)
             }
         }
 
+        // compositing
+        optional<std::string> comp_op_name = node.get_opt_attr<std::string>("comp-op");
+        if (comp_op_name)
+        {
+            optional<composite_mode_e> comp_op = comp_op_from_string(*comp_op_name);
+            if (comp_op)
+            {
+                lyr.set_comp_op(*comp_op);
+            }
+            else
+            {
+                throw config_error("failed to parse comp-op: '" + *comp_op_name + "'");
+            }
+        }
+
+        optional<double> opacity = node.get_opt_attr<double>("opacity");
+        if (opacity) lyr.set_opacity(*opacity);
+
         for (auto const& child: node)
         {
 
@@ -758,8 +780,12 @@ void map_parser::parse_layer(Map & map, xml_node const& node)
                     throw config_error("Unknown exception occurred attempting to create datasoure for layer '" + lyr.name() + "'");
                 }
             }
+            else if (child.is("Layer"))
+            {
+                parse_layer(lyr, child);
+            }
         }
-        map.add_layer(std::move(lyr));
+        parent.add_layer(std::move(lyr));
     }
     catch (config_error const& ex)
     {


### PR DESCRIPTION
Enables [grouped compositing](https://github.com/mapnik/mapnik/wiki/Compositing#grouped-compositing) and improves layer organization.

Layers are rendered recursively, creating it's own buffer if `comp-op` or `opacity` properties are set. Otherwise, rendering buffer is inherited from parent layer.

All tests are passing except some SVGs with changes in grouping SVG elements per `Layer`.

Here is a simple example.

``` xml
<Map background-color="darkblue" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
    <Parameters>
        <Parameter name="sizes">512,256</Parameter>
        <Parameter name="bbox">-20037508.3427892476320267,1283343.6938826972618699,20037508.3427892439067364,13365151.3630704730749130</Parameter>
    </Parameters>
    <Style name="world">
        <Rule>
            <PolygonSymbolizer fill="white"/>
        </Rule>
    </Style>
    <Style name="text">
        <Rule>
            <TextSymbolizer size="120" dy="-50" halo-radius="8" face-name="DejaVu Sans Bold" fill="white" vertical-alignment="top" placement="point">WORLD</TextSymbolizer>
        </Rule>
    </Style>

    <Layer name="world" comp-op="src-over" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
        <StyleName>world</StyleName>
        <Datasource>
            <Parameter name="file">../../data/shp/world_merc</Parameter>
            <Parameter name="type">shape</Parameter>
        </Datasource>

        <Layer name="text" comp-op="dst-in" srs="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs">
            <StyleName>text</StyleName>
            <Datasource>
                <Parameter name="type">csv</Parameter>
                <Parameter name="inline">
                    x, y
                    0, 0
                </Parameter>
            </Datasource>
        </Layer>
    </Layer>
</Map>
```

![marker-whole-multi-polygon-512-256-1 0-agg](https://cloud.githubusercontent.com/assets/1950911/17253478/46b33b54-55b1-11e6-8881-6831ad675ea3.png)
