### PR TITLE
minor render_thunk_list change

### DIFF
--- a/include/mapnik/renderer_common/render_group_symbolizer.hpp
+++ b/include/mapnik/renderer_common/render_group_symbolizer.hpp
@@ -42,9 +42,9 @@ struct render_thunk_list_dispatch
     {
         offset_ = offset;
 
-        for (render_thunk_ptr const& thunk : thunks)
+        for (render_thunk const& thunk : thunks)
         {
-            util::apply_visitor(std::ref(*this), *thunk);
+            util::apply_visitor(std::ref(*this), thunk);
         }
     }
 

--- a/include/mapnik/renderer_common/render_thunk.hpp
+++ b/include/mapnik/renderer_common/render_thunk.hpp
@@ -107,8 +107,7 @@ struct text_render_thunk : util::movable
 using render_thunk = util::variant<vector_marker_render_thunk,
                                    raster_marker_render_thunk,
                                    text_render_thunk>;
-using render_thunk_ptr = std::unique_ptr<render_thunk>;
-using render_thunk_list = std::list<render_thunk_ptr>;
+using render_thunk_list = std::list<render_thunk>;
 
 } // namespace mapnik
 

--- a/src/renderer_common/render_group_symbolizer.cpp
+++ b/src/renderer_common/render_group_symbolizer.cpp
@@ -66,7 +66,7 @@ void render_group_symbolizer(group_symbolizer const& sym,
 
     // keep track of which lists of render thunks correspond to
     // entries in the group_layout_manager.
-    std::vector<render_thunk_list> layout_thunks;
+    std::list<render_thunk_list> layout_thunks;
 
     // layout manager to store and arrange bboxes of matched features
     group_layout_manager layout_manager(props->get_layout());
@@ -182,11 +182,13 @@ void render_group_symbolizer(group_symbolizer const& sym,
     pixel_position_list const& positions = helper.get();
     for (pixel_position const& pos : positions)
     {
-        for (size_t layout_i = 0; layout_i < layout_thunks.size(); ++layout_i)
+        size_t layout_i = 0;
+        for (auto const& thunks : layout_thunks)
         {
             pixel_position const& offset = layout_manager.offset_at(layout_i);
             pixel_position render_offset = pos + offset;
-            render_thunks.render_list(layout_thunks[layout_i], render_offset);
+            render_thunks.render_list(thunks, render_offset);
+            ++layout_i;
         }
     }
 }

--- a/src/renderer_common/render_thunk_extractor.cpp
+++ b/src/renderer_common/render_thunk_extractor.cpp
@@ -55,7 +55,7 @@ struct thunk_markers_renderer_context : markers_renderer_context
     {
         vector_marker_render_thunk thunk(src, attrs, marker_tr, params.opacity,
                                          comp_op_, params.snap_to_pixels);
-        thunks_.push_back(std::make_unique<render_thunk>(std::move(thunk)));
+        thunks_.emplace_back(std::move(thunk));
     }
 
     virtual void render_marker(image_rgba8 const& src,
@@ -64,7 +64,7 @@ struct thunk_markers_renderer_context : markers_renderer_context
     {
         raster_marker_render_thunk thunk(src, marker_tr, params.opacity,
                                          comp_op_, params.snap_to_pixels);
-        thunks_.push_back(std::make_unique<render_thunk>(std::move(thunk)));
+        thunks_.emplace_back(std::move(thunk));
     }
 
 private:
@@ -128,7 +128,7 @@ void render_thunk_extractor::extract_text_thunk(text_render_thunk::helper_ptr &&
     halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym, keys::halo_rasterizer, feature_, common_.vars_, HALO_RASTERIZER_FULL);
 
     text_render_thunk thunk(std::move(helper), opacity, comp_op, halo_rasterizer);
-    thunks_.push_back(std::make_unique<render_thunk>(std::move(thunk)));
+    thunks_.emplace_back(std::move(thunk));
 
     update_box();
 }


### PR DESCRIPTION
The first commit is just a minor optimization, it removes unnecessary wrapping of `render_thunk` in `unique_ptr`.

The second replaces `std::vector` with `std::list` in `render_group_symbolizer`, because vector insertion requires its elements to be either nothrow_move_constructible, or copy_constructible. `render_thunk_list` isn't copy_constructible, and whether it's nothrow_move_constructible depends on STL implementation of `std::list`. This should fix one of the issues with MSVC 2017 (refs #3573)
