### PR TITLE
[WIP] Performance stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
  - export PATH=${PREFIX}/bin:$(pwd)/mason_packages/.link/bin:${PATH}
  - export COVERAGE=${COVERAGE:-false}
  - export BENCH=${BENCH:-false}
- - git_submodule_update --init --depth=10
+ - git_submodule_update --init
 
 install:
  - on 'osx' export DATA_PATH=$(brew --prefix)/var/postgres

--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -45,6 +45,7 @@
 #include <mapnik/util/featureset_buffer.hpp>
 #include <mapnik/util/variant.hpp>
 #include <mapnik/symbolizer_dispatch.hpp>
+#include <mapnik/performance_stats.hpp>
 
 // stl
 #include <vector>
@@ -87,6 +88,7 @@ feature_style_processor<Processor>::feature_style_processor(Map const& m, double
 template <typename Processor>
 void feature_style_processor<Processor>::apply(double scale_denom)
 {
+    mapnik::stats_timer __stats__("total_map_rendering");
     Processor & p = static_cast<Processor&>(*this);
     p.start_map_processing(m_);
 

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -61,8 +61,8 @@ public:
     timer_metrics get(std::string const& metric_name);
     void reset(std::string metric_name);
     void reset_all();
-    std::string dump();
-    std::string flush();
+    metrics_hash_t dump();
+    metrics_hash_t flush();
 
 private:
     friend class CreateStatic<timer_stats>;

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -61,8 +61,6 @@ public:
     timer_metrics get(std::string const& metric_name);
     void reset(std::string metric_name);
     void reset_all();
-    metrics_hash_t::iterator begin();
-    metrics_hash_t::iterator end();
     std::string dump();
     std::string flush();
 

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -52,7 +52,7 @@ struct timer_metrics {
     double wall_clock_elapsed;
 };
 
-typedef std::unordered_map<std::string, timer_metrics> metrics_hash_t;
+using metrics_hash_t = std::unordered_map<std::string, timer_metrics>;
 
 class MAPNIK_DECL timer_stats : public singleton<timer_stats, CreateStatic>
 {

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -52,11 +52,11 @@ struct timer_metrics {
     double wall_clock_elapsed;
 };
 
-using metrics_hash_t = std::unordered_map<std::string, timer_metrics>;
-
 class MAPNIK_DECL timer_stats : public singleton<timer_stats, CreateStatic>
 {
 public:
+    using metrics_hash_t = std::unordered_map<std::string, timer_metrics>;
+
     void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed);
     timer_metrics get(std::string const& metric_name);
     void reset(std::string metric_name);

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -1,0 +1,125 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_PERFORMANCE_STATS_HPP
+#define MAPNIK_PERFORMANCE_STATS_HPP
+
+// stl
+#include <cstdlib>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <ctime>
+#include <unordered_map>
+#include <iterator>
+
+#include "timer.hpp"
+
+
+namespace mapnik {
+
+struct timer_metrics {
+    double cpu_elapsed;
+    double wall_clock_elapsed;
+};
+
+typedef std::unordered_map<std::string, timer_metrics> metrics_hash_t;
+
+class timer_stats_
+{
+public:
+    void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
+    {
+        timer_metrics& metrics = timer_stats_[metric_name];
+        metrics.cpu_elapsed += cpu_elapsed;
+        metrics.wall_clock_elapsed += wall_clock_elapsed;
+        timer_stats_[metric_name] = metrics;
+    }
+
+    timer_metrics get(std::string const& metric_name)
+    {
+        return timer_stats_[metric_name];
+    }
+
+    void reset(std::string metric_name) {
+        timer_stats_.erase(metric_name);
+    }
+
+    void reset_all() {
+        timer_stats_.clear();
+    }
+
+    metrics_hash_t::iterator begin() {
+        return timer_stats_.begin();
+    }
+
+    metrics_hash_t::iterator end() {
+        return timer_stats_.end();
+    }
+
+private:
+    metrics_hash_t timer_stats_;
+};
+
+timer_stats_ timer_stats;
+
+
+
+//  A stats_timer behaves like a timer except that the destructor stores
+//  elapsed and CPU times for later retrieval from global timer_stats
+class stats_timer : public timer
+{
+public:
+    stats_timer(std::string const& metric_name)
+        : metric_name_(metric_name)
+    {}
+
+    ~stats_timer()
+    {
+        if (! stopped_)
+        {
+            stop();
+        }
+    }
+
+    void stop() const
+    {
+        timer::stop();
+        try
+        {
+            timer_stats.add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
+        }
+        catch (...) {} // eat any exceptions
+    }
+
+    void discard()
+    {
+        stopped_ = true;
+    }
+
+private:
+    std::string metric_name_;
+};
+
+}
+
+#endif // MAPNIK_PERFORMANCE_STATS_HPP

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -84,6 +84,13 @@ public:
         return out.str();
     }
 
+    std::string flush() {
+        std::string out = dump();
+        reset_all();
+        return out;
+    }
+
+
 private:
     metrics_hash_t timer_stats_;
 };

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -35,7 +35,10 @@
 // mapnik
 #include <mapnik/config.hpp>            // for MAPNIK_DECL
 #include <mapnik/timer.hpp>
+#include <mapnik/util/singleton.hpp>
 
+using mapnik::singleton;
+using mapnik::CreateStatic;
 
 namespace mapnik {
 
@@ -46,10 +49,9 @@ struct timer_metrics {
 
 typedef std::unordered_map<std::string, timer_metrics> metrics_hash_t;
 
-class MAPNIK_DECL timer_stats
+class MAPNIK_DECL timer_stats : public singleton<timer_stats, CreateStatic>
 {
 public:
-    static timer_stats & instance();
     void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed);
     timer_metrics get(std::string const& metric_name);
     void reset(std::string metric_name);
@@ -60,8 +62,11 @@ public:
     std::string flush();
 
 private:
+    friend class CreateStatic<timer_stats>;
     metrics_hash_t metrics_;
 };
+
+extern template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;
 
 
 //  A stats_timer behaves like a timer except that the destructor stores

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -76,6 +76,14 @@ public:
         return timer_stats_.end();
     }
 
+    std::string dump() {
+        std::stringstream out;
+        for(auto metric : timer_stats_) {
+            out << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;
+        }
+        return out.str();
+    }
+
 private:
     metrics_hash_t timer_stats_;
 };

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -70,36 +70,14 @@ extern template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;
 
 
 //  A stats_timer behaves like a timer except that the destructor stores
-//  elapsed and CPU times for later retrieval from global timer_stats
+//  elapsed and CPU times for later retrieval from singleton timer_stats
 class stats_timer : public timer
 {
 public:
-    stats_timer(std::string const& metric_name)
-        : metric_name_(metric_name)
-    {}
-
-    ~stats_timer()
-    {
-        if (! stopped_)
-        {
-            stop();
-        }
-    }
-
-    void stop() const
-    {
-        timer::stop();
-        try
-        {
-            timer_stats::instance().add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
-        }
-        catch (...) {} // eat any exceptions
-    }
-
-    void discard()
-    {
-        stopped_ = true;
-    }
+    stats_timer(std::string const& metric_name);
+    ~stats_timer();
+    void stop() const;
+    void discard();
 
 private:
     std::string metric_name_;

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -71,7 +71,7 @@ extern template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;
 
 //  A stats_timer behaves like a timer except that the destructor stores
 //  elapsed and CPU times for later retrieval from singleton timer_stats
-class stats_timer : public timer
+class MAPNIK_DECL stats_timer : public timer
 {
 public:
     stats_timer(std::string const& metric_name);

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -32,7 +32,9 @@
 #include <unordered_map>
 #include <iterator>
 
-#include "timer.hpp"
+// mapnik
+#include <mapnik/config.hpp>            // for MAPNIK_DECL
+#include <mapnik/timer.hpp>
 
 
 namespace mapnik {
@@ -44,59 +46,22 @@ struct timer_metrics {
 
 typedef std::unordered_map<std::string, timer_metrics> metrics_hash_t;
 
-class timer_stats_
+class MAPNIK_DECL timer_stats
 {
 public:
-    void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
-    {
-        timer_metrics& metrics = timer_stats_[metric_name];
-        metrics.cpu_elapsed += cpu_elapsed;
-        metrics.wall_clock_elapsed += wall_clock_elapsed;
-        timer_stats_[metric_name] = metrics;
-    }
-
-    timer_metrics get(std::string const& metric_name)
-    {
-        return timer_stats_[metric_name];
-    }
-
-    void reset(std::string metric_name) {
-        timer_stats_.erase(metric_name);
-    }
-
-    void reset_all() {
-        timer_stats_.clear();
-    }
-
-    metrics_hash_t::iterator begin() {
-        return timer_stats_.begin();
-    }
-
-    metrics_hash_t::iterator end() {
-        return timer_stats_.end();
-    }
-
-    std::string dump() {
-        std::stringstream out;
-        for(auto metric : timer_stats_) {
-            out << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;
-        }
-        return out.str();
-    }
-
-    std::string flush() {
-        std::string out = dump();
-        reset_all();
-        return out;
-    }
-
+    static timer_stats & instance();
+    void add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed);
+    timer_metrics get(std::string const& metric_name);
+    void reset(std::string metric_name);
+    void reset_all();
+    metrics_hash_t::iterator begin();
+    metrics_hash_t::iterator end();
+    std::string dump();
+    std::string flush();
 
 private:
-    metrics_hash_t timer_stats_;
+    metrics_hash_t metrics_;
 };
-
-timer_stats_ timer_stats;
-
 
 
 //  A stats_timer behaves like a timer except that the destructor stores
@@ -121,7 +86,7 @@ public:
         timer::stop();
         try
         {
-            timer_stats.add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
+            timer_stats::instance().add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
         }
         catch (...) {} // eat any exceptions
     }

--- a/include/mapnik/performance_stats.hpp
+++ b/include/mapnik/performance_stats.hpp
@@ -32,6 +32,11 @@
 #include <unordered_map>
 #include <iterator>
 
+#ifdef MAPNIK_THREADSAFE
+#include <mutex>
+#endif
+
+
 // mapnik
 #include <mapnik/config.hpp>            // for MAPNIK_DECL
 #include <mapnik/timer.hpp>
@@ -64,6 +69,9 @@ public:
 private:
     friend class CreateStatic<timer_stats>;
     metrics_hash_t metrics_;
+#ifdef MAPNIK_THREADSAFE
+    std::mutex metrics_mutex_;
+#endif
 };
 
 extern template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -33,6 +33,7 @@
 #include <mapnik/sql_utils.hpp>
 #include <mapnik/util/conversions.hpp>
 #include <mapnik/timer.hpp>
+#include <mapnik/performance_stats.hpp>
 #include <mapnik/value_types.hpp>
 
 #pragma GCC diagnostic push
@@ -1024,10 +1025,10 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
                 s << " LIMIT " << row_limit_;
             }
 
-            {
-                mapnik::stats_timer __stats__("postgis::get_resultset");
-                std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
-            }
+            mapnik::stats_timer __stats_timer__("postgis::get_resultset");
+            std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
+            __stats_timer__.stop();
+
             return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty(),
                                                         key_field_as_attribute_, twkb_encoding_);
         }

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -1025,7 +1025,7 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
                 s << " LIMIT " << row_limit_;
             }
 
-            mapnik::stats_timer __stats_timer__("postgis::get_resultset");
+            mapnik::stats_timer __stats_timer__("postgis_datasource::features_at_point::get_resultset");
             std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
             __stats_timer__.stop();
 

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -1024,7 +1024,10 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
                 s << " LIMIT " << row_limit_;
             }
 
-            std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
+            {
+                mapnik::stats_timer __stats__("postgis::get_resultset");
+                std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool);
+            }
             return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty(),
                                                         key_field_as_attribute_, twkb_encoding_);
         }

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -937,7 +937,9 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
             s << " LIMIT " << row_limit_;
         }
 
+        mapnik::stats_timer __stats_timer__("postgis_datasource::features_with_context::get_resultset");
         std::shared_ptr<IResultSet> rs = get_resultset(conn, s.str(), pool, proc_ctx);
+        __stats_timer__.stop();
         return std::make_shared<postgis_featureset>(rs, ctx, desc_.get_encoding(), !key_field_.empty(),
                                                     key_field_as_attribute_, twkb_encoding_);
 

--- a/src/build.py
+++ b/src/build.py
@@ -264,6 +264,7 @@ source = Split(
     renderer_common/render_thunk_extractor.cpp
     math.cpp
     value.cpp
+    performance_stats.cpp
     """
     )
 

--- a/src/image_util.cpp
+++ b/src/image_util.cpp
@@ -36,6 +36,7 @@
 #include <mapnik/util/variant.hpp>
 #include <mapnik/debug.hpp>
 #include <mapnik/safe_cast.hpp>
+#include <mapnik/performance_stats.hpp>
 #ifdef SSE_MATH
 #include <mapnik/sse.hpp>
 #endif
@@ -61,6 +62,7 @@ MAPNIK_DECL std::string save_to_string(T const& image,
                                        std::string const& type,
                                        rgba_palette const& palette)
 {
+    mapnik::stats_timer __stats_timer__("save_to_string");
     std::ostringstream ss(std::ios::out|std::ios::binary);
     save_to_stream(image, ss, type, palette);
     return ss.str();
@@ -70,6 +72,7 @@ template <typename T>
 MAPNIK_DECL std::string save_to_string(T const& image,
                                        std::string const& type)
 {
+    mapnik::stats_timer __stats_timer__("save_to_string");
     std::ostringstream ss(std::ios::out|std::ios::binary);
     save_to_stream(image, ss, type);
     return ss.str();

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -61,20 +61,6 @@ void timer_stats::reset_all()
     metrics_.clear();
 }
 
-metrics_hash_t::iterator timer_stats::begin() {
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(metrics_mutex_);
-#endif
-    return metrics_.begin();
-}
-
-metrics_hash_t::iterator timer_stats::end() {
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(metrics_mutex_);
-#endif
-    return metrics_.end();
-}
-
 std::string timer_stats::dump() {
 #ifdef MAPNIK_THREADSAFE
     std::lock_guard<std::mutex> lock(metrics_mutex_);

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -69,7 +69,7 @@ metrics_hash_t timer_stats::dump() {
 }
 
 metrics_hash_t timer_stats::flush() {
-    metrics_hash_t out = dump();
+    metrics_hash_t out(dump());
     reset_all();
     return out;
 }

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -61,15 +61,15 @@ void timer_stats::reset_all()
     metrics_.clear();
 }
 
-metrics_hash_t timer_stats::dump() {
+timer_stats::metrics_hash_t timer_stats::dump() {
 #ifdef MAPNIK_THREADSAFE
     std::lock_guard<std::mutex> lock(metrics_mutex_);
 #endif
     return metrics_;
 }
 
-metrics_hash_t timer_stats::flush() {
-    metrics_hash_t out(dump());
+timer_stats::metrics_hash_t timer_stats::flush() {
+    timer_stats::metrics_hash_t out(dump());
     reset_all();
     return out;
 }

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -90,11 +90,7 @@ stats_timer::~stats_timer()
 void stats_timer::stop() const
 {
     timer::stop();
-    try
-        {
-            timer_stats::instance().add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
-        }
-    catch (...) {} // eat any exceptions
+    timer_stats::instance().add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
 }
 
 void stats_timer::discard()

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -61,19 +61,15 @@ void timer_stats::reset_all()
     metrics_.clear();
 }
 
-std::string timer_stats::dump() {
+metrics_hash_t timer_stats::dump() {
 #ifdef MAPNIK_THREADSAFE
     std::lock_guard<std::mutex> lock(metrics_mutex_);
 #endif
-    std::stringstream out;
-    for(auto metric : metrics_) {
-        out << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;
-    }
-    return out.str();
+    return metrics_;
 }
 
-std::string timer_stats::flush() {
-    std::string out = dump();
+metrics_hash_t timer_stats::flush() {
+    metrics_hash_t out = dump();
     reset_all();
     return out;
 }

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -34,7 +34,6 @@ void timer_stats::add(std::string const& metric_name, double cpu_elapsed, double
     timer_metrics& metrics = metrics_[metric_name];
     metrics.cpu_elapsed += cpu_elapsed;
     metrics.wall_clock_elapsed += wall_clock_elapsed;
-    metrics_[metric_name] = metrics;
 }
 
 timer_metrics timer_stats::get(std::string const& metric_name)

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -69,4 +69,33 @@ std::string timer_stats::flush() {
     return out;
 }
 
+
+
+stats_timer::stats_timer(std::string const& metric_name)
+    : metric_name_(metric_name)
+{}
+
+stats_timer::~stats_timer()
+{
+    if (! stopped_)
+        {
+            stop();
+        }
 }
+
+void stats_timer::stop() const
+{
+    timer::stop();
+    try
+        {
+            timer_stats::instance().add(metric_name_, cpu_elapsed(), wall_clock_elapsed());
+        }
+    catch (...) {} // eat any exceptions
+}
+
+void stats_timer::discard()
+{
+    stopped_ = true;
+}
+
+} // end of ns

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -24,11 +24,7 @@
 
 namespace mapnik {
 
-timer_stats & timer_stats::instance()
-{
-    static timer_stats ts;
-    return ts;
-}
+template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;
 
 void timer_stats::add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
 {

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#include <mapnik/performance_stats.hpp>
+
+namespace mapnik {
+
+timer_stats & timer_stats::instance()
+{
+    static timer_stats ts;
+    return ts;
+}
+
+void timer_stats::add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
+{
+    timer_metrics& metrics = metrics_[metric_name];
+    metrics.cpu_elapsed += cpu_elapsed;
+    metrics.wall_clock_elapsed += wall_clock_elapsed;
+    metrics_[metric_name] = metrics;
+}
+
+timer_metrics timer_stats::get(std::string const& metric_name)
+{
+    return metrics_[metric_name];
+}
+
+void timer_stats::reset(std::string metric_name) {
+    metrics_.erase(metric_name);
+}
+
+void timer_stats::reset_all() {
+    metrics_.clear();
+}
+
+metrics_hash_t::iterator timer_stats::begin() {
+    return metrics_.begin();
+}
+
+metrics_hash_t::iterator timer_stats::end() {
+    return metrics_.end();
+}
+
+std::string timer_stats::dump() {
+    std::stringstream out;
+    for(auto metric : metrics_) {
+        out << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;
+    }
+    return out.str();
+}
+
+std::string timer_stats::flush() {
+    std::string out = dump();
+    reset_all();
+    return out;
+}
+
+}

--- a/src/performance_stats.cpp
+++ b/src/performance_stats.cpp
@@ -28,6 +28,9 @@ template class MAPNIK_DECL singleton<timer_stats, CreateStatic>;
 
 void timer_stats::add(std::string const& metric_name, double cpu_elapsed, double wall_clock_elapsed)
 {
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     timer_metrics& metrics = metrics_[metric_name];
     metrics.cpu_elapsed += cpu_elapsed;
     metrics.wall_clock_elapsed += wall_clock_elapsed;
@@ -36,26 +39,46 @@ void timer_stats::add(std::string const& metric_name, double cpu_elapsed, double
 
 timer_metrics timer_stats::get(std::string const& metric_name)
 {
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     return metrics_[metric_name];
 }
 
-void timer_stats::reset(std::string metric_name) {
+void timer_stats::reset(std::string metric_name)
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     metrics_.erase(metric_name);
 }
 
-void timer_stats::reset_all() {
+void timer_stats::reset_all()
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     metrics_.clear();
 }
 
 metrics_hash_t::iterator timer_stats::begin() {
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     return metrics_.begin();
 }
 
 metrics_hash_t::iterator timer_stats::end() {
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     return metrics_.end();
 }
 
 std::string timer_stats::dump() {
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+#endif
     std::stringstream out;
     for(auto metric : metrics_) {
         out << metric.first << "\tcpu_time = " << metric.second.cpu_elapsed << " ms\twall_time = " << metric.second.wall_clock_elapsed << " ms" << std::endl;

--- a/test/standalone/performance_stats_test.cpp
+++ b/test/standalone/performance_stats_test.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("performance_stats") {
 SECTION("collect_and_flush") {
-    CHECK(mapnik::timer_stats::instance().flush().length() == 0);
+    CHECK(mapnik::timer_stats::instance().flush().size() == 0);
     {
         mapnik::stats_timer __stats__("dummy::sleep");
         usleep(10000);
@@ -28,9 +28,11 @@ SECTION("collect_and_flush") {
     }
     __stats__.stop();
 
-    std::string out = mapnik::timer_stats::instance().flush();
-    CHECK(out.length() > 0);
-    std::cout << out;
-    CHECK(mapnik::timer_stats::instance().flush().length() == 0);
+    auto metrics = mapnik::timer_stats::instance().flush();
+    CHECK(metrics.size() == 2);
+    CHECK(metrics["dummy::sleep"].cpu_elapsed <= metrics["dummy::sleep"].wall_clock_elapsed);
+    CHECK(metrics["dummy::sleep"].cpu_elapsed <= metrics["busy::wait"].cpu_elapsed);
+
+    CHECK(mapnik::timer_stats::instance().flush().size() == 0);
 }
 }

--- a/test/standalone/performance_stats_test.cpp
+++ b/test/standalone/performance_stats_test.cpp
@@ -31,7 +31,10 @@ SECTION("collect_and_flush") {
     auto metrics = mapnik::timer_stats::instance().flush();
     CHECK(metrics.size() == 2);
     CHECK(metrics["dummy::sleep"].cpu_elapsed <= metrics["dummy::sleep"].wall_clock_elapsed);
-    CHECK(metrics["dummy::sleep"].cpu_elapsed <= metrics["busy::wait"].cpu_elapsed);
+    CHECK(metrics["dummy::sleep"].cpu_elapsed >= 0);
+    CHECK(metrics["dummy::sleep"].wall_clock_elapsed >= 0);
+    CHECK(metrics["busy::wait"].cpu_elapsed >= 0);
+    CHECK(metrics["busy::wait"].wall_clock_elapsed >= 0);
 
     CHECK(mapnik::timer_stats::instance().flush().size() == 0);
 }

--- a/test/standalone/performance_stats_test.cpp
+++ b/test/standalone/performance_stats_test.cpp
@@ -1,0 +1,36 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <unistd.h>
+#include <iostream>
+#include <mapnik/performance_stats.hpp>
+
+
+TEST_CASE("performance_stats") {
+SECTION("collect_and_flush") {
+    CHECK(mapnik::timer_stats::instance().flush().length() == 0);
+    {
+        mapnik::stats_timer __stats__("dummy::sleep");
+        usleep(10000);
+    }
+
+    {
+        mapnik::stats_timer __stats__("dummy::sleep");
+        usleep(10000);
+    }
+
+    mapnik::stats_timer __stats__("busy::wait");
+    unsigned long int counter = 0;
+    for(unsigned int i=0; i<10000; i++) {
+        for(unsigned int j=0; j<10000; j++) {
+            counter++;
+        }
+    }
+    __stats__.stop();
+
+    std::string out = mapnik::timer_stats::instance().flush();
+    CHECK(out.length() > 0);
+    std::cout << out;
+    CHECK(mapnik::timer_stats::instance().flush().length() == 0);
+}
+}


### PR DESCRIPTION
These changes are WIP but I'd really like to hear your opinions to iterate on them. The changes aim at covering some of the concerns of https://github.com/mapnik/mapnik/issues/1956

Basically this PR adds a `stats_timer` class. The objects of that class track the CPU and wall time between either the creation and destruction of them, or up to a call to `stop()`. The main difference from existing `timer` class (from which it inherits) is that they store the metrics in a singleton `timer_stats`, from which the stats can later be recovered.

It also adds a few stat timers to measure things I was particularly interested in, and a standalone test for the feature (as I was having some trouble linking against the singleton).

Any comment (especially re. approach, design and API of the classes) is more than welcomed.