### PR TITLE
The last stripe of a tiff could be read incorrectly due to a swap

### DIFF
--- a/src/tiff_reader.cpp
+++ b/src/tiff_reader.cpp
@@ -169,6 +169,8 @@ private:
     template <typename ImageData>
     void read_stripped(std::size_t x,std::size_t y, ImageData & image);
 
+    void read_stripped(std::size_t x,std::size_t y, image_rgba8 & image);
+
     template <typename ImageData>
     void read_tiled(std::size_t x,std::size_t y, ImageData & image);
 
@@ -530,10 +532,11 @@ struct tiff_reader_traits<image_rgba8>
     {
         if (TIFFReadRGBAStrip(tif, y, buf) != -1)
         {
+            /*
             for (std::size_t y = 0; y < rows_per_strip/2; ++y)
             {
                 std::swap_ranges(buf + y * strip_width, buf + (y + 1) * strip_width, buf + (rows_per_strip - y - 1) * strip_width);
-            }
+            }*/
             return true;
         }
         return false;
@@ -714,6 +717,54 @@ void tiff_reader<T>::read_tiled(std::size_t x0,std::size_t y0, ImageData & image
                 {
                     image.set_row(row_index, tx0 - x0, tx1 - x0, &tile[ty * tile_width_ + tx0 - x]);
                 }
+            }
+        }
+    }
+}
+
+template <typename T>
+void tiff_reader<T>::read_stripped(std::size_t x0, std::size_t y0, image_rgba8 & image)
+{
+    using pixel_type = typename detail::tiff_reader_traits<image_rgba8>::pixel_type;
+    TIFF* tif = open(stream_);
+    if (tif)
+    {
+        std::uint32_t strip_size = TIFFStripSize(tif);
+        std::unique_ptr<pixel_type[]> strip(new pixel_type[strip_size]);
+        std::size_t width = image.width();
+        std::size_t height = image.height();
+
+        std::size_t start_y = (y0 / rows_per_strip_) * rows_per_strip_;
+        std::size_t end_y = std::min(y0 + height, height_);
+        std::size_t tx0, tx1, ty0, ty1, rows_on_strip;
+
+        tx0 = x0;
+        tx1 = std::min(width + x0, width_);
+        rows_on_strip = rows_per_strip_;
+        std::size_t row = 0;
+        bool pick_first_band = (bands_ > 1) && (strip_size / (width_ * rows_per_strip_ * sizeof(pixel_type)) == bands_);
+        for (std::size_t y = start_y; y < end_y; y += rows_per_strip_)
+        {
+            ty0 = std::max(y0, y) - y;
+            ty1 = std::min(end_y, y + rows_per_strip_) - y;
+            rows_on_strip = std::min(end_y - y, static_cast<std::size_t>(rows_per_strip_));
+
+            if (!detail::tiff_reader_traits<image_rgba8>::read_strip(tif, y, rows_per_strip_, width_, strip.get()))
+            {
+                MAPNIK_LOG_DEBUG(tiff_reader) << "TIFFRead(Encoded|RGBA)Strip failed at " << y << " for " << width_ << "/" << height_ << "\n";
+                break;
+            }
+            if (pick_first_band)
+            {
+                std::uint32_t size = width_ * rows_per_strip_ * sizeof(pixel_type);
+                for (std::uint32_t n = 0; n < size; ++n)
+                {
+                    strip[n] = strip[bands_ * n];
+                }
+            }
+            for (std::size_t ty = ty0; ty < ty1; ++ty)
+            {
+                image.set_row(row++, tx0 - x0, tx1 - x0, &strip[(rows_on_strip - ty - 1) * width_ + tx0]);
             }
         }
     }


### PR DESCRIPTION
I was looking at our code currently and how we have been using `std::swap_range` within the tiff reader for the reading of RGBA. I believe that our logic is flawed because the temporary buffer's order could be reversed. However, reading the TIFF reader logic give an idea why we have not seen any issues:

http://www.libtiff.org/man/TIFFReadRGBAStrip.3t.html

> When reading a partial last strip in the file the last line of the image will begin at the beginning of the buffer.

We always expected this to be shifted in the read buffer therefore we could be reading the wrong pixels. However, this has been often producing "good" results because I believe we are simply reading a portion of the result from the previous stripped section we read. Therefore, the last lines would often likely just appear as those they were repeats.

My change I believe makes this work differently for the stripped case of RGBA8, but we still would need to make this change for the tiled case as well. 

/cc @artemp @springmeyer 

