### PR TITLE
add twkb support to sqlite plugin

### DIFF
--- a/plugins/input/sqlite/sqlite_datasource.hpp
+++ b/plugins/input/sqlite/sqlite_datasource.hpp
@@ -82,6 +82,7 @@ private:
     const std::string intersects_token_;
     mapnik::layer_descriptor desc_;
     mapnik::wkbFormat format_;
+    bool twkb_encoding_;
     bool use_spatial_index_;
     bool has_spatial_index_;
     bool using_subquery_;

--- a/plugins/input/sqlite/sqlite_featureset.cpp
+++ b/plugins/input/sqlite/sqlite_featureset.cpp
@@ -49,6 +49,7 @@ sqlite_featureset::sqlite_featureset(std::shared_ptr<sqlite_resultset> rs,
                                      std::string const& encoding,
                                      mapnik::box2d<double> const& bbox,
                                      mapnik::wkbFormat format,
+                                     bool twkb_encoding,
                                      bool spatial_index,
                                      bool using_subquery)
     : rs_(rs),
@@ -56,6 +57,7 @@ sqlite_featureset::sqlite_featureset(std::shared_ptr<sqlite_resultset> rs,
       tr_(new transcoder(encoding)),
       bbox_(bbox),
       format_(format),
+      twkb_encoding_(twkb_encoding),
       spatial_index_(spatial_index),
       using_subquery_(using_subquery)
 {}
@@ -81,7 +83,9 @@ feature_ptr sqlite_featureset::next()
         }
 
         feature_ptr feature = feature_factory::create(ctx_,rs_->column_integer64(1));
-        mapnik::geometry::geometry<double> geom = geometry_utils::from_wkb(data, size, format_);
+        mapnik::geometry::geometry<double> geom;
+        if (twkb_encoding_) geom = geometry_utils::from_twkb(data, size);
+        else geom = geometry_utils::from_wkb(data, size, format_);
         if (mapnik::geometry::is_empty(geom))
         {
             continue;

--- a/plugins/input/sqlite/sqlite_featureset.hpp
+++ b/plugins/input/sqlite/sqlite_featureset.hpp
@@ -44,6 +44,7 @@ public:
                       std::string const& encoding,
                       mapnik::box2d<double> const& bbox,
                       mapnik::wkbFormat format,
+                      bool twkb_encoding,
                       bool spatial_index,
                       bool using_subquery);
     virtual ~sqlite_featureset();
@@ -55,6 +56,7 @@ private:
     const std::unique_ptr<mapnik::transcoder> tr_;
     mapnik::box2d<double> bbox_;
     mapnik::wkbFormat format_;
+    bool twkb_encoding_;
     bool spatial_index_;
     bool using_subquery_;
 


### PR DESCRIPTION
This PR adds TWKB support for SQLite datasource. To use it, convert geometry BLOBs into TWKB and specify twkb as a format in the datasource wkb_format option.