### PR TITLE
Rename PostGIS' ST_Estimate_Extent to ST_EstimateExtent

### DIFF
--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -1143,7 +1143,7 @@ box2d<double> pgraster_datasource::envelope() const
                   throw mapnik::datasource_exception("Pgraster Plugin: " + s_error.str());
                 }
                 s << "SELECT ST_XMin(ext),ST_YMin(ext),ST_XMax(ext),ST_YMax(ext)"
-                  << " FROM (SELECT ST_Estimated_Extent('";
+                  << " FROM (SELECT ST_EstimatedExtent('";
 
                 if (! sch.empty())
                 {

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -1069,7 +1069,7 @@ box2d<double> postgis_datasource::envelope() const
             if (estimate_extent_)
             {
                 s << "SELECT ST_XMin(ext),ST_YMin(ext),ST_XMax(ext),ST_YMax(ext)"
-                  << " FROM (SELECT ST_Estimated_Extent('";
+                  << " FROM (SELECT ST_EstimatedExtent('";
 
                 if (! schema_.empty())
                 {


### PR DESCRIPTION
When running under PostGIS 2.3.2, "WARNING:  ST_Estimated_Extent signature was deprecated in 2.1.0. Please use ST_EstimatedExtent" appears repeatedly.

This PR simply renames ST_EstimatedExtent to ST_Estimated_Extent for use with PostGIS 2.1.0 and above.