### PR TITLE
Use 2D box for pgraster bounding box

### DIFF
--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -627,10 +627,10 @@ std::string pgraster_datasource::sql_bbox(box2d<double> const& env) const
         b << "ST_SetSRID(";
     }
 
-    b << "'BOX3D(";
+    b << "'BOX(";
     b << std::setprecision(16);
     b << env.minx() << " " << env.miny() << ",";
-    b << env.maxx() << " " << env.maxy() << ")'::box3d";
+    b << env.maxx() << " " << env.maxy() << ")'::box2d";
 
     if (srid_ > 0)
     {


### PR DESCRIPTION
Using a 3D box causes errors with postgis 2.3 when clipping is enabled as ST_Clip throws an error clipping a raster to a 3D box:

```
ERROR: python_tests.pgraster_test.test_rgba_8bui
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/builddir/build/BUILD/python-mapnik-541fd962d4fc99d50ec472af6ddccfdbf98cff37/test/python_tests/pgraster_test.py", line 385, in test_rgba_8bui
    'rgba_8bui', tilesize, constraint, overview)
  File "/builddir/build/BUILD/python-mapnik-541fd962d4fc99d50ec472af6ddccfdbf98cff37/test/python_tests/pgraster_test.py", line 377, in _test_rgba_8bui
    _test_rgba_8bui_rendering(lbl, overview, prescale, clip)
  File "/builddir/build/BUILD/python-mapnik-541fd962d4fc99d50ec472af6ddccfdbf98cff37/test/python_tests/pgraster_test.py", line 342, in _test_rgba_8bui_rendering
    mapnik.render(mm, im)
RuntimeError: Postgis Plugin: ERROR:  Unknown geometry type: 13 - PolyhedralSurface
CONTEXT:  PL/pgSQL function st_clip(raster,integer[],geometry,double precision[],boolean) line 8 at RETURN
in executeQuery Full sql was: 'SELECT ST_AsBinary(ST_Clip("rast", ST_Expand('BOX3D(164.5 -105,192.5 -77)'::box3d, greatest(abs(ST_ScaleX("rast")), abs(ST_ScaleY("rast")))))) AS geom FROM (select * from "River") foo WHERE "rast" && 'BOX3D(164.5 -105,192.5 -77)'::box3d'
```