### PR TITLE
fix feature_style_processor::apply_to_layer() after #3474

### DIFF
--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -213,8 +213,12 @@ void feature_style_processor<Processor>::apply_to_layer(layer const& lay,
 
     if (!mat.active_styles_.empty())
     {
+        p.start_layer_processing(mat.lay_, mat.layer_ext2_);
+
         render_material(mat,p);
         render_submaterials(mat, p);
+
+        p.end_layer_processing(mat.lay_);
     }
 }
 


### PR DESCRIPTION
Fixes the buffer-size problem from https://github.com/mapnik/node-mapnik/pull/805.

I will add test coverage soon.