### PR TITLE
"X" EXACT_POSITION should not use dx/dy...

### DIFF
--- a/src/text/text_layout.cpp
+++ b/src/text/text_layout.cpp
@@ -62,7 +62,7 @@ pixel_position evaluate_displacement(double dx, double dy, directions_e dir)
     switch (dir)
     {
     case EXACT_POSITION:
-        return pixel_position(dx,dy);
+        return pixel_position(0,0);
         break;
     case NORTH:
         return pixel_position(0,-std::abs(dy));


### PR DESCRIPTION
When using "X" in simple placement-type, the text is always moved event if "X" is the first displacement in the list...