### PR TITLE
Set premultiplied flag to the color font glyph bitmap

### DIFF
--- a/src/text/renderer.cpp
+++ b/src/text/renderer.cpp
@@ -157,6 +157,7 @@ void composite_color_bitmap(T & pixmap, FT_Bitmap *bitmap, int x, int y, double 
   int scaled_height = bitmap->rows * scale;
   image_rgba8 scaled_image(scaled_width, scaled_height);
   scale_image_agg(scaled_image, image , SCALING_BILINEAR , scale, scale, 0.0, 0.0, 1.0, 0);
+  set_premultiplied_alpha(scaled_image, true);
   composite(pixmap, scaled_image, comp_op, opacity, x, y);
 }
 


### PR DESCRIPTION
Premultiplied flag has to be set to the glyph bitmap, otherwise [compositing is throwing an error if MAPNIK_DEBUG=True](https://github.com/mapnik/mapnik/blob/333ef9fde145f88339eaccba810305707bae9b0e/src/image_compositing.cpp#L148).

Glyph bitmaps are stored premultiplied:
http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/ChangeLog.25?id=ca799e9be52526739691f120285a27b91fd15d68#n4906

Also simple visual test is added:
![bitmap-color-font-1-256-256-1 0-agg-reference](https://user-images.githubusercontent.com/1950911/27796466-5c244956-600a-11e7-9a68-3bcf95a0bc21.png)

