### PR TITLE
Restore Filter Factor in Image Scaling

### DIFF
--- a/plugins/input/gdal/gdal_featureset.cpp
+++ b/plugins/input/gdal/gdal_featureset.cpp
@@ -149,6 +149,9 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
     box2d<double> intersect = raster_extent_.intersect(q.get_bbox());
     box2d<double> box = t.forward(intersect);
 
+    // get the filter factor if it is set
+    double filter_factor = q.get_filter_factor();
+
     //size of resized output pixel in source image domain
     double margin_x = 1.0 / (std::fabs(dx_) * std::get<0>(q.resolution()));
     double margin_y = 1.0 / (std::fabs(dy_) * std::get<1>(q.resolution()));
@@ -224,7 +227,7 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
                 {
                     throw datasource_exception(CPLGetLastErrorMsg());
                 }
-                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, 0.0);
+                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
                 // set nodata value to be used in raster colorizer
                 if (nodata_value_) raster->set_nodata(*nodata_value_);
                 else raster->set_nodata(raster_nodata);
@@ -244,7 +247,7 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
                 {
                     throw datasource_exception(CPLGetLastErrorMsg());
                 }
-                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, 0.0);
+                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
                 // set nodata value to be used in raster colorizer
                 if (nodata_value_) raster->set_nodata(*nodata_value_);
                 else raster->set_nodata(raster_nodata);
@@ -263,7 +266,7 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
                 {
                     throw datasource_exception(CPLGetLastErrorMsg());
                 }
-                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, 0.0);
+                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
                 // set nodata value to be used in raster colorizer
                 if (nodata_value_) raster->set_nodata(*nodata_value_);
                 else raster->set_nodata(raster_nodata);
@@ -283,7 +286,7 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
                 {
                     throw datasource_exception(CPLGetLastErrorMsg());
                 }
-                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, 0.0);
+                mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
                 // set nodata value to be used in raster colorizer
                 if (nodata_value_) raster->set_nodata(*nodata_value_);
                 else raster->set_nodata(raster_nodata);
@@ -583,7 +586,7 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
                     }
                 }
             }
-            mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, 0.0);
+            mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
             // set nodata value to be used in raster colorizer
             if (nodata_value_) raster->set_nodata(*nodata_value_);
             else raster->set_nodata(raster_nodata);

--- a/plugins/input/raster/raster_featureset.cpp
+++ b/plugins/input/raster/raster_featureset.cpp
@@ -55,7 +55,8 @@ raster_featureset<LookupPolicy>::raster_featureset(LookupPolicy const& policy,
       extent_(extent),
       bbox_(q.get_bbox()),
       curIter_(policy_.begin()),
-      endIter_(policy_.end())
+      endIter_(policy_.end()),
+      filter_factor_(q.get_filter_factor())
 {
 }
 
@@ -115,7 +116,7 @@ feature_ptr raster_featureset<LookupPolicy>::next()
                                                         rem.maxy() + y_off + height);
                     feature_raster_extent = t.backward(feature_raster_extent);
                     mapnik::image_any data = reader->read(x_off, y_off, width, height);
-                    mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, std::move(data), 1.0);
+                    mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, std::move(data), filter_factor_);
                     feature->set_raster(raster);
                 }
             }

--- a/plugins/input/raster/raster_featureset.hpp
+++ b/plugins/input/raster/raster_featureset.hpp
@@ -321,6 +321,7 @@ private:
     mapnik::box2d<double> bbox_;
     iterator_type curIter_;
     iterator_type endIter_;
+    double filter_factor_;
 };
 
 #endif // RASTER_FEATURESET_HPP


### PR DESCRIPTION
Restoring the way filter factors operate so that select algorithms still are passed variables in the form of filter factor to change their operation. Added this operation to raster plugin where it never existed prior. Additionally added a test that was created for #3698 proving that it is not currently an issue.