### PR TITLE
Empty geometries

### DIFF
--- a/include/mapnik/json/create_geometry.hpp
+++ b/include/mapnik/json/create_geometry.hpp
@@ -44,7 +44,10 @@ struct create_point
     }
 
     template <typename T>
-    void operator()(T const&) const {} // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+        throw std::runtime_error("Failed to parse geojson geometry");
+    }
     Geometry & geom_;
 };
 
@@ -56,21 +59,21 @@ struct create_linestring
 
     void operator() (ring const& points) const
     {
+        mapnik::geometry::line_string<double> line;
         std::size_t size = points.size();
-        if (size > 1)
+        line.reserve(size);
+        for (auto && pt : points)
         {
-            mapnik::geometry::line_string<double> line;
-            line.reserve(size);
-            for (auto && pt : points)
-            {
-                line.emplace_back(std::move(pt));
-            }
-            geom_ = std::move(line);
+            line.emplace_back(std::move(pt));
         }
+        geom_ = std::move(line);
     }
 
     template <typename T>
-    void operator()(T const&) const {}  // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+        throw std::runtime_error("Failed to parse geojson geometry");
+    }
 
     Geometry & geom_;
 };
@@ -107,7 +110,10 @@ struct create_polygon
     }
 
     template <typename T>
-    void operator()(T const&) const {}  // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+       throw std::runtime_error("Failed to parse geojson geometry");
+    }
 
     Geometry & geom_;
 };
@@ -131,7 +137,10 @@ struct create_multipoint
     }
 
     template <typename T>
-    void operator()(T const&) const {}  // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+        throw std::runtime_error("Failed to parse geojson geometry");
+    }
 
     Geometry & geom_;
 };
@@ -161,7 +170,10 @@ struct create_multilinestring
     }
 
     template <typename T>
-    void operator()(T const&) const {}  // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+        throw std::runtime_error("Failed to parse geojson geometry");
+    }
 
     Geometry & geom_;
 };
@@ -202,7 +214,10 @@ struct create_multipolygon
     }
 
     template <typename T>
-    void operator()(T const&) const {}  // no-op - shouldn't get here
+    void operator()(T const&) const
+    {
+        throw std::runtime_error("Failed to parse geojson geometry");
+    }
 
     Geometry & geom_;
 };
@@ -232,6 +247,7 @@ void create_geometry (Geometry & geom, int type, mapnik::json::positions const& 
         util::apply_visitor(create_multipolygon<Geometry>(geom), coords);
         break;
     default:
+        throw std::runtime_error("Failed to parse geojson geometry");
         break;
     }
 }

--- a/include/mapnik/json/geometry_generator_grammar_impl.hpp
+++ b/include/mapnik/json/geometry_generator_grammar_impl.hpp
@@ -50,39 +50,54 @@ geometry_generator_grammar<OutputIterator, Geometry>::geometry_generator_grammar
         |
         geometry_collection
         |
-        lit("null")
+        lit("null") // geometry_empty
         ;
 
     point = lit("{\"type\":\"Point\",\"coordinates\":") << point_coord << lit("}")
         ;
-    linestring = lit("{\"type\":\"LineString\",\"coordinates\":[") << linestring_coord << lit("]}")
+
+    linestring = lit("{\"type\":\"LineString\",\"coordinates\":") << linestring_coord << lit("}")
         ;
-    polygon = lit("{\"type\":\"Polygon\",\"coordinates\":[") << polygon_coord << lit("]}")
+
+    polygon = lit("{\"type\":\"Polygon\",\"coordinates\":") << polygon_coord << lit("}")
         ;
+
     multi_point = lit("{\"type\":\"MultiPoint\",\"coordinates\":[") << multi_point_coord << lit("]}")
         ;
+
     multi_linestring = lit("{\"type\":\"MultiLineString\",\"coordinates\":[") << multi_linestring_coord << lit("]}")
         ;
+
     multi_polygon = lit("{\"type\":\"MultiPolygon\",\"coordinates\":[") << multi_polygon_coord << lit("]}")
         ;
+
     geometry_collection = lit("{\"type\":\"GeometryCollection\",\"geometries\":[") << geometries  << lit("]}")
         ;
+
     point_coord = lit('[') << coordinate << lit(',') << coordinate  << lit(']')
         ;
-    linestring_coord = point_coord % lit(',')
+
+    linestring_coord = lit('[') << -(point_coord % lit(',')) << lit(']')
         ;
-    polygon_coord = lit('[') << exterior_ring_coord << lit(']') << interior_ring_coord
+
+    polygon_coord = lit('[') << exterior_ring_coord << interior_ring_coord << lit(']')
         ;
+
     exterior_ring_coord = linestring_coord.alias()
         ;
-    interior_ring_coord =  *(lit(",[") << exterior_ring_coord << lit(']'))
+
+    interior_ring_coord =  *(lit(",") << exterior_ring_coord)
         ;
+
     multi_point_coord = linestring_coord.alias()
         ;
-    multi_linestring_coord = (lit('[') << linestring_coord << lit(']')) % lit(',')
+
+    multi_linestring_coord = lit('[') << linestring_coord  % lit(',') << lit(']')
         ;
-    multi_polygon_coord = (lit('[') << polygon_coord << lit(']')) % lit(',')
+
+    multi_polygon_coord = lit('[') << polygon_coord  % lit(',') << lit("]")
         ;
+
     geometries =  geometry % lit(',')
         ;
 }

--- a/include/mapnik/wkt/wkt_generator_grammar_impl.hpp
+++ b/include/mapnik/wkt/wkt_generator_grammar_impl.hpp
@@ -49,36 +49,51 @@ wkt_generator_grammar<OutputIterator, Geometry>::wkt_generator_grammar()
         lit("POINT EMPTY") // special case for geometry_empty
         ;
 
-    point = lit("POINT(") << coordinate << lit(' ') << coordinate << lit(")")
+    point = lit("POINT(") << point_coord << lit(")")
         ;
-    linestring = lit("LINESTRING(") << linestring_coord << lit(")")
+
+    linestring = lit("LINESTRING") << (linestring_coord | lit(" EMPTY"))
         ;
-    polygon = lit("POLYGON(") << polygon_coord << lit(")")
+
+    polygon = lit("POLYGON") << (polygon_coord | lit(" EMPTY"))
         ;
-    multi_point = lit("MULTIPOINT(") << multi_point_coord << lit(")")
+
+    multi_point = lit("MULTIPOINT") << (multi_point_coord | lit(" EMPTY"))
         ;
-    multi_linestring = lit("MULTILINESTRING(") << multi_linestring_coord << lit(")")
+
+    multi_linestring = lit("MULTILINESTRING") << (multi_linestring_coord | lit(" EMPTY"))
         ;
-    multi_polygon = lit("MULTIPOLYGON(") << multi_polygon_coord << lit(")")
+
+    multi_polygon = lit("MULTIPOLYGON") << (multi_polygon_coord | lit(" EMPTY"))
         ;
-    geometry_collection = lit("GEOMETRYCOLLECTION(") << geometries  << lit(")")
+
+    geometry_collection = lit("GEOMETRYCOLLECTION") << (lit("(") << geometries  << lit(")") | lit(" EMPTY"))
         ;
+
     point_coord = coordinate << lit(' ') << coordinate
         ;
-    linestring_coord = point_coord % lit(',')
+
+    linestring_coord = lit("(") << point_coord % lit(',') << lit(")")
         ;
-    polygon_coord = lit('(') << exterior_ring_coord << lit(')') << interior_ring_coord
+
+    polygon_coord = lit("(") << exterior_ring_coord << interior_ring_coord << lit(")")
         ;
+
     exterior_ring_coord = linestring_coord.alias()
         ;
-    interior_ring_coord =  *(lit(",(") << exterior_ring_coord << lit(')'))
+
+    interior_ring_coord =  *(lit(",") << exterior_ring_coord)
         ;
+
     multi_point_coord = linestring_coord.alias()
         ;
-    multi_linestring_coord = (lit('(') << linestring_coord  << lit(')')) % lit(',')
+
+    multi_linestring_coord = lit("(") << linestring_coord % lit(',') << lit(")")
         ;
-    multi_polygon_coord = (lit('(') << polygon_coord << lit(')')) % lit(',')
+
+    multi_polygon_coord = lit("(") << polygon_coord % lit(',') << lit(")")
         ;
+
     geometries = geometry % lit(',')
         ;
 


### PR DESCRIPTION
Handle `empty` geometries consistently across parsers and generators, preserving `type`.


#### Old 
| in | | out  |
|---|---|---|
|`POINT EMPTY` |  <--> | `POINT EMPTY`|
|`LINESTRING EMPTY` |  --> | `POINT EMPTY`|
    

#### New
| in | | out  |
|---|---|---|
|`POINT EMPTY` |  <--> | `POINT EMPTY`|
|`LINESTRING EMPTY` |  <--> | `LINESTRING EMPTY`|