### PR TITLE
Fix image swap

### DIFF
--- a/include/mapnik/image.hpp
+++ b/include/mapnik/image.hpp
@@ -76,7 +76,6 @@ public:
 private:
     detail::image_dimensions<65535> dimensions_;
     detail::buffer buffer_;
-    pixel_type *pData_;
     double offset_;
     double scaling_;
     bool premultiplied_alpha_;

--- a/test/unit/imaging/image.cpp
+++ b/test/unit/imaging/image.cpp
@@ -363,4 +363,30 @@ SECTION("Image copy/move")
     }
 }
 
+SECTION("image::swap")
+{
+    auto blue = mapnik::color(50, 50, 250).rgba();
+    auto orange = mapnik::color(250, 150, 0).rgba();
+
+    mapnik::image_rgba8 im;
+    mapnik::image_rgba8 im2(16, 16);
+    mapnik::image_rgba8 im3(16, 16);
+
+    im2.set(blue);
+    im3.set(orange);
+
+    // swap two non-empty images
+    CHECK_NOTHROW(im2.swap(im3));
+    CHECK(im2(0, 0) == orange);
+    CHECK(im3(0, 0) == blue);
+
+    // swap empty <-> non-empty
+    CHECK_NOTHROW(im.swap(im3));
+    CHECK(im3.data() == nullptr);
+    CHECKED_IF(im.data() != nullptr)
+    {
+        CHECK(im(0, 0) == blue);
+    }
+}
+
 } // END TEST CASE


### PR DESCRIPTION
mapnik::image::swap didn't swap `pData_` pointers. Instead of fixing that by adding one line, I removed the member, it was just `reinterpret_cast` pointer from `buffer_`