### PR TITLE
visual tests: report failed tests

### DIFF
--- a/test/visual/report.cpp
+++ b/test/visual/report.cpp
@@ -39,22 +39,7 @@ void console_report::report(result const & r)
         s << '-' << r.tiles.width << 'x' << r.tiles.height;
     }
     s << '-' << std::fixed << std::setprecision(1) << r.scale_factor << "\" with " << r.renderer_name << "... ";
-
-    switch (r.state)
-    {
-        case STATE_OK:
-            s << "OK";
-            break;
-        case STATE_FAIL:
-            s << "FAILED (" << r.diff << " different pixels)";
-            break;
-        case STATE_OVERWRITE:
-            s << "OVERWRITTEN (" << r.diff << " different pixels)";
-            break;
-        case STATE_ERROR:
-            s << "ERROR (" << r.error_message << ")";
-            break;
-    }
+    report_state(r);
 
     if (show_duration)
     {
@@ -115,7 +100,50 @@ unsigned console_report::summary(result_list const & results)
         s << "total: \t" << duration_cast<milliseconds>(total).count() << " milliseconds" << std::endl;
     }
 
+    s << std::endl;
+    report_failures(results);
+    s << std::endl;
+
     return fail + error;
+}
+
+void console_report::report_state(result const & r)
+{
+    switch (r.state)
+    {
+        case STATE_OK:
+            s << "OK";
+            break;
+        case STATE_FAIL:
+            s << "FAILED (" << r.diff << " different pixels)";
+            break;
+        case STATE_OVERWRITE:
+            s << "OVERWRITTEN (" << r.diff << " different pixels)";
+            break;
+        case STATE_ERROR:
+            s << "ERROR (" << r.error_message << ")";
+            break;
+    }
+}
+
+void console_report::report_failures(result_list const & results)
+{
+    for (auto const & r : results)
+    {
+        if (r.state == STATE_OK)
+        {
+            continue;
+        }
+
+        s << r.name << " ";
+        report_state(r);
+        s << std::endl;
+        if (!r.actual_image_path.empty())
+        {
+            s << "    " << r.actual_image_path << " (actual)" << std::endl;
+            s << "    " << r.reference_image_path << " (reference)" << std::endl;
+        }
+    }
 }
 
 void console_short_report::report(result const & r)

--- a/test/visual/report.hpp
+++ b/test/visual/report.hpp
@@ -48,6 +48,9 @@ public:
     unsigned summary(result_list const & results);
 
 protected:
+    void report_state(result const & r);
+    void report_failures(result_list const & results);
+
     std::ostream & s;
     bool show_duration;
 };


### PR DESCRIPTION
It was missing for a long time that failed visual test names were not reported to the console. This is practical especially on Travis.

```console
 $ test/visual/run --agg -s 1 -j 24                                                                        
.......................................................................................................................
.......................................................................................................................
...✘✘.............................................................✘...................................................
Visual rendering: 3 failed / 353 passed / 0 overwritten / 0 errors

tiff-nodata-edge-rgba FAILED (76902 different pixels)
    "/tmp/mapnik-visual-images/tiff-nodata-edge-rgba-512-512-1.0-agg.png" (actual)
    "test/data-visual/images/tiff-nodata-edge-rgba-512-512-1.0-agg-reference.png" (reference)
gdal-filter-factor-3-lanczos FAILED (101595 different pixels)
    "/tmp/mapnik-visual-images/gdal-filter-factor-3-lanczos-600-400-1.0-agg.png" (actual)
    "test/data-visual/images/gdal-filter-factor-3-lanczos-600-400-1.0-agg-reference.png" (reference)
tiff-nodata-rgba FAILED (156954 different pixels)
    "/tmp/mapnik-visual-images/tiff-nodata-rgba-512-512-1.0-agg.png" (actual)
    "test/data-visual/images/tiff-nodata-rgba-512-512-1.0-agg-reference.png" (reference)

View failure report at "/tmp/mapnik-visual-images/visual-test-results/index.html"

```