### PR TITLE
Ensure the svg_parser interface is back compatible with v3.0.x series

### DIFF
--- a/include/mapnik/svg/svg_parser.hpp
+++ b/include/mapnik/svg/svg_parser.hpp
@@ -69,8 +69,11 @@ public:
     explicit svg_parser(svg_converter_type & path, bool strict = false);
     ~svg_parser();
     error_handler & err_handler();
-    void parse(std::string const& filename);
-    void parse_from_string(std::string const& svg);
+    std::vector<std::string> const& error_messages() {
+        return err_handler_.error_messages();
+    }
+    bool parse(std::string const& filename);
+    bool parse_from_string(std::string const& svg);
     svg_converter_type & path_;
     bool is_defs_;
     bool strict_;

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -1433,7 +1433,7 @@ svg_parser::svg_parser(svg_converter<svg_path_adapter,
 
 svg_parser::~svg_parser() {}
 
-void svg_parser::parse(std::string const& filename)
+bool svg_parser::parse(std::string const& filename)
 {
 #ifdef _WINDOWS
     std::basic_ifstream<char> stream(mapnik::utf8_to_utf16(filename));
@@ -1470,9 +1470,10 @@ void svg_parser::parse(std::string const& filename)
     {
         traverse_tree(*this, child);
     }
+    return !err_handler_.error_messages().empty();
 }
 
-void svg_parser::parse_from_string(std::string const& svg)
+bool svg_parser::parse_from_string(std::string const& svg)
 {
     const int flags = rapidxml::parse_trim_whitespace | rapidxml::parse_validate_closing_tags;
     rapidxml::xml_document<> doc;
@@ -1494,6 +1495,7 @@ void svg_parser::parse_from_string(std::string const& svg)
     {
         traverse_tree(*this, child);
     }
+    return !err_handler_.error_messages().empty();
 }
 
 svg_parser::error_handler & svg_parser::err_handler()


### PR DESCRIPTION
This fixes the API breakages when #3685 was ported to v3.0.x. This allows node-mapnik master to stay compiling against v3.0.x without changes. This was useful for me to test other branches against mapnik core branches off v3.0.x.