### PR TITLE
Fix a layer compositing offset

### DIFF
--- a/src/agg/agg_renderer.cpp
+++ b/src/agg/agg_renderer.cpp
@@ -250,9 +250,7 @@ void agg_renderer<T0,T1>::end_layer_processing(layer const& lyr)
     {
         composite_mode_e comp_op = lyr.comp_op() ? *lyr.comp_op() : src_over;
         composite(previous_buffer, current_buffer,
-                  comp_op, lyr.get_opacity(),
-                  -common_.t_.offset(),
-                  -common_.t_.offset());
+                  comp_op, lyr.get_opacity(), 0, 0);
         internal_buffers_.pop();
     }
 }


### PR DESCRIPTION
Fixes a bug from https://github.com/mapnik/mapnik/pull/3474 where layers are wrongly composited with offset `-common_.t_.offset()`. This offset should arrange position of inflated buffer when image filters with `image-filters-inflate="true"` are used.

Layers don't support image filters so the offset can be just zero.

This is how the offset was causing shifted rendering:

![layer-compositing-offset-256-256-1 0-agg-reference-good](https://cloud.githubusercontent.com/assets/1950911/26734078/18844f9e-47bd-11e7-8862-13a17dc8f169.png)
![layer-compositing-offset-256-256-1 0-agg-bad](https://cloud.githubusercontent.com/assets/1950911/26734077/186d8a16-47bd-11e7-9da1-818687c36b62.png)


