### PR TITLE
Color font support improvements

### DIFF
--- a/include/mapnik/text/color_font_renderer.hpp
+++ b/include/mapnik/text/color_font_renderer.hpp
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_COLOR_FONT_RENDERER_HPP
+#define MAPNIK_COLOR_FONT_RENDERER_HPP
+
+#pragma GCC diagnostic push
+#include <mapnik/warning_ignore.hpp>
+
+#pragma GCC diagnostic push
+#include <mapnik/warning_ignore_agg.hpp>
+#include <agg_trans_affine.h>
+#pragma GCC diagnostic pop
+
+// freetype2
+extern "C"
+{
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_STROKER_H
+}
+
+#pragma GCC diagnostic pop
+
+#include <mapnik/text/glyph_info.hpp>
+#include <mapnik/image_any.hpp>
+#include <mapnik/image_compositing.hpp>
+#include <mapnik/geometry/box2d.hpp>
+
+namespace mapnik
+{
+
+agg::trans_affine glyph_transform(agg::trans_affine const& tr,
+                                  unsigned glyph_height,
+                                  int x, int y,
+                                  double angle,
+                                  box2d<double> const& bbox);
+
+template <typename T>
+void composite_color_glyph(T & pixmap,
+                           FT_Bitmap const& bitmap,
+                           agg::trans_affine const& tr,
+                           double opacity,
+                           composite_mode_e comp_op);
+
+struct glyph_t;
+
+image_rgba8 render_glyph_image(glyph_t const& glyph,
+                               FT_Bitmap const& bitmap,
+                               agg::trans_affine const& tr,
+                               pixel_position & render_pos);
+
+}
+
+#endif

--- a/include/mapnik/text/face.hpp
+++ b/include/mapnik/text/face.hpp
@@ -77,8 +77,10 @@ public:
     ~font_face();
 
 private:
+    bool init_color_font();
+
     FT_Face face_;
-    bool color_font_ = false;
+    const bool color_font_;
 };
 using face_ptr = std::shared_ptr<font_face>;
 

--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -284,7 +284,7 @@ static void shape_text(text_line & line,
                         double tmp_height = g.height();
                         if (g.face->is_color())
                         {
-                            tmp_height = size;
+                            tmp_height = g.ymax();
                         }
                         if (tmp_height > max_glyph_height) max_glyph_height = tmp_height;
                         width_map[char_index] += g.advance();

--- a/include/mapnik/text/rotation.hpp
+++ b/include/mapnik/text/rotation.hpp
@@ -17,6 +17,11 @@ struct rotation
     double cos;
     rotation operator~() const { return rotation(sin, -cos); }
     rotation operator!() const { return rotation(-sin, cos); }
+
+    double angle() const
+    {
+        return std::atan2(sin, cos);
+    }
 };
 }
 

--- a/src/build.py
+++ b/src/build.py
@@ -241,6 +241,7 @@ source = Split(
     text/placement_finder.cpp
     text/properties_util.cpp
     text/renderer.cpp
+    text/color_font_renderer.cpp
     text/symbolizer_helpers.cpp
     text/text_properties.cpp
     text/font_feature_settings.cpp

--- a/src/text/color_font_renderer.cpp
+++ b/src/text/color_font_renderer.cpp
@@ -1,0 +1,169 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+// mapnik
+#include <mapnik/text/color_font_renderer.hpp>
+#include <mapnik/text/renderer.hpp>
+#include <mapnik/font_engine_freetype.hpp>
+#include <mapnik/image_scaling.hpp>
+#include <mapnik/text/face.hpp>
+#include <mapnik/agg_rasterizer.hpp>
+#include <mapnik/image_util.hpp>
+
+#pragma GCC diagnostic push
+#include <mapnik/warning_ignore_agg.hpp>
+#include "agg_rendering_buffer.h"
+#include "agg_color_rgba.h"
+#include "agg_scanline_u.h"
+#include "agg_image_filters.h"
+#include "agg_trans_bilinear.h"
+#include "agg_span_allocator.h"
+#include "agg_image_accessors.h"
+#include "agg_span_image_filter_rgba.h"
+#include "agg_renderer_base.h"
+#include "agg_renderer_scanline.h"
+#include "agg_pixfmt_rgba.h"
+#pragma GCC diagnostic pop
+
+namespace mapnik
+{
+
+template <typename Pixmap, typename ImageAccessor>
+void composite_image(Pixmap & pixmap,
+                     ImageAccessor & img_accessor,
+                     double width,
+                     double height,
+                     agg::trans_affine const& tr,
+                     double opacity,
+                     composite_mode_e comp_op)
+{
+    double p[8];
+    p[0] = 0;     p[1] = 0;
+    p[2] = width; p[3] = 0;
+    p[4] = width; p[5] = height;
+    p[6] = 0;     p[7] = height;
+
+    tr.transform(&p[0], &p[1]);
+    tr.transform(&p[2], &p[3]);
+    tr.transform(&p[4], &p[5]);
+    tr.transform(&p[6], &p[7]);
+
+    rasterizer ras;
+    ras.move_to_d(p[0], p[1]);
+    ras.line_to_d(p[2], p[3]);
+    ras.line_to_d(p[4], p[5]);
+    ras.line_to_d(p[6], p[7]);
+
+    using color_type = agg::rgba8;
+    using order_type = agg::order_rgba;
+    using blender_type = agg::comp_op_adaptor_rgba_pre<color_type, order_type>;
+    using pixfmt_comp_type = agg::pixfmt_custom_blend_rgba<blender_type, agg::rendering_buffer>;
+    using renderer_base = agg::renderer_base<pixfmt_comp_type>;
+
+    agg::scanline_u8 sl;
+    agg::rendering_buffer buf(pixmap.bytes(),
+                              pixmap.width(),
+                              pixmap.height(),
+                              pixmap.row_size());
+    pixfmt_comp_type pixf(buf);
+    pixf.comp_op(static_cast<agg::comp_op_e>(comp_op));
+    renderer_base renb(pixf);
+
+    agg::span_allocator<color_type> sa;
+    agg::image_filter_bilinear filter_kernel;
+    agg::image_filter_lut filter(filter_kernel, false);
+
+    using interpolator_type = agg::span_interpolator_linear<agg::trans_affine>;
+    using span_gen_type = agg::span_image_resample_rgba_affine<ImageAccessor>;
+    using renderer_type = agg::renderer_scanline_aa_alpha<renderer_base,
+                                                          agg::span_allocator<agg::rgba8>,
+                                                          span_gen_type>;
+    agg::trans_affine final_tr(p, 0, 0, width, height);
+    final_tr.tx = std::floor(final_tr.tx + .5);
+    final_tr.ty = std::floor(final_tr.ty + .5);
+    interpolator_type interpolator(final_tr);
+    span_gen_type sg(img_accessor, interpolator, filter);
+    renderer_type rp(renb,sa, sg, static_cast<unsigned>(opacity * 255));
+    agg::render_scanlines(ras, sl, rp);
+}
+
+agg::trans_affine glyph_transform(agg::trans_affine const& tr,
+                                  unsigned glyph_height,
+                                  int x, int y,
+                                  double angle,
+                                  box2d<double> const& bbox)
+{
+    agg::trans_affine t;
+    double scale = bbox.height() / glyph_height;
+    t *= agg::trans_affine_translation(0, -bbox.maxy() / scale); // set to baseline
+    t *= tr;
+    t *= agg::trans_affine_rotation(angle);
+    t *= agg::trans_affine_scaling(scale);
+    t *= agg::trans_affine_translation(x, y);
+    return t;
+}
+
+template <typename T>
+void composite_color_glyph(T & pixmap,
+                           FT_Bitmap const& bitmap,
+                           agg::trans_affine const& tr,
+                           double opacity,
+                           composite_mode_e comp_op)
+{
+    using glyph_pixfmt_type = agg::pixfmt_bgra32_pre;
+    using img_accessor_type = agg::image_accessor_clone<glyph_pixfmt_type>;
+    unsigned width = bitmap.width;
+    unsigned height = bitmap.rows;
+    agg::rendering_buffer glyph_buf(bitmap.buffer, width, height, width * glyph_pixfmt_type::pix_width);
+    glyph_pixfmt_type glyph_pixf(glyph_buf);
+    img_accessor_type img_accessor(glyph_pixf);
+
+    composite_image<T, img_accessor_type>(
+        pixmap, img_accessor, width, height, tr,
+        opacity, comp_op);
+}
+
+template
+void composite_color_glyph<image_rgba8>(image_rgba8 & pixmap,
+                           FT_Bitmap const& bitmap,
+                           agg::trans_affine const& tr,
+                           double opacity,
+                           composite_mode_e comp_op);
+
+image_rgba8 render_glyph_image(glyph_t const& glyph,
+                               FT_Bitmap const& bitmap,
+                               agg::trans_affine const& tr,
+                               pixel_position & render_pos)
+{
+    agg::trans_affine transform(glyph_transform(tr, bitmap.rows, 0, 0, -glyph.rot.angle(), glyph.bbox));
+    box2d<double> bitmap_bbox(0, 0, bitmap.width, bitmap.rows);
+    bitmap_bbox *= transform;
+    image_rgba8 glyph_image(bitmap_bbox.width(), bitmap_bbox.height());
+    transform *= agg::trans_affine_translation(-bitmap_bbox.minx(), -bitmap_bbox.miny());
+    render_pos = render_pos +
+                 pixel_position(glyph.pos.x, -glyph.pos.y) +
+                 pixel_position(std::round(bitmap_bbox.minx()), std::round(bitmap_bbox.miny()));
+    composite_color_glyph(glyph_image, bitmap, transform, 1, dst_over);
+    return glyph_image;
+}
+
+} // namespace mapnik

--- a/src/text/face.cpp
+++ b/src/text/face.cpp
@@ -38,12 +38,17 @@ namespace mapnik
 {
 
 font_face::font_face(FT_Face face)
-    : face_(face)
+    : face_(face),
+      color_font_(init_color_font())
+{
+}
+
+bool font_face::init_color_font()
 {
     static const uint32_t tag = FT_MAKE_TAG('C', 'B', 'D', 'T');
     unsigned long length = 0;
     FT_Load_Sfnt_Table(face_, tag, 0, nullptr, &length);
-    if (length) color_font_ = true;
+    return length > 0;
 }
 
 bool font_face::set_character_sizes(double size)
@@ -85,6 +90,15 @@ bool font_face::glyph_dimensions(glyph_info & glyph) const
     glyph.unscaled_ymax = glyph_bbox.yMax;
     glyph.unscaled_advance = face_->glyph->advance.x;
     glyph.unscaled_line_height = face_->size->metrics.height;
+
+    if (color_font_)
+    {
+        double scale_multiplier = 2048.0 / (face_->size->metrics.height);
+        glyph.unscaled_ymin *= scale_multiplier;
+        glyph.unscaled_ymax *= scale_multiplier;
+        glyph.unscaled_advance *= scale_multiplier;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
I tried to improve rendering with colored fonts. So far with AGG only, no halo yet. The main goal was to transform glyphs correctly to support line placement.

![bitmap-color-font-2-512-512-1 0-agg-reference](https://user-images.githubusercontent.com/1950911/30185764-231af59a-9423-11e7-8675-6dc8c984f8e5.png)
![bitmap-color-font-3-512-512-1 0-agg-reference](https://user-images.githubusercontent.com/1950911/30185765-236283ec-9423-11e7-8d60-5b4c21934ca0.png)
