### PR TITLE
C++14-like type traits aliases

### DIFF
--- a/include/mapnik/cxx11_support.hpp
+++ b/include/mapnik/cxx11_support.hpp
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2016 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_CXX11_SUPPORT_HPP
+#define MAPNIK_CXX11_SUPPORT_HPP
+
+#include <type_traits>
+
+namespace mapnik {
+namespace detail {
+
+template <bool B, typename T, typename F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
+template <typename T>
+using decay_t = typename std::decay<T>::type;
+
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+} // namespace detail
+} // namespace mapnik
+
+#endif // MAPNIK_CXX11_SUPPORT_HPP

--- a/include/mapnik/value/types.hpp
+++ b/include/mapnik/value/types.hpp
@@ -25,6 +25,7 @@
 
 // mapnik
 #include <mapnik/config.hpp>
+#include <mapnik/cxx11_support.hpp>
 #include <mapnik/pixel_types.hpp>
 
 
@@ -34,7 +35,6 @@
 #pragma GCC diagnostic pop
 
 // stl
-#include <type_traits>
 #include <iosfwd>
 #include <cstddef>
 
@@ -160,13 +160,13 @@ namespace detail {
 //  value_double    if T is a floating-point type
 //  T &&            otherwise
 
-template <typename T, typename dT = std::decay_t<T>>
+template <typename T, typename dT = decay_t<T>>
 using mapnik_value_type_t =
-    std::conditional_t<
+    conditional_t<
         std::is_same<dT, bool>::value, value_bool,
-        std::conditional_t<
+        conditional_t<
             std::is_integral<dT>::value, value_integer,
-            std::conditional_t<
+            conditional_t<
                 std::is_floating_point<dT>::value, value_double,
                 T && >>>;
 


### PR DESCRIPTION
Backport C++14 aliases to C++11. Using aliases from `detail::` instead of `std::` allows cherry-picking onto 3.0.x branch without modifications.
