### PR TITLE
use ICU regex instead of boost

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -97,7 +97,6 @@ pretty_dep_names = {
     'freetype-config':'freetype-config program | try setting FREETYPE_CONFIG SCons option or configure with FREETYPE_LIBS & FREETYPE_INCLUDES',
     'freetype':'libfreetype library | try setting FREETYPE_CONFIG SCons option or configure with FREETYPE_LIBS & FREETYPE_INCLUDES',
     'osm':'more info: https://github.com/mapnik/mapnik/wiki/OsmPlugin',
-    'boost_regex_icu':'libboost_regex built with optional ICU unicode support is needed for unicode regex support in mapnik.',
     'sqlite_rtree':'The SQLite plugin requires libsqlite3 built with RTREE support (-DSQLITE_ENABLE_RTREE=1)',
     'pgsql2sqlite_rtree':'The pgsql2sqlite program requires libsqlite3 built with RTREE support (-DSQLITE_ENABLE_RTREE=1)'
     }
@@ -956,39 +955,6 @@ int main()
         return True
     return False
 
-def boost_regex_has_icu(context):
-    if env['RUNTIME_LINK'] == 'static':
-        # re-order icu libs to ensure linux linker is happy
-        for lib_name in ['icui18n',env['ICU_LIB_NAME'],'icudata']:
-            if lib_name in context.env['LIBS']:
-                context.env['LIBS'].remove(lib_name)
-            context.env.Append(LIBS=lib_name)
-    ret = context.TryRun("""
-
-#include <boost/regex/icu.hpp>
-#include <unicode/unistr.h>
-
-int main()
-{
-    U_NAMESPACE_QUALIFIER UnicodeString ustr;
-    try {
-        boost::u32regex pattern = boost::make_u32regex(ustr);
-    }
-    // an exception is fine, still indicates support is
-    // likely compiled into regex
-    catch (...) {
-        return 0;
-    }
-    return 0;
-}
-
-""", '.cpp')
-    context.Message('Checking if boost_regex was built with ICU unicode support... ')
-    context.Result(ret[0])
-    if ret[0]:
-        return True
-    return False
-
 def sqlite_has_rtree(context, silent=False):
     """ check an sqlite3 install has rtree support.
 
@@ -1078,7 +1044,6 @@ conf_tests = { 'prioritize_paths'      : prioritize_paths,
                'icu_at_least_four_two' : icu_at_least_four_two,
                'harfbuzz_version'      : harfbuzz_version,
                'harfbuzz_with_freetype_support': harfbuzz_with_freetype_support,
-               'boost_regex_has_icu'   : boost_regex_has_icu,
                'sqlite_has_rtree'      : sqlite_has_rtree,
                'supports_cxx14'        : supports_cxx14,
                'CheckBoostScopedEnum'  : CheckBoostScopedEnum,
@@ -1403,7 +1368,6 @@ if not preconfigured:
         BOOST_LIBSHEADERS = [
             ['system', 'boost/system/system_error.hpp', True],
             ['filesystem', 'boost/filesystem/operations.hpp', True],
-            ['regex', 'boost/regex.hpp', True],
             ['program_options', 'boost/program_options.hpp', False]
         ]
 
@@ -1447,15 +1411,6 @@ if not preconfigured:
                     env.Append(CXXFLAGS = '-DBOOST_NO_CXX11_SCOPED_ENUMS')
 
     if not env['HOST'] and env['ICU_LIB_NAME'] not in env['MISSING_DEPS']:
-        # http://lists.boost.org/Archives/boost/2009/03/150076.php
-        # we need libicui18n if using static boost libraries, so it is
-        # important to try this check with the library linked
-        if conf.boost_regex_has_icu():
-            # TODO - should avoid having this be globally defined...
-            env.Append(CPPDEFINES = '-DBOOST_REGEX_HAS_ICU')
-        else:
-            env['SKIPPED_DEPS'].append('boost_regex_icu')
-
         for libname, headers, required, lang, define in OPTIONAL_LIBSHEADERS:
             if not env['HOST']:
                 if not conf.CheckLibWithHeader(libname, headers, lang):

--- a/include/mapnik/csv/csv_grammar_x3_def.hpp
+++ b/include/mapnik/csv/csv_grammar_x3_def.hpp
@@ -32,11 +32,10 @@
 namespace mapnik { namespace grammar {
 
 namespace x3 = boost::spirit::x3;
-namespace ascii = boost::spirit::x3::ascii;
 
 using x3::lit;
 using x3::lexeme;
-using ascii::char_;
+using x3::ascii::char_;
 
 struct unesc_char_ : x3::symbols<char>
 {

--- a/include/mapnik/expression_grammar_x3_def.hpp
+++ b/include/mapnik/expression_grammar_x3_def.hpp
@@ -177,17 +177,21 @@ namespace mapnik { namespace grammar {
 // regex
     auto do_regex_match = [] (auto const& ctx)
     {
-        auto const& tr = x3::get<transcoder_tag>(ctx).get();
-        _val(ctx) = std::move(mapnik::regex_match_node(tr, std::move(_val(ctx)) , std::move(_attr(ctx))));
+        auto const& transcode = x3::get<transcoder_tag>(ctx);
+        auto const& pattern = _attr(ctx);
+        _val(ctx) = mapnik::regex_match_node(std::move(_val(ctx)),
+                                             transcode(pattern));
     };
 
     auto do_regex_replace = [] (auto const& ctx)
     {
-        auto const& tr = x3::get<transcoder_tag>(ctx).get();
+        auto const& transcode = x3::get<transcoder_tag>(ctx);
         auto const& pair = _attr(ctx);
         auto const& pattern = std::get<0>(pair);
         auto const& format = std::get<1>(pair);
-        _val(ctx) = mapnik::regex_replace_node(tr, _val(ctx) , pattern, format);
+        _val(ctx) = mapnik::regex_replace_node(std::move(_val(ctx)),
+                                               transcode(pattern),
+                                               transcode(format));
     };
 
 // mapnik::value_integer

--- a/include/mapnik/expression_grammar_x3_def.hpp
+++ b/include/mapnik/expression_grammar_x3_def.hpp
@@ -49,9 +49,8 @@ BOOST_FUSION_ADAPT_STRUCT(mapnik::binary_function_call,
 namespace mapnik { namespace grammar {
 
     namespace x3 = boost::spirit::x3;
-    namespace ascii = boost::spirit::x3::ascii;
-    using ascii::char_;
-    using ascii::string;
+
+    using x3::ascii::char_;
     using x3::lit;
     using x3::double_;
     using x3::int_;

--- a/include/mapnik/expression_grammar_x3_def.hpp
+++ b/include/mapnik/expression_grammar_x3_def.hpp
@@ -120,8 +120,8 @@ namespace mapnik { namespace grammar {
 
     auto do_unicode = [] (auto const& ctx)
     {
-        auto & tr = x3::get<transcoder_tag>(ctx).get();
-        _val(ctx) = std::move(tr.transcode(_attr(ctx).c_str()));
+        auto const& transcode = x3::get<transcoder_tag>(ctx);
+        _val(ctx) = transcode(_attr(ctx));
     };
 
     auto do_null = [] (auto const& ctx)

--- a/include/mapnik/json/attribute_value_visitor.hpp
+++ b/include/mapnik/json/attribute_value_visitor.hpp
@@ -38,25 +38,25 @@ public:
 
     mapnik::value operator()(std::string const& val) const
     {
-        return mapnik::value(tr_.transcode(val.c_str()));
+        return tr_(val);
     }
 
     mapnik::value operator()(std::vector<mapnik::json::json_value> const& array) const
     {
         std::string str = stringifier()(array);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     mapnik::value operator()(std::vector<std::pair<std::string, mapnik::json::json_value> > const& object) const
     {
         std::string str = stringifier()(object);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     template <typename T>
     mapnik::value operator()(T const& val) const
     {
-        return mapnik::value(val);
+        return val;
     }
 
     mapnik::transcoder const& tr_;

--- a/include/mapnik/json/create_feature.hpp
+++ b/include/mapnik/json/create_feature.hpp
@@ -119,34 +119,34 @@ public:
 
     mapnik::value operator()(std::string const& val) const
     {
-        return mapnik::value(tr_.transcode(val.c_str()));
+        return tr_(val);
     }
 
     mapnik::value operator()(mapnik::json::geojson_array const& array) const
     {
         std::string str = stringifier(keys_)(array);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     mapnik::value operator()(mapnik::json::geojson_object const& object) const
     {
         std::string str = stringifier(keys_)(object);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     mapnik::value operator() (mapnik::value_bool val) const
     {
-        return mapnik::value(val);
+        return val;
     }
 
     mapnik::value operator() (mapnik::value_integer val) const
     {
-        return mapnik::value(val);
+        return val;
     }
 
     mapnik::value operator() (mapnik::value_double val) const
     {
-        return mapnik::value(val);
+        return val;
     }
 
     template <typename T>

--- a/include/mapnik/json/feature_grammar_x3_def.hpp
+++ b/include/mapnik/json/feature_grammar_x3_def.hpp
@@ -108,25 +108,25 @@ public:
 
     mapnik::value operator()(std::string const& val) const
     {
-        return mapnik::value(tr_.transcode(val.c_str()));
+        return tr_(val);
     }
 
     mapnik::value operator()(std::vector<mapnik::json::json_value> const& array) const
     {
         std::string str = stringifier()(array);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     mapnik::value operator()(std::vector<std::pair<std::string, mapnik::json::json_value> > const& object) const
     {
         std::string str = stringifier()(object);
-        return mapnik::value(tr_.transcode(str.c_str()));
+        return tr_(str);
     }
 
     template <typename T>
     mapnik::value operator()(T const& val) const
     {
-        return mapnik::value(val);
+        return val;
     }
 
     mapnik::transcoder const& tr_;

--- a/include/mapnik/transform/transform_expression_grammar_x3_def.hpp
+++ b/include/mapnik/transform/transform_expression_grammar_x3_def.hpp
@@ -71,7 +71,6 @@ inline void move_to<mapnik::skewY_node, mapnik::detail::transform_node>(mapnik::
 namespace mapnik { namespace grammar {
 
 namespace x3 = boost::spirit::x3;
-namespace ascii = boost::spirit::x3::ascii;
 
 // [http://www.w3.org/TR/SVG/coords.html#TransformAttribute]
 

--- a/include/mapnik/unicode.hpp
+++ b/include/mapnik/unicode.hpp
@@ -40,14 +40,19 @@ class MAPNIK_DECL transcoder : private util::noncopyable
 {
 public:
     explicit transcoder (std::string const& encoding);
-    mapnik::value_unicode_string transcode(const char* data, std::int32_t length = -1) const;
     ~transcoder();
+
+    value_unicode_string transcode(char const* data, std::int32_t length = -1) const;
+    value_unicode_string operator() (char const* data, std::int32_t length = -1) const;
+    value_unicode_string operator() (std::string const& str) const;
+
 private:
     UConverter * conv_;
 };
 
-// convinience method
-void MAPNIK_DECL to_utf8(mapnik::value_unicode_string const& input, std::string & target);
+// convenience functions
+std::string MAPNIK_DECL to_utf8(value_unicode_string const& input);
+void MAPNIK_DECL to_utf8(value_unicode_string const& input, std::string & target);
 
 }
 

--- a/include/mapnik/wkt/wkt_grammar_x3_def.hpp
+++ b/include/mapnik/wkt/wkt_grammar_x3_def.hpp
@@ -39,7 +39,7 @@ struct is_substitute<T&, Attribute&, Enable>
 namespace mapnik { namespace grammar {
 
 namespace x3 = boost::spirit::x3;
-namespace ascii = boost::spirit::x3::ascii;
+
 using x3::lit;
 using x3::double_;
 using x3::no_case;

--- a/src/build.py
+++ b/src/build.py
@@ -54,13 +54,11 @@ ABI_VERSION = env['ABI_VERSION']
 
 enabled_imaging_libraries = []
 filesystem = 'boost_filesystem%s' % env['BOOST_APPEND']
-regex = 'boost_regex%s' % env['BOOST_APPEND']
 system = 'boost_system%s' % env['BOOST_APPEND']
 
 # clear out and re-set libs for this env
 # note: order matters on linux: see lorder | tsort
-lib_env['LIBS'] = [filesystem,
-                   regex]
+lib_env['LIBS'] = [filesystem]
 
 if env['COVERAGE']:
     lib_env.Append(LINKFLAGS='--coverage')
@@ -91,9 +89,6 @@ if '-DHAVE_WEBP' in env['CPPDEFINES']:
 if env['XMLPARSER'] == 'libxml2' and env['HAS_LIBXML2']:
     lib_env['LIBS'].append('xml2')
 
-if '-DBOOST_REGEX_HAS_ICU' in env['CPPDEFINES']:
-    lib_env['LIBS'].append('icui18n')
-
 lib_env['LIBS'].append(system)
 
 lib_env['LIBS'].append('harfbuzz')
@@ -103,6 +98,7 @@ if '-DHAVE_JPEG' in env['CPPDEFINES']:
    enabled_imaging_libraries.append('jpeg_reader.cpp')
 
 lib_env['LIBS'].append(env['ICU_LIB_NAME'])
+lib_env['LIBS'].append('icui18n')
 
 lib_env['LIBS'].append('freetype')
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -27,15 +27,16 @@
 #include <mapnik/expression_node_types.hpp>
 #include <mapnik/expression_grammar_x3.hpp>
 
+namespace x3 = boost::spirit::x3;
+
 namespace mapnik
 {
 
 expression_ptr parse_expression(std::string const& str)
 {
     auto node = std::make_shared<expr_node>();
-    using boost::spirit::x3::ascii::space;
     mapnik::transcoder const tr("utf8");
-    auto parser = boost::spirit::x3::with<mapnik::grammar::transcoder_tag>(std::ref(tr))
+    auto parser = x3::with<mapnik::grammar::transcoder_tag>(std::ref(tr))
         [
             mapnik::expression_grammar()
         ];
@@ -46,9 +47,9 @@ expression_ptr parse_expression(std::string const& str)
 
     try
     {
-        r = boost::spirit::x3::phrase_parse(itr, end, parser, space, *node);
+        r = x3::phrase_parse(itr, end, parser, x3::ascii::space, *node);
     }
-    catch (boost::spirit::x3::expectation_failure<std::string::const_iterator> const& ex)
+    catch (x3::expectation_failure<std::string::const_iterator> const& ex)
     {
         // no need to show "boost::spirit::qi::expectation_failure" which is a std::runtime_error
         throw config_error("Failed to parse expression: \"" + str + "\"");

--- a/src/parse_transform.cpp
+++ b/src/parse_transform.cpp
@@ -28,25 +28,26 @@
 #include <string>
 #include <stdexcept>
 
+namespace x3 = boost::spirit::x3;
+
 namespace mapnik {
 
 transform_list_ptr parse_transform(std::string const& str, std::string const& encoding)
 {
-    using boost::spirit::x3::ascii::space;
     transform_list_ptr trans_list = std::make_shared<transform_list>();
     std::string::const_iterator itr = str.begin();
     std::string::const_iterator end = str.end();
     mapnik::transcoder const tr(encoding);
-    auto const parser = boost::spirit::x3::with<mapnik::grammar::transcoder_tag>(std::ref(tr))
+    auto const parser = x3::with<mapnik::grammar::transcoder_tag>(std::ref(tr))
         [
             mapnik::transform_expression_grammar()
         ];
     bool status = false;
     try
     {
-        status = boost::spirit::x3::phrase_parse(itr, end, parser, space, *trans_list);
+        status = x3::phrase_parse(itr, end, parser, x3::ascii::space, *trans_list);
     }
-    catch (boost::spirit::x3::expectation_failure<std::string::const_iterator> const& ex)
+    catch (x3::expectation_failure<std::string::const_iterator> const& ex)
     {
         throw config_error("Failed to parse transform expression: \"" + str + "\"");
     }


### PR DESCRIPTION
Boost.regex requires ICU to work properly with unicode anyway, so why not use ICU regex instead? Boost.regex+icu is such a PITA that it seems compelling to drop the dependency.

There most likely are differences in capabilities and performance -- we don't have extensive testing, only basic word boundaries tests, which pass unchanged.
