### PR TITLE
Postgis parameter quoting and interpolation

### DIFF
--- a/include/mapnik/sql_utils.hpp
+++ b/include/mapnik/sql_utils.hpp
@@ -39,6 +39,41 @@
 
 namespace mapnik { namespace sql_utils {
 
+    struct quoted_string
+    {
+        std::string const* operator-> () const { return &str; }
+        std::string const& str;
+        char const quot;
+    };
+
+    inline quoted_string identifier(std::string const& str)
+    {
+        return { str, '"' };
+    }
+
+    inline quoted_string literal(std::string const& str)
+    {
+        return { str, '\'' };
+    }
+
+    inline std::ostream& operator << (std::ostream& os, quoted_string qs)
+    {
+        std::size_t pos = 0, next;
+
+        os.put(qs.quot);
+        while ((next = qs->find(qs.quot, pos)) != std::string::npos)
+        {
+            os.write(qs->data() + pos, next - pos + 1);
+            os.put(qs.quot);
+            pos = next + 1;
+        }
+        if ((next = qs->size()) > pos)
+        {
+            os.write(qs->data() + pos, next - pos);
+        }
+        return os.put(qs.quot);
+    }
+
     inline std::string unquote_double(std::string const& sql)
     {
         std::string table_name = sql;

--- a/include/mapnik/sql_utils.hpp
+++ b/include/mapnik/sql_utils.hpp
@@ -74,6 +74,36 @@ namespace mapnik { namespace sql_utils {
         return os.put(qs.quot);
     }
 
+    // Does nothing if `str` doesn't start with `quot`.
+    // Otherwise erases the opening quote, collapses inner quote pairs,
+    // and erases everything from the closing quote to the end of the
+    // string. The closing quote is the first non-paired quote after the
+    // opening one. For a well-formed quoted string, it is also the last
+    // character, so nothing gets lost.
+    inline void unquote(char quot, std::string & str)
+    {
+        if (!str.empty() && str.front() == quot)
+        {
+            std::size_t di = 0;
+            for (std::size_t si = 1; si < str.size(); ++si)
+            {
+                char c = str[si];
+                if (c == quot && (++si >= str.size() || str[si] != quot))
+                    break;
+                str[di++] = c;
+            }
+            str.erase(di);
+        }
+    }
+
+    inline std::string unquote_copy(char quot, std::string const& str)
+    {
+        std::string tmp(str);
+        sql_utils::unquote(quot, tmp);
+        return tmp;
+    }
+
+    [[deprecated("flawed")]]
     inline std::string unquote_double(std::string const& sql)
     {
         std::string table_name = sql;
@@ -81,6 +111,7 @@ namespace mapnik { namespace sql_utils {
         return table_name;
     }
 
+    [[deprecated("flawed")]]
     inline std::string unquote(std::string const& sql)
     {
         std::string table_name = sql;
@@ -88,6 +119,7 @@ namespace mapnik { namespace sql_utils {
         return table_name;
     }
 
+    [[deprecated("flawed")]]
     inline void quote_attr(std::ostringstream & s, std::string const& field)
     {
         s << ",\"" << field << "\"";

--- a/plugins/input/pgraster/pgraster_datasource.hpp
+++ b/plugins/input/pgraster/pgraster_datasource.hpp
@@ -42,6 +42,7 @@
 #include <boost/optional.hpp>
 
 // stl
+#include <regex>
 #include <vector>
 #include <string>
 #include <memory>
@@ -90,24 +91,26 @@ public:
 
 private:
     std::string sql_bbox(box2d<double> const& env) const;
-    std::string populate_tokens(std::string const& sql, double scale_denom, box2d<double> const& env, double pixel_width, double pixel_height) const;
+    std::string populate_tokens(std::string const& sql, double scale_denom,
+                                box2d<double> const& env,
+                                double pixel_width, double pixel_height,
+                                mapnik::attributes const& vars,
+                                bool intersect = true) const;
     std::string populate_tokens(std::string const& sql) const;
     std::shared_ptr<IResultSet> get_resultset(std::shared_ptr<Connection> &conn, std::string const& sql, CnxPool_ptr const& pool, processor_context_ptr ctx= processor_context_ptr()) const;
     static const std::string RASTER_COLUMNS;
     static const std::string RASTER_OVERVIEWS;
     static const std::string SPATIAL_REF_SYS;
-    static const double FMAX;
 
     const std::string uri_;
     const std::string username_;
     const std::string password_;
     // table name (schema qualified or not) or subquery
     const std::string table_;
-    // schema name (possibly extracted from table_)
-    std::string schema_;
-    // table name (possibly extracted from table_)
-    std::string raster_table_;
+    const std::string raster_table_; // possibly schema-qualified
     const std::string raster_field_;
+    std::string parsed_schema_; // extracted from raster_table_ or table_
+    std::string parsed_table_; // extracted from raster_table_ or table_
     std::string key_field_;
     mapnik::value_integer cursor_fetch_size_;
     mapnik::value_integer row_limit_;
@@ -129,10 +132,7 @@ private:
     bool clip_rasters_;
     layer_descriptor desc_;
     ConnectionCreator<Connection> creator_;
-    const std::string bbox_token_;
-    const std::string scale_denom_token_;
-    const std::string pixel_width_token_;
-    const std::string pixel_height_token_;
+    std::regex re_tokens_;
     int pool_max_size_;
     bool persist_connection_;
     bool extent_from_subquery_;

--- a/plugins/input/postgis/build.py
+++ b/plugins/input/postgis/build.py
@@ -52,7 +52,6 @@ libraries = copy(plugin_env['LIBS'])
 
 if env['PLUGIN_LINKING'] == 'shared':
     libraries.append('boost_system%s' % env['BOOST_APPEND'])
-    libraries.append('boost_regex%s' % env['BOOST_APPEND'])
     libraries.insert(0,env['MAPNIK_NAME'])
     libraries.append(env['ICU_LIB_NAME'])
 

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -37,10 +37,10 @@
 
 // boost
 #include <boost/optional.hpp>
-#include <boost/regex.hpp>
 
 // stl
 #include <memory>
+#include <regex>
 #include <vector>
 #include <string>
 
@@ -84,12 +84,12 @@ private:
                                 box2d<double> const& env,
                                 double pixel_width,
                                 double pixel_height,
-                                mapnik::attributes const& vars) const;
+                                mapnik::attributes const& vars,
+                                bool intersect = true) const;
     std::string populate_tokens(std::string const& sql) const;
     std::shared_ptr<IResultSet> get_resultset(std::shared_ptr<Connection> &conn, std::string const& sql, CnxPool_ptr const& pool, processor_context_ptr ctx= processor_context_ptr()) const;
     static const std::string GEOMETRY_COLUMNS;
     static const std::string SPATIAL_REF_SYS;
-    static const double FMAX;
 
     const std::string uri_;
     const std::string username_;
@@ -109,10 +109,6 @@ private:
     bool simplify_geometries_;
     layer_descriptor desc_;
     ConnectionCreator<Connection> creator_;
-    const std::string bbox_token_;
-    const std::string scale_denom_token_;
-    const std::string pixel_width_token_;
-    const std::string pixel_height_token_;
     int pool_max_size_;
     bool persist_connection_;
     bool extent_from_subquery_;
@@ -126,7 +122,7 @@ private:
     mapnik::value_double simplify_prefilter_;
     bool simplify_dp_preserve_;
     mapnik::value_double simplify_clip_resolution_;
-    boost::regex pattern_;
+    std::regex re_tokens_;
     int intersect_min_scale_;
     int intersect_max_scale_;
     bool key_field_as_attribute_;

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -87,6 +87,7 @@ private:
                                 mapnik::attributes const& vars,
                                 bool intersect = true) const;
     std::string populate_tokens(std::string const& sql) const;
+    void append_geometry_table(std::ostream & os) const;
     std::shared_ptr<IResultSet> get_resultset(std::shared_ptr<Connection> &conn, std::string const& sql, CnxPool_ptr const& pool, processor_context_ptr ctx= processor_context_ptr()) const;
     static const std::string GEOMETRY_COLUMNS;
     static const std::string SPATIAL_REF_SYS;
@@ -95,9 +96,10 @@ private:
     const std::string username_;
     const std::string password_;
     const std::string table_;
-    std::string schema_;
-    std::string geometry_table_;
+    const std::string geometry_table_;
     const std::string geometry_field_;
+    std::string parsed_schema_;
+    std::string parsed_table_;
     std::string key_field_;
     mapnik::value_integer cursor_fetch_size_;
     mapnik::value_integer row_limit_;

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -270,6 +270,21 @@ TEST_CASE("postgis") {
             REQUIRE(ext.maxy() == 4);
         }
 
+        SECTION("Postgis doesn't interpret @domain in email address as @variable")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "(SELECT gid, geom, 'fake@mail.ru' as email"
+                              " FROM public.test LIMIT 1) AS data";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+            auto featureset = all_features(ds);
+            auto feature = featureset->next();
+            CHECKED_IF(feature != nullptr)
+            {
+                CHECK(feature->get("email").to_string() == "fake@mail.ru");
+            }
+        }
+
         SECTION("Postgis query extent: full dataset")
         {
             //include schema to increase coverage

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -185,6 +185,24 @@ TEST_CASE("postgis") {
             CHECK(ds->get_geometry_type() == mapnik::datasource_geometry_t::Point);
         }
 
+        SECTION("Postgis properly escapes names with single quotes")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "\"test'single'quotes\"";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+            CHECK(ds->get_geometry_type() == mapnik::datasource_geometry_t::Point);
+        }
+
+        SECTION("Postgis properly escapes names with double quotes")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "\"test\"\"double\"\"quotes\"";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+            CHECK(ds->get_geometry_type() == mapnik::datasource_geometry_t::Point);
+        }
+
         SECTION("Postgis query field names")
         {
             mapnik::parameters params(base_params);

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -26,6 +26,7 @@
 #include <mapnik/datasource.hpp>
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/geometry/geometry_type.hpp>
+#include <mapnik/unicode.hpp>
 #include <mapnik/util/fs.hpp>
 
 /*
@@ -300,6 +301,40 @@ TEST_CASE("postgis") {
             CHECKED_IF(feature != nullptr)
             {
                 CHECK(feature->get("email").to_string() == "fake@mail.ru");
+            }
+        }
+
+        SECTION("Postgis interpolates !@uservar! tokens in query")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "(SELECT * FROM public.test"
+                              " WHERE GeometryType(geom) = !@wantedGeomType!"
+                              " LIMIT 1) AS data";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+
+            mapnik::transcoder tr("utf8");
+            mapnik::query qry(ds->envelope());
+            qry.set_variables({{"wantedGeomType", tr.transcode("POINT")}});
+            CHECK(qry.variables().count("wantedGeomType") == 1);
+
+            auto featureset = ds->features(qry);
+            auto feature = featureset->next();
+            CHECKED_IF(feature != nullptr)
+            {
+                auto const& geom = feature->get_geometry();
+                CHECK(mapnik::geometry::geometry_type(geom) == mapnik::geometry::Point);
+            }
+
+            qry.set_variables({{"wantedGeomType", tr.transcode("POLYGON")}});
+            CHECK(qry.variables().count("wantedGeomType") == 1);
+
+            featureset = ds->features(qry);
+            feature = featureset->next();
+            CHECKED_IF(feature != nullptr)
+            {
+                auto const& geom = feature->get_geometry();
+                CHECK(mapnik::geometry::geometry_type(geom) == mapnik::geometry::Polygon);
             }
         }
 


### PR DESCRIPTION
This started out as an attempt to solve #3603 but ended up much broader.

#### Breaking change 1: interpolation of attributes aka render-time `@variables`
Previously
```sql
... WHERE col = @foo AND email = 'bar@sue.me'
-- would be transformed into
... WHERE col = _value_of_foo_ AND email = 'bar_value_of_sue_.me'
```

Now in order for `@variable` to be interpolated, it has to be wrapped in `!`, and the injected value will be quoted:
```sql
... WHERE col = !@foo! AND email = 'bar@sue.me'
-- will be transformed into
... WHERE col = '_value_of_foo_' AND email = 'bar@sue.me'
```

#### Breaking change 2: parameter `geometry_table` quoting
Previously
```sh
<Parameter name="geometry_table">schema-foo.table-bar</Parameter>
```
might've worked. Now it needs to be quoted in the same way it'd need to be quoted in an SQL query, i.e.:

```sh
<Parameter name="geometry_table">"schema-foo"."table+bar"</Parameter>

<Parameter name="geometry_table">simple_identifiers.dont_need_quoting</Parameter>
```

What lead to this:
The `geometry_table_` member variable contained either the value of the datasource parameter `geometry_table`, or only the table name (if the parameter was schema-qualified), or a table name extracted from datasource parameter `table` (where it had to be quoted), or even the whole query in `table` (if `sql_utils::table_from_sql` failed to find a name). It confused me when I was trying to figure out how it should be quoted in various places. So I made `geometry_table_` retain the value from the parameter, putting extracted schema and table name into separate variables. And it made sense to do this extraction in a common way (from either `geometry_table` or `table`) right inside `table_from_sql`, hence the need for `geometry_table` parameter to be "properly SQL-quoted".


#### Side effects
- drops postgis plugin's dependency on `boost::regex`
- same changes applied to pgraster plugin (which didn't have `@var` interpolation at all)
- fixes #3603
