### PR TITLE
Bypass unavailable plugins in Python tests (2.3.x)

### DIFF
--- a/tests/python_tests/datasource_test.py
+++ b/tests/python_tests/datasource_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 import os, mapnik
 
 def setup():
@@ -126,9 +126,10 @@ def test_hit_grid():
         """ encode a list of strings with run-length compression """
         return ["%d:%s" % (len(list(group)), name) for name, group in groupby(l)]
 
-    m = mapnik.Map(256,256);
-    try:
-        mapnik.load_map(m,'../data/good_maps/agg_poly_gamma_map.xml');
+    xmlfile = '../data/good_maps/agg_poly_gamma_map.xml'
+    if datasources_available(xmlfile):
+        m = mapnik.Map(256,256);
+        mapnik.load_map(m, xmlfile);
         m.zoom_all()
         join_field = 'NAME'
         fg = [] # feature grid
@@ -144,10 +145,6 @@ def test_hit_grid():
         hit_list = '|'.join(rle_encode(fg))
         eq_(hit_list[:16],'730:|2:Greenland')
         eq_(hit_list[-12:],'1:Chile|812:')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(str(e))
 
 
 if __name__ == '__main__':

--- a/tests/python_tests/layer_modification_test.py
+++ b/tests/python_tests/layer_modification_test.py
@@ -28,47 +28,46 @@ def test_adding_datasource_to_layer():
 
 </Map>
 '''
+    if 'shape' not in mapnik.DatasourceCache.plugin_names():
+        print "skipping test_adding_datasource_to_layer because \"shape\" plugin is not available"
+        return
+
     m = mapnik.Map(256, 256)
 
-    try:
-        mapnik.load_map_from_string(m, map_string)
+    mapnik.load_map_from_string(m, map_string)
 
-        # validate it loaded fine
-        eq_(m.layers[0].styles[0],'world_borders_style')
-        eq_(m.layers[0].styles[1],'point_style')
-        eq_(len(m.layers),1)
+    # validate it loaded fine
+    eq_(m.layers[0].styles[0], 'world_borders_style')
+    eq_(m.layers[0].styles[1], 'point_style')
+    eq_(len(m.layers), 1)
 
-        # also assign a variable reference to that layer
-        # below we will test that this variable references
-        # the same object that is attached to the map
-        lyr = m.layers[0]
+    # also assign a variable reference to that layer
+    # below we will test that this variable references
+    # the same object that is attached to the map
+    lyr = m.layers[0]
 
-        # ensure that there was no datasource for the layer...
-        eq_(m.layers[0].datasource,None)
-        eq_(lyr.datasource,None)
+    # ensure that there was no datasource for the layer...
+    eq_(m.layers[0].datasource, None)
+    eq_(lyr.datasource, None)
 
-        # also note that since the srs was black it defaulted to wgs84
-        eq_(m.layers[0].srs,'+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-        eq_(lyr.srs,'+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    # also note that since the srs was black it defaulted to wgs84
+    eq_(m.layers[0].srs, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    eq_(lyr.srs, '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
 
-        # now add a datasource one...
-        ds = mapnik.Shapefile(file='../data/shp/world_merc.shp')
-        m.layers[0].datasource = ds
+    # now add a datasource one...
+    ds = mapnik.Shapefile(file='../data/shp/world_merc.shp')
+    m.layers[0].datasource = ds
 
-        # now ensure it is attached
-        eq_(m.layers[0].datasource.describe()['name'],"shape")
-        eq_(lyr.datasource.describe()['name'],"shape")
+    # now ensure it is attached
+    eq_(m.layers[0].datasource.describe()['name'], "shape")
+    eq_(lyr.datasource.describe()['name'], "shape")
 
-        # and since we have now added a shapefile in spherical mercator, adjust the projection
-        lyr.srs = '+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs'
+    # and since we have now added a shapefile in spherical mercator, adjust the projection
+    lyr.srs = '+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs'
 
-        # test that assignment
-        eq_(m.layers[0].srs,'+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
-        eq_(lyr.srs,'+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
+    # test that assignment
+    eq_(m.layers[0].srs, '+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
+    eq_(lyr.srs, '+proj=merc +lon_0=0 +lat_ts=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs')
 
 if __name__ == "__main__":
     setup()

--- a/tests/python_tests/load_map_test.py
+++ b/tests/python_tests/load_map_test.py
@@ -48,7 +48,7 @@ def test_good_files():
         if have_inputs:
             good_files.append(xmlfile)
         else:
-            print 'Notice: skipping load_map_test for %s due to missing input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
+            print 'Notice: skipping load_map_test for %s due to unavailable input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
 
     failures = [];
     strict = False

--- a/tests/python_tests/object_test.py
+++ b/tests/python_tests/object_test.py
@@ -236,7 +236,6 @@ def test_markers_symbolizer():
     eq_(p.clip,True)
     eq_(p.comp_op,mapnik.CompositeOp.src_over)
 
-
     p.width = mapnik.Expression('12')
     p.height = mapnik.Expression('12')
     eq_(str(p.width),'12')
@@ -378,9 +377,9 @@ def test_map_init_from_string():
       </Layer>
     </Map>'''
 
-    m = mapnik.Map(600, 300)
-    eq_(m.base, '')
-    try:
+    if 'shape' in mapnik.DatasourceCache.plugin_names():
+        m = mapnik.Map(600, 300)
+        eq_(m.base, '')
         mapnik.load_map_from_string(m, map_string)
         eq_(m.base, './')
         mapnik.load_map_from_string(m, map_string, False, "") # this "" will have no effect
@@ -395,10 +394,6 @@ def test_map_init_from_string():
         m.base = 'foo'
         mapnik.load_map_from_string(m, map_string, True, ".")
         eq_(m.base, '.')
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
 
 # Color initialization
 @raises(Exception) # Boost.Python.ArgumentError

--- a/tests/python_tests/raster_symbolizer_test.py
+++ b/tests/python_tests/raster_symbolizer_test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 from nose.tools import *
-from utilities import execution_path, run_all, contains_word, get_unique_colors
+from utilities import execution_path, run_all, contains_word, get_unique_colors,\
+    datasources_available
 
 import os, mapnik
 
@@ -89,27 +90,22 @@ def test_dataraster_query_point():
         assert len(features) == 0
 
 def test_load_save_map():
-    map = mapnik.Map(256,256)
+    m = mapnik.Map(256,256)
     in_map = "../visual_tests/styles/raster_symbolizer.xml"
-    try:
-        mapnik.load_map(map, in_map)
-
-        out_map = mapnik.save_map_to_string(map)
+    if datasources_available(in_map):
+        mapnik.load_map(m, in_map)
+        out_map = mapnik.save_map_to_string(m)
         assert 'RasterSymbolizer' in out_map
         assert 'RasterColorizer' in out_map
         assert 'stop' in out_map
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(str(e))
 
 def test_raster_with_alpha_blends_correctly_with_background():
     WIDTH = 500
     HEIGHT = 500
 
-    map = mapnik.Map(WIDTH, HEIGHT)
+    m = mapnik.Map(WIDTH, HEIGHT)
     WHITE = mapnik.Color(255, 255, 255)
-    map.background = WHITE
+    m.background = WHITE
 
     style = mapnik.Style()
     rule = mapnik.Rule()
@@ -119,20 +115,20 @@ def test_raster_with_alpha_blends_correctly_with_background():
     rule.symbols.append(symbolizer)
     style.rules.append(rule)
 
-    map.append_style('raster_style', style)
+    m.append_style('raster_style', style)
 
     map_layer = mapnik.Layer('test_layer')
     filepath = '../data/raster/white-alpha.png'
     if 'gdal' in mapnik.DatasourceCache.plugin_names():
         map_layer.datasource = mapnik.Gdal(file=filepath)
         map_layer.styles.append('raster_style')
-        map.layers.append(map_layer)
+        m.layers.append(map_layer)
 
-        map.zoom_all()
+        m.zoom_all()
 
         mim = mapnik.Image(WIDTH, HEIGHT)
 
-        mapnik.render(map, mim)
+        mapnik.render(m, mim)
         imdata = mim.tostring()
         # All white is expected
         eq_(get_unique_colors(mim),['rgba(254,254,254,255)'])

--- a/tests/python_tests/render_test.py
+++ b/tests/python_tests/render_test.py
@@ -4,8 +4,7 @@
 from nose.tools import *
 import tempfile
 import os, mapnik
-from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 
 def setup():
     # All of the paths used are relative, if we run the tests
@@ -105,16 +104,15 @@ def get_paired_images(w,h,mapfile):
     return im,im2
 
 def test_render_from_serialization():
-    try:
-        im,im2 = get_paired_images(100,100,'../data/good_maps/building_symbolizer.xml')
+    xmlfile = '../data/good_maps/building_symbolizer.xml'
+    if datasources_available(xmlfile):
+        im, im2 = get_paired_images(100, 100, xmlfile)
         eq_(im.tostring('png32'),im2.tostring('png32'))
 
-        im,im2 = get_paired_images(100,100,'../data/good_maps/polygon_symbolizer.xml')
+    xmlfile = '../data/good_maps/polygon_symbolizer.xml'
+    if datasources_available(xmlfile):
+        im, im2 = get_paired_images(100, 100, xmlfile)
         eq_(im.tostring('png32'),im2.tostring('png32'))
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(e)
 
 def test_render_points():
     if not mapnik.has_cairo(): return

--- a/tests/python_tests/save_map_test.py
+++ b/tests/python_tests/save_map_test.py
@@ -23,7 +23,7 @@ def compare_map(xmlfile):
     missing_plugins = set()
     have_inputs = datasources_available(xmlfile, missing_plugins)
     if not have_inputs:
-        print 'Notice: skipping saved map comparison for %s due to missing input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
+        print 'Notice: skipping saved map comparison for %s due to unavailable input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
         return False
 
     m = mapnik.Map(256, 256)

--- a/tests/python_tests/save_map_test.py
+++ b/tests/python_tests/save_map_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from nose.tools import *
-from utilities import execution_path, run_all
+from utilities import execution_path, run_all, datasources_available
 import tempfile
 
 import os, sys, glob, mapnik
@@ -19,16 +19,16 @@ def setup():
 def teardown():
     mapnik.logger.set_severity(default_logging_severity)
 
-def compare_map(xml):
+def compare_map(xmlfile):
+    missing_plugins = set()
+    have_inputs = datasources_available(xmlfile, missing_plugins)
+    if not have_inputs:
+        print 'Notice: skipping saved map comparison for %s due to missing input plugins: %s' % (os.path.basename(xmlfile), list(missing_plugins))
+        return False
+
     m = mapnik.Map(256, 256)
-    absolute_base = os.path.abspath(os.path.dirname(xml))
-    try:
-        mapnik.load_map(m, xml, True, absolute_base)
-    except RuntimeError, e:
-        # only test datasources that we have installed
-        if not 'Could not create datasource' in str(e):
-            raise RuntimeError(str(e))
-        return
+    absolute_base = os.path.abspath(os.path.dirname(xmlfile))
+    mapnik.load_map(m, xmlfile, True, absolute_base)
     (handle, test_map) = tempfile.mkstemp(suffix='.xml', prefix='mapnik-temp-map1-')
     os.close(handle)
     (handle, test_map2) = tempfile.mkstemp(suffix='.xml', prefix='mapnik-temp-map2-')
@@ -38,12 +38,12 @@ def compare_map(xml):
     mapnik.save_map(m, test_map)
     new_map = mapnik.Map(256, 256)
     mapnik.load_map(new_map, test_map, True, absolute_base)
-    open(test_map2,'w').write(mapnik.save_map_to_string(new_map))
+    open(test_map2, 'w').write(mapnik.save_map_to_string(new_map))
     diff = ' diff %s %s' % (os.path.abspath(test_map),os.path.abspath(test_map2))
     try:
-        eq_(open(test_map).read(),open(test_map2).read())
+        eq_(open(test_map).read(), open(test_map2).read())
     except AssertionError, e:
-        raise AssertionError('serialized map "%s" not the same after being reloaded, \ncompare with command:\n\n$%s' % (xml,diff))
+        raise AssertionError('serialized map "%s" not the same after being reloaded, \ncompare with command:\n\n$%s' % (xmlfile, diff))
 
     if os.path.exists(test_map):
         os.remove(test_map)
@@ -53,8 +53,6 @@ def compare_map(xml):
 
 def test_compare_map():
     good_maps = glob.glob("../data/good_maps/*.xml")
-    # remove one map that round trips CDATA differently, but this is okay
-    good_maps.remove('../data/good_maps/empty_parameter2.xml')
     for m in good_maps:
         compare_map(m)
 


### PR DESCRIPTION
I reworked the logic in the Python tests that accounted for data source types that depended on input plugins that were not included in the build configuration. This is a forward port of PR #3465 - see that PR's thread for discussion and details.