### PR TITLE
Travis: Add g++ testing, upgrade to clang++ 3.9, downgrade to libstdc++-4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,10 @@ script:
  # (and might work) for the next build
  - DURATION=2400
  - scripts/travis-command-wrapper.py -s "date" -i 120 --deadline=$(( $(date +%s) + ${DURATION} )) make
- - make test
+ - RESULT=0
+ - make test || RESULT=$?
+ # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
+ - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang"
-      sudo: required
-      dist: trusty
+      sudo: false
       env: JOBS=4 CXX="ccache g++-6" CC="gcc-6"
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,29 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang"
-      env: JOBS=8 MASON_PUBLISH=true CXX="ccache clang++-3.8 -Qunused-arguments" CC="clang-3.8" TRIGGER=true
+      sudo: required
+      dist: trusty
+      env: JOBS=4 CXX="ccache g++-6" CC="gcc-6"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
-          packages: [ 'libstdc++-5-dev', 'xutils-dev']
+          packages: [ 'libstdc++-6-dev', 'g++-6', 'xutils-dev']
+    - os: linux
+      sudo: false
+      compiler: ": clang"
+      env: JOBS=8 MASON_PUBLISH=true CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9" TRIGGER=true
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test']
+          packages: [ 'libstdc++-4.9-dev', 'xutils-dev']
     - os: linux
       sudo: false
       compiler: ": clang-coverage"
-      env: JOBS=8 COVERAGE=true CXX="ccache clang++-3.8 -Qunused-arguments" CC="clang-3.8"
+      env: JOBS=8 COVERAGE=true CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
-          packages: ['libstdc++-5-dev', 'xutils-dev' ]
+          packages: ['libstdc++-4.9-dev', 'xutils-dev' ]
     - os: osx
       compiler: ": clang-osx"
       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
@@ -78,10 +88,12 @@ before_script:
  - source bootstrap.sh
  - |
    if [[ $(uname -s) == 'Linux' ]]; then
-     mason install clang 3.8.0
-     export PATH=$(mason prefix clang 3.8.0)/bin:${PATH}
-     which clang++
-     export LLVM_COV="$(mason prefix clang 3.8.0)/bin/llvm-cov"
+     mason install clang++ 3.9.0
+     export PATH=$(mason prefix clang++ 3.9.0)/bin:${PATH}
+     mason install llvm-cov 3.9.0
+     export PATH=$(mason prefix llvm-cov 3.9.0)/bin:${PATH}
+     which llvm-cov
+     export LLVM_COV="$(mason prefix llvm-cov 3.9.0)/bin/llvm-cov"
    fi
  - ccache --version
  - ccache -p || true

--- a/include/mapnik/offset_converter.hpp
+++ b/include/mapnik/offset_converter.hpp
@@ -77,18 +77,18 @@ struct offset_converter
         return threshold_;
     }
 
-    void set_offset(double value)
+    void set_offset(double val)
     {
-        if (offset_ != value)
+        if (offset_ != val)
         {
-            offset_ = value;
+            offset_ = val;
             reset();
         }
     }
 
-    void set_threshold(double value)
+    void set_threshold(double val)
     {
-        threshold_ = value;
+        threshold_ = val;
         // no need to reset(), since threshold doesn't affect
         // offset vertices' computation, it only controls how
         // far will we be looking for self-intersections

--- a/include/mapnik/simplify_converter.hpp
+++ b/include/mapnik/simplify_converter.hpp
@@ -120,11 +120,11 @@ public:
         return algorithm_;
     }
 
-    void set_simplify_algorithm(simplify_algorithm_e value)
+    void set_simplify_algorithm(simplify_algorithm_e val)
     {
-        if (algorithm_ != value)
+        if (algorithm_ != val)
         {
-            algorithm_ = value;
+            algorithm_ = val;
             reset();
         }
     }
@@ -134,11 +134,11 @@ public:
         return tolerance_;
     }
 
-    void set_simplify_tolerance(double value)
+    void set_simplify_tolerance(double val)
     {
-        if (tolerance_ != value)
+        if (tolerance_ != val)
         {
-            tolerance_ = value;
+            tolerance_ = val;
             reset();
         }
     }

--- a/scripts/travis-common.sh
+++ b/scripts/travis-common.sh
@@ -83,9 +83,9 @@ config_override () {
 configure () {
     if enabled ${COVERAGE}; then
         ./configure "$@" PREFIX=${PREFIX} PGSQL2SQLITE=False SVG2PNG=False SVG_RENDERER=False \
-            COVERAGE=True DEBUG=True WARNING_CXXFLAGS="-Wno-unknown-warning-option"
+            COVERAGE=True DEBUG=True
     else
-        ./configure "$@" PREFIX=${PREFIX} WARNING_CXXFLAGS="-Wno-unknown-warning-option"
+        ./configure "$@" PREFIX=${PREFIX}
     fi
     # print final config values, sorted and indented
     sort -sk1,1 ./config.py | sed -e 's/^/	/'


### PR DESCRIPTION
This PR addresses:

 - We want to test g++ on travis to ensure it compiles. Let's start and track visual failures at https://github.com/mapnik/mapnik/issues/3567
 - We don't need to depend on libstdc++-5 (it offers no real benefit on top of 4.9). Both support C++14. Previously we needed libstdc++-5 because the mason clang++ binary was built against it. But that is no longer the case
 - We want to test against latest clang++. Latest is now 3.9. Will upgrade to 3.9.1 soon.

Also knocks out a few -Wshadow warnings for g++ and removes the unneeded `-Wno-unknown-warning-option` usage (can't recall why we had this at all).