### PR TITLE
use proper feature-test macro for inheriting constructors

### DIFF
--- a/include/mapnik/geometry.hpp
+++ b/include/mapnik/geometry.hpp
@@ -146,13 +146,19 @@ struct geometry : geometry_base<T>
 {
     using coord_type = T;
 
-    geometry()
-        : geometry_base<T>() {} // empty
+#if __cpp_inheriting_constructors >= 200802
+
+    using geometry_base<T>::geometry_base;
+
+#else
+
+    geometry() = default;
 
     template <typename G>
     geometry(G && geom)
         : geometry_base<T>(std::forward<G>(geom)) {}
 
+#endif
 };
 
 template <typename T>

--- a/include/mapnik/json/generic_json.hpp
+++ b/include/mapnik/json/generic_json.hpp
@@ -57,15 +57,18 @@ using json_value_base = mapnik::util::variant<value_null,
                                               mapnik::util::recursive_wrapper<json_object> >;
 struct json_value : json_value_base
 {
+#if __cpp_inheriting_constructors >= 200802
 
-#ifdef _WINDOWS
+    using json_value_base::json_value_base;
+
+#else
+
     json_value() = default;
+
     template <typename T>
     json_value(T && val)
         : json_value_base(std::forward<T>(val)) {}
-#else
-    // MSVC 2015 inheriting constructors is not working in this context (support is apparently planned)
-    using json_value_base::json_value_base;
+
 #endif
 };
 


### PR DESCRIPTION
Finally found the proper way to test for support of inheriting constructors. [P0096R2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0096r2.html)

These are not all instances of inheriting constructors in mapnik, in order to be 100% correct we should probably guard the rest as well.

But apparently MSVC has partial support, i.e. it's fine with simple non-template constructors. It only ICEs when we try to inherit templated constructors. Luckily it doesn't define the feature-test macro; and hopefully once it gets complete support, it will define it.