### PR TITLE
[v3.0.x] Add metrics support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -388,6 +388,7 @@ opts.AddVariables(
     # Variables for logging and statistics
     BoolVariable('ENABLE_LOG', 'Enable logging, which is enabled by default when building in *debug*', 'False'),
     BoolVariable('ENABLE_STATS', 'Enable global statistics during map processing', 'False'),
+    BoolVariable('ENABLE_METRICS', 'Enable internal metrics during map processing', 'False'),
     ('DEFAULT_LOG_SEVERITY', 'The default severity of the logger (eg. ' + ', '.join(severities) + ')', 'error'),
 
     # Plugin linking
@@ -1917,6 +1918,10 @@ if not preconfigured:
         if env['ENABLE_STATS']:
             debug_defines.append('-DMAPNIK_STATS')
             ndebug_defines.append('-DMAPNIK_STATS')
+
+        # Enable metrics
+        if env['ENABLE_METRICS']:
+            env.Append(CPPDEFINES = '-DMAPNIK_METRICS')
 
         # Add rdynamic to allow using statics between application and plugins
         # http://stackoverflow.com/questions/8623657/multiple-instances-of-singleton-across-shared-libraries-on-linux

--- a/include/mapnik/feature_style_processor.hpp
+++ b/include/mapnik/feature_style_processor.hpp
@@ -25,11 +25,13 @@
 
 // mapnik
 #include <mapnik/box2d.hpp>
-#include <mapnik/featureset.hpp>
 #include <mapnik/config.hpp>
 #include <mapnik/feature_style_processor_context.hpp>
+#include <mapnik/featureset.hpp>
+#include <mapnik/metrics.hpp>
 
 // stl
+#include <memory>
 #include <set>
 #include <string>
 
@@ -56,6 +58,11 @@ class MAPNIK_DECL feature_style_processor
 public:
     explicit feature_style_processor(Map const& m,
                                      double scale_factor = 1.0);
+#ifdef MAPNIK_METRICS
+    explicit feature_style_processor(Map const& m,
+                                     double scale_factor,
+                                     metrics& metr);
+#endif
 
     /*!
      * \brief apply renderer to all map layers.
@@ -113,7 +120,12 @@ private:
     void render_material(layer_rendering_material const & mat, Processor & p );
 
     Map const& m_;
+
+#ifdef MAPNIK_METRICS
+public:
+    metrics metrics_ = metrics(false);
+#endif
 };
-}
+} //namespace mapnik
 
 #endif // MAPNIK_FEATURE_STYLE_PROCESSOR_HPP

--- a/include/mapnik/grid/grid.hpp
+++ b/include/mapnik/grid/grid.hpp
@@ -24,21 +24,22 @@
 #define MAPNIK_GRID_HPP
 
 // mapnik
-#include <mapnik/config.hpp>
-#include <mapnik/image.hpp>
 #include <mapnik/box2d.hpp>
-#include <mapnik/grid/grid_view.hpp>
-#include <mapnik/global.hpp>
-#include <mapnik/value.hpp>
+#include <mapnik/config.hpp>
 #include <mapnik/feature.hpp>
 #include <mapnik/feature_factory.hpp>
-#include <mapnik/util/conversions.hpp>
+#include <mapnik/global.hpp>
+#include <mapnik/grid/grid_view.hpp>
+#include <mapnik/image.hpp>
+#include <mapnik/metrics.hpp>
 #include <mapnik/safe_cast.hpp>
+#include <mapnik/util/conversions.hpp>
+#include <mapnik/value.hpp>
 
 // stl
+#include <cmath>
 #include <map>
 #include <set>
-#include <cmath>
 #include <string>
 #include <vector>
 
@@ -215,9 +216,15 @@ public:
             }
         }
     }
+
+#ifdef MAPNIK_METRICS
+public:
+    metrics metrics_ = metrics(false);
+#endif
+
 };
 
 using grid = hit_grid<mapnik::value_integer_pixel>;
 
-}
+} //namespace mapnik
 #endif //MAPNIK_GRID_HPP

--- a/include/mapnik/image.hpp
+++ b/include/mapnik/image.hpp
@@ -25,6 +25,7 @@
 
 // mapnik
 #include <mapnik/config.hpp>
+#include <mapnik/metrics.hpp>
 #include <mapnik/pixel_types.hpp>
 
 namespace mapnik {
@@ -39,7 +40,7 @@ struct MAPNIK_DECL buffer
     buffer(buffer const& rhs);
     ~buffer();
     buffer& operator=(buffer rhs);
-    inline bool operator!() const {return (data_ == nullptr)? true : false;}
+    inline bool operator!() const {return (data_ == nullptr);}
     inline unsigned char* data() {return data_;}
     inline unsigned char const* data() const {return data_;}
     inline std::size_t size() const {return size_;}
@@ -61,7 +62,7 @@ private:
     std::size_t height_;
 };
 
-} // end ns detail
+} // namespace detail
 
 template <typename T>
 class image
@@ -80,6 +81,10 @@ private:
     double scaling_;
     bool premultiplied_alpha_;
     bool painted_;
+#ifdef MAPNIK_METRICS
+public:
+    metrics metrics_ = metrics(false);
+#endif
 public:
     image();
     image(int width,
@@ -94,9 +99,12 @@ public:
           bool painted = false);
     image(image<T> const& rhs);
     image(image<T> && rhs) noexcept;
-    image<T>& operator=(image<T> rhs);
+    image<T>& operator=(image<T> const& rhs);
+    image<T>& operator=(image<T>&& rhs) noexcept;
     bool operator==(image<T> const& rhs) const;
     bool operator<(image<T> const& rhs) const;
+
+    ~image() = default;
 
     void swap(image<T> & rhs);
     pixel_type& operator() (std::size_t i, std::size_t j);
@@ -131,6 +139,7 @@ public:
     void painted(bool painted);
     bool painted() const;
     image_dtype get_dtype() const;
+
 };
 
 using image_null = image<null_t>;
@@ -146,6 +155,6 @@ using image_gray64 = image<gray64_t>;
 using image_gray64s = image<gray64s_t>;
 using image_gray64f = image<gray64f_t>;
 
-} // end ns mapnik
+} // namespace mapnik
 
 #endif // MAPNIK_IMAGE_HPP

--- a/include/mapnik/image_any.hpp
+++ b/include/mapnik/image_any.hpp
@@ -72,6 +72,9 @@ struct MAPNIK_DECL image_any : image_base
     image_dtype get_dtype() const;
     void set_offset(double val);
     void set_scaling(double val);
+#ifdef MAPNIK_METRICS
+    metrics&  get_metrics();
+#endif
 };
 
 MAPNIK_DECL image_any create_image_any(int width,
@@ -81,6 +84,6 @@ MAPNIK_DECL image_any create_image_any(int width,
                                        bool premultiplied = false,
                                        bool painted = false);
 
-} // end mapnik ns
+} // namespace mapnik
 
 #endif // MAPNIK_IMAGE_ANY_HPP

--- a/include/mapnik/image_impl.hpp
+++ b/include/mapnik/image_impl.hpp
@@ -99,7 +99,11 @@ image<T>::image(image<T> const& rhs)
       offset_(rhs.offset_),
       scaling_(rhs.scaling_),
       premultiplied_alpha_(rhs.premultiplied_alpha_),
-      painted_(rhs.painted_) {}
+      painted_(rhs.painted_)
+#ifdef MAPNIK_METRICS
+     ,metrics_(rhs.metrics_)
+#endif
+{}
 
 template <typename T>
 image<T>::image(image<T> && rhs) noexcept
@@ -109,14 +113,40 @@ image<T>::image(image<T> && rhs) noexcept
       scaling_(rhs.scaling_),
       premultiplied_alpha_(rhs.premultiplied_alpha_),
       painted_(rhs.painted_)
+#ifdef MAPNIK_METRICS
+     ,metrics_(std::move(rhs.metrics_))
+#endif
 {
     rhs.dimensions_ = { 0, 0 };
 }
 
 template <typename T>
-image<T>& image<T>::operator=(image<T> rhs)
+image<T>& image<T>::operator=(image<T> const &rhs)
 {
-    swap(rhs);
+    dimensions_ = rhs.dimensions_;
+    buffer_ = rhs.buffer_;
+    offset_ = rhs.offset_;
+    scaling_ = rhs.scaling_;
+    premultiplied_alpha_ = rhs.premultiplied_alpha_;
+    painted_ = rhs.painted_;
+#ifdef MAPNIK_METRICS
+    metrics_ = rhs.metrics_;
+#endif
+    return *this;
+}
+
+template <typename T>
+image<T>& image<T>::operator=(image<T>&& rhs) noexcept
+{
+    dimensions_ = std::move(rhs.dimensions_);
+    buffer_ = std::move(rhs.buffer_);
+    offset_ = rhs.offset_;
+    scaling_ = rhs.scaling_;
+    premultiplied_alpha_ = rhs.premultiplied_alpha_;
+    painted_ = rhs.painted_;
+#ifdef MAPNIK_METRICS
+    metrics_ = std::move(rhs.metrics_);
+#endif
     return *this;
 }
 
@@ -141,6 +171,9 @@ void image<T>::swap(image<T> & rhs)
     std::swap(scaling_, rhs.scaling_);
     std::swap(premultiplied_alpha_, rhs.premultiplied_alpha_);
     std::swap(painted_, rhs.painted_);
+#ifdef MAPNIK_METRICS
+    std::swap(metrics_, rhs.metrics_);
+#endif
 }
 
 template <typename T>
@@ -322,5 +355,4 @@ inline image_dtype image<T>::get_dtype()  const
 {
     return dtype;
 }
-
 } // end ns

--- a/include/mapnik/image_null.hpp
+++ b/include/mapnik/image_null.hpp
@@ -69,6 +69,10 @@ public:
     void painted(bool) {}
     bool painted() const { return false; }
     image_dtype get_dtype() const { return dtype; }
+#ifdef MAPNIK_METRICS
+public:
+    metrics metrics_ = metrics(false);
+#endif
 };
 
 } // end ns mapnik

--- a/include/mapnik/metrics.hpp
+++ b/include/mapnik/metrics.hpp
@@ -1,0 +1,182 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_METRICS_HPP
+#define MAPNIK_METRICS_HPP
+
+#ifdef MAPNIK_METRICS
+
+#include <mapnik/config.hpp>
+
+#include <boost/optional/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <chrono>
+#include <memory>
+#include <string>
+
+#ifdef MAPNIK_THREADSAFE
+#include <mutex>
+#endif
+
+namespace mapnik {
+
+enum measurement_t : int_fast8_t
+{
+    UNASSIGNED = 0,
+    TIME_MICROSECONDS,
+    VALUE,
+    CALLS,
+    TOTAL_ENUM_SIZE
+};
+
+struct MAPNIK_DECL measurement
+{
+    measurement() = default;
+    explicit measurement(int64_t value, measurement_t type = measurement_t::UNASSIGNED);
+
+    int64_t value_ = 0;
+    int_fast32_t calls_ = 1;
+    measurement_t type_ = measurement_t::UNASSIGNED;
+};
+
+class metrics;
+
+class MAPNIK_DECL autochrono
+{
+    using steady_clock = std::chrono::steady_clock;
+    using time_units = std::chrono::microseconds;
+
+public:
+    autochrono(metrics* m, std::string name);
+    ~autochrono();
+
+    autochrono() = delete;
+    autochrono(autochrono const &&) = delete;
+    autochrono& operator=(autochrono const &) = delete;
+    autochrono& operator=(autochrono &&) = delete;
+    autochrono(autochrono const &) = delete;
+
+
+private:
+    metrics* metrics_;
+    std::string const name_;
+    steady_clock clock_;
+    steady_clock::time_point start_;
+};
+
+
+class MAPNIK_DECL metrics
+{
+    friend autochrono;
+public:
+    using metrics_tree = boost::property_tree::basic_ptree<std::string,
+                                                           struct measurement>;
+    /* Whether metrics are enabled or not. If disabled any calls to
+     * measure_XXX (add/dec/time) will be ignored */
+    bool enabled_ = false;
+
+    /* Prefix to use when storing metrics under this object. Make sure to finish
+     * it with a '.' to change the hierarchy level of the metrics. For example,
+     * if set to "Render." a new metric "Layer" will be stored as "Render.Layer"
+     */
+    std::string prefix_ = "";
+
+    /**
+     * Default constructor with an empty tree
+     */
+    metrics() = delete;
+    metrics(bool enabled);
+
+    /**
+     * Builds with the same shared tree as the passed object
+     * enabled_ is also copied but independent
+     * The prefix is added to the passed one. So if the previous has "Render.",
+     * and the new one is "Layer.", "Render.Layer." will be used
+     */
+    metrics(metrics const &m, std::string prefix = "");
+
+    /* Move constructor */
+    metrics(metrics const &&m);
+
+    /* Copy assignment operator */
+    metrics& operator=(metrics const &);
+
+    /* Move assignment operator */
+    metrics& operator=(metrics &&);
+
+    ~metrics() = default;
+
+    /**
+     * Sets up a timer to measure an event. The timer will be stopped and saved
+     * when the return value is destroyed / out of scope
+     * @param metric_name - Name to use to store the metric
+     * @return Smart pointer to hold the reference to the timer
+     */
+    inline std::unique_ptr<autochrono> measure_time(std::string const& name)
+    {
+        if (!enabled_) return nullptr;
+        return measure_time_impl(name);
+    }
+
+    /**
+     * Increment the value of a metric
+     * @param name - Name of the metric
+     * @param value - Value to increment. Default = 1
+     * @param type - Type of the stored metric. Default: VALUE
+     */
+    inline void measure_add(std::string const& name, int64_t value = 1,
+                            measurement_t type = measurement_t::VALUE)
+    {
+        if (!enabled_) return;
+        measure_add_impl(name, value, type);
+    }
+
+    /**
+     * Find a metric by name
+     * @param name - Name of the metric
+     * @param ignore_prefix - Whether to ignore stored prefix in the search
+     * @return optional value with the measurement
+     */
+    boost::optional<measurement &> find(std::string const& name,
+                                        bool ignore_prefix = false);
+
+    /**
+     * Generates a string with the metrics (for the full tree)
+     * @return std::string in JSON style
+     */
+    std::string to_string();
+
+private:
+    std::unique_ptr<autochrono> measure_time_impl(std::string const& name);
+    void measure_add_impl(std::string const& name, int64_t value, measurement_t type);
+
+    std::shared_ptr<metrics_tree> storage_{new metrics_tree};
+#ifdef MAPNIK_THREADSAFE
+    std::shared_ptr<std::mutex> lock_ {new std::mutex};
+#endif
+};
+
+} //namespace mapnik
+
+#endif /* MAPNIK_METRICS */
+
+#endif /* MAPNIK_METRICS_HPP */

--- a/src/agg/agg_renderer.cpp
+++ b/src/agg/agg_renderer.cpp
@@ -70,7 +70,11 @@ namespace mapnik
 
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, T0 & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
+#ifdef MAPNIK_METRICS
+    : feature_style_processor<agg_renderer>(m, scale_factor, pixmap.metrics_),
+#else
     : feature_style_processor<agg_renderer>(m, scale_factor),
+#endif
       pixmap_(pixmap),
       internal_buffer_(),
       current_buffer_(&pixmap),
@@ -85,7 +89,11 @@ agg_renderer<T0,T1>::agg_renderer(Map const& m, T0 & pixmap, double scale_factor
 
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, request const& req, attributes const& vars, T0 & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
+#ifdef MAPNIK_METRICS
+    : feature_style_processor<agg_renderer>(m, scale_factor, pixmap.metrics_),
+#else
     : feature_style_processor<agg_renderer>(m, scale_factor),
+#endif
       pixmap_(pixmap),
       internal_buffer_(),
       current_buffer_(&pixmap),
@@ -101,7 +109,11 @@ agg_renderer<T0,T1>::agg_renderer(Map const& m, request const& req, attributes c
 template <typename T0, typename T1>
 agg_renderer<T0,T1>::agg_renderer(Map const& m, T0 & pixmap, std::shared_ptr<T1> detector,
                               double scale_factor, unsigned offset_x, unsigned offset_y)
+#ifdef MAPNIK_METRICS
+    : feature_style_processor<agg_renderer>(m, scale_factor, pixmap.metrics_),
+#else
     : feature_style_processor<agg_renderer>(m, scale_factor),
+#endif
       pixmap_(pixmap),
       internal_buffer_(),
       current_buffer_(&pixmap),

--- a/src/build.py
+++ b/src/build.py
@@ -264,6 +264,7 @@ source = Split(
     renderer_common/render_thunk_extractor.cpp
     math.cpp
     value.cpp
+    metrics.cpp
     """
     )
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -65,6 +65,9 @@ hit_grid<T>::hit_grid(hit_grid<T> const& rhs)
       f_keys_(rhs.f_keys_),
       features_(rhs.features_),
       ctx_(rhs.ctx_)
+#ifdef MAPNIK_METRICS
+     ,metrics_(rhs.metrics_)
+#endif
 {
     f_keys_[base_mask] = "";
     data_.set(base_mask);
@@ -80,6 +83,9 @@ void hit_grid<T>::clear()
     f_keys_[base_mask] = "";
     data_.set(base_mask);
     ctx_ = std::make_shared<mapnik::context_type>();
+#ifdef MAPNIK_METRICS
+    metrics_ = metrics(false);
+#endif
 }
 
 template <typename T>

--- a/src/grid/grid_renderer.cpp
+++ b/src/grid/grid_renderer.cpp
@@ -62,7 +62,11 @@ namespace mapnik
 
 template <typename T>
 grid_renderer<T>::grid_renderer(Map const& m, T & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
+#ifdef MAPNIK_METRICS
+    : feature_style_processor<grid_renderer>(m, scale_factor, pixmap.metrics_),
+#else
     : feature_style_processor<grid_renderer>(m, scale_factor),
+#endif
       pixmap_(pixmap),
       ras_ptr(new grid_rasterizer),
       common_(m, attributes(), offset_x, offset_y, m.width(), m.height(), scale_factor)
@@ -72,7 +76,11 @@ grid_renderer<T>::grid_renderer(Map const& m, T & pixmap, double scale_factor, u
 
 template <typename T>
 grid_renderer<T>::grid_renderer(Map const& m, request const& req, attributes const& vars, T & pixmap, double scale_factor, unsigned offset_x, unsigned offset_y)
+#ifdef MAPNIK_METRICS
+    : feature_style_processor<grid_renderer>(m, scale_factor, pixmap.metrics_),
+#else
     : feature_style_processor<grid_renderer>(m, scale_factor),
+#endif
       pixmap_(pixmap),
       ras_ptr(new grid_rasterizer),
       common_(m, req, vars, offset_x, offset_y, req.width(), req.height(), scale_factor)

--- a/src/image_any.cpp
+++ b/src/image_any.cpp
@@ -151,6 +151,18 @@ private:
     double val_;
 };
 
+#ifdef MAPNIK_METRICS
+struct get_metrics_visitor
+{
+    template <typename T>
+    metrics& operator() (T& data)
+    {
+        return data.metrics_;
+    }
+};
+#endif
+
+
 } // namespace detail
 
 MAPNIK_DECL image_any::image_any(int width,
@@ -225,6 +237,13 @@ MAPNIK_DECL void image_any::set_scaling(double val)
 {
     util::apply_visitor(detail::set_scaling_visitor(val),*this);
 }
+
+#ifdef MAPNIK_METRICS
+MAPNIK_DECL metrics& image_any::get_metrics()
+{
+    return util::apply_visitor(detail::get_metrics_visitor(),*this);
+}
+#endif
 
 
 MAPNIK_DECL image_any create_image_any(int width,

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -1,0 +1,195 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifdef MAPNIK_METRICS
+
+#include <mapnik/metrics.hpp>
+
+#include <mapnik/make_unique.hpp>
+
+#include <boost/next_prior.hpp>
+#include <sstream>
+#include <utility>
+
+namespace mapnik {
+
+const std::string measurement_str[TOTAL_ENUM_SIZE] =
+{
+    "UNKNOWN",
+    "Time (us)",
+    "Value",
+    "Calls"
+};
+
+measurement::measurement(int64_t value, measurement_t type)
+    : value_(value),
+      type_(type)
+{
+}
+
+autochrono::autochrono(metrics* m, std::string name)
+    : metrics_(m),
+      name_(std::move(name))
+{
+    start_ = clock_.now();
+}
+
+autochrono::~autochrono()
+{
+    auto ns = std::chrono::duration_cast<time_units>(clock_.now() - start_);
+    metrics_->measure_add(name_, ns.count(), measurement_t::TIME_MICROSECONDS);
+}
+
+metrics::metrics(bool enabled)
+    : enabled_(enabled)
+{
+}
+
+metrics::metrics(metrics const &m, std::string prefix)
+    : enabled_(m.enabled_),
+      prefix_(m.prefix_ + prefix),
+      storage_(m.storage_)
+#ifdef MAPNIK_THREADSAFE
+     ,lock_(m.lock_)
+#endif
+{
+}
+
+/* Move constructor */
+metrics::metrics(metrics const &&m)
+{
+    *this = m;
+}
+
+/* Copy assignment operator */
+metrics& metrics::operator=(metrics const& m)
+{
+    enabled_ = m.enabled_;
+    prefix_ = m.prefix_;
+    storage_ = m.storage_;
+    lock_ = m.lock_;
+    return *this;
+}
+
+/* Move assignment operator */
+metrics& metrics::operator=(metrics&& m)
+{
+    return *this = m;
+}
+
+std::unique_ptr<autochrono> metrics::measure_time_impl(const std::string& name)
+{
+    return std::make_unique<autochrono>(this, name);
+}
+
+void metrics::measure_add_impl(std::string const& name, int64_t value, measurement_t type)
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(*this->lock_);
+#endif
+    auto child = storage_->get_child_optional(prefix_ + name);
+    if (!child)
+    {
+        storage_->put(prefix_ + name, measurement(value, type));
+    }
+    else
+    {
+        auto &measure = child->data();
+        measure.value_ += value;
+        if (measure.type_ == measurement_t::UNASSIGNED)
+        {
+            measure.type_ = type;
+        }
+        else
+        {
+            measure.calls_++;
+        }
+    }
+}
+
+
+boost::optional<measurement &> metrics::find(std::string const& name, bool ignore_prefix)
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(*this->lock_);
+#endif
+    auto m = storage_->get_child_optional(ignore_prefix ? name : prefix_ + name);
+    return (m ? m->data() : boost::optional<measurement &>());
+}
+
+/**
+ * Recursively generate a JSON string from a metrics tree.
+ * It doesn't use boost::property_tree::json_parser because we can have
+ * nodes with data and children
+ * @param buf
+ * @param t
+ */
+void to_string_helper(std::ostringstream &buf, metrics::metrics_tree t)
+{
+    measurement &m = t.data();
+    if (t.empty() && m.type_ == measurement_t::VALUE)
+    {
+        buf << m.value_;
+        return;
+    }
+
+    buf << "{";
+    if (m.type_ != measurement_t::UNASSIGNED)
+    {
+        buf << R"(")" << measurement_str[m.type_] << R"(":)" << m.value_;
+        if (m.type_ == measurement_t::TIME_MICROSECONDS)
+        {
+            buf << R"(,")" << measurement_str[measurement_t::CALLS];
+            buf << R"(":)" << m.calls_;
+        }
+        if (!t.empty())
+        {
+            buf << ",";
+        }
+    }
+
+    for (auto it = t.begin(); it != t.end(); it++)
+    {
+        buf << R"(")" << it->first << R"(":)";
+        to_string_helper(buf, it->second);
+        if (boost::next(it) != t.end())
+        {
+            buf << ",";
+        }
+    }
+    buf << "}";
+}
+
+std::string metrics::to_string()
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(*this->lock_);
+#endif
+    std::ostringstream buf;
+
+    to_string_helper(buf, *storage_);
+    return buf.str();
+}
+
+} //namespace mapnik
+
+#endif //MAPNIK_METRICS

--- a/test/unit/imaging/image.cpp
+++ b/test/unit/imaging/image.cpp
@@ -142,6 +142,10 @@ SECTION("test gray16") {
     CHECK(im2(0,1) == 514);
     CHECK(im2(1,1) == 50);
 
+#ifdef MAPNIK_METRICS
+    CHECK(im.metrics_.enabled_ == false);
+#endif
+
 } // END SECTION
 
 SECTION("image_null")
@@ -188,6 +192,10 @@ SECTION("image_null")
     CHECK(e1 == nullptr);
     CHECK(e2 == nullptr);
 
+#ifdef MAPNIK_METRICS
+    CHECK(im_null.metrics_.enabled_ == false);
+#endif
+
 } // END SECTION
 
 SECTION("image any")
@@ -216,6 +224,10 @@ SECTION("image any")
     im_any.set_scaling(2.1);
     CHECK(im_any.get_scaling() == 2.1);
     CHECK_FALSE(im_any.painted());
+
+#ifdef MAPNIK_METRICS
+    CHECK(im_any.get_metrics().enabled_ == false);
+#endif
 
 } // END SECTION
 
@@ -330,12 +342,24 @@ SECTION("Image copy/move")
         pixel = mapnik::color(0,255,0).rgba(); // green
     }
 
+#ifdef MAPNIK_METRICS
+    im.metrics_.enabled_ = true;
+    im.metrics_.measure_add("check");
+    REQUIRE(im.metrics_.find("check"));
+#endif
+
     // move
     mapnik::image_rgba8 im2(std::move(im));
     CHECK (im.data() == nullptr);
     CHECK (im.bytes() == nullptr);
     CHECK (im.width() == 0);
     CHECK (im.height() == 0);
+
+#ifdef MAPNIK_METRICS
+    CHECK(im2.metrics_.enabled_ == true);
+    CHECK(im2.metrics_.find("check"));
+#endif
+
     for (auto const& pixel : im2)
     {
         // expect `green`
@@ -361,6 +385,27 @@ SECTION("Image copy/move")
         // expect `red`
         CHECK( pixel == mapnik::color(255,0,0).rgba());
     }
+
+#ifdef MAPNIK_METRICS
+    CHECK(im3.metrics_.enabled_ == true);
+    CHECK(im3.metrics_.find("check"));
+#endif
+
+    mapnik::image_rgba8 im4;
+    im4 = im2;
+
+    for (auto & pixel : im4)
+    {
+        CHECK( pixel == mapnik::color(255,0,0).rgba());
+    }
+
+#ifdef MAPNIK_METRICS
+    CHECK(im3.metrics_.enabled_ == true);
+    CHECK(im3.metrics_.find("check"));
+    CHECK(im4.metrics_.enabled_ == true);
+    CHECK(im4.metrics_.find("check"));
+#endif
+
 }
 
 SECTION("image::swap")
@@ -375,6 +420,12 @@ SECTION("image::swap")
     im2.set(blue);
     im3.set(orange);
 
+#ifdef MAPNIK_METRICS
+    im2.metrics_.enabled_ = true;
+    im2.metrics_.measure_add("check");
+    REQUIRE(im2.metrics_.find("check"));
+#endif
+
     // swap two non-empty images
     CHECK_NOTHROW(im2.swap(im3));
     CHECK(im2(0, 0) == orange);
@@ -387,6 +438,12 @@ SECTION("image::swap")
     {
         CHECK(im(0, 0) == blue);
     }
+#ifdef MAPNIK_METRICS
+    CHECK(im.metrics_.enabled_ == true);
+    CHECK(im.metrics_.find("check"));
+    CHECK(im3.metrics_.enabled_ == false);
+    CHECK(!im3.metrics_.find("check"));
+#endif
 }
 
 } // END TEST CASE

--- a/test/unit/metrics/metrics_test.cpp
+++ b/test/unit/metrics/metrics_test.cpp
@@ -1,0 +1,223 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2017 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifdef MAPNIK_METRICS
+#include "catch.hpp"
+
+#include <mapnik/metrics.hpp>
+
+using namespace mapnik;
+
+TEST_CASE("metrics")
+{
+    SECTION("Construtors and assigments")
+    {
+        metrics m(false);
+        CHECK(m.enabled_ == false);
+        CHECK(m.prefix_ == "");
+        CHECK(m.to_string() == "{}");
+        m.enabled_ = true;
+        m.measure_add("test");
+
+        metrics m2(m);
+        CHECK(m.to_string() == m2.to_string());
+        m.measure_add("new test", 25);
+        CHECK(m.to_string() == m2.to_string());
+        m2.measure_add("other test", 100, measurement_t::TIME_MICROSECONDS);
+        CHECK(m.to_string() == m2.to_string());
+
+        metrics m3(m, "prefix.");
+        CHECK(m.to_string() == m3.to_string());
+        m3.measure_add("test3", 50);
+        CHECK(m.to_string() == m3.to_string());
+
+        metrics m4(m3, "second.");
+        CHECK(m4.prefix_ == "prefix.second.");
+    }
+
+    SECTION("Find")
+    {
+        metrics m(true);
+        m.measure_add("exists", 10);
+        m.measure_add("prefix.sub");
+
+        CHECK(m.find("exists"));
+        CHECK(!m.find("doesn't exists"));
+
+        CHECK(m.find("prefix.sub"));
+        CHECK(!m.find("sub"));
+        m.prefix_ = "prefix.";
+        CHECK(!m.find("prefix.sub"));
+        CHECK(m.find("sub"));
+
+        CHECK(m.find("prefix.sub", true));
+        CHECK(!m.find("sub", true));
+    }
+
+
+    SECTION("Additions")
+    {
+        metrics m(true);
+        m.measure_add("test");
+        auto it = m.find("test");
+        REQUIRE(it);
+        CHECK(it->value_ == 1);
+        CHECK(it->calls_ == 1);
+        CHECK(it->type_ == measurement_t::VALUE);
+
+        m.measure_add("test");
+        CHECK(it->value_ == 2);
+        CHECK(it->calls_ == 2);
+
+        m.measure_add("test", 20);
+        CHECK(it->value_ == 22);
+        CHECK(it->calls_ == 3);
+
+        m.enabled_ = false;
+        m.measure_add("test");
+        CHECK(it->value_ == 22);
+        CHECK(it->calls_ == 3);
+
+        m.measure_add("test_disabled");
+        CHECK(!m.find("test_disabled"));
+    }
+
+    SECTION("Time")
+    {
+        metrics m(true);
+        {
+            auto t = m.measure_time("new_measurement");
+            usleep(1000); // microseconds
+        }
+        auto it = m.find("new_measurement");
+        REQUIRE(it);
+        CHECK(it->value_ > 1000);
+    }
+
+    SECTION("Time: Measurements with the same name are added")
+    {
+        static const int times = 8;
+        metrics m(true);
+        for (uint i = 0; i < times; i++)
+        {
+            auto time_metric = m.measure_time("same_measurement");
+            auto time_metric2 = m.measure_time("other measurement");
+            usleep(100); // microseconds
+        }
+        auto it = m.find("same_measurement");
+        REQUIRE(it);
+        CHECK(it->value_ > 100 * times);
+        CHECK(it->calls_ == times);
+    }
+
+    SECTION("Copy and move")
+    {
+        metrics m(true);
+        m.prefix_ = "m1.";
+        m.measure_add("measurement", 100, measurement_t::TIME_MICROSECONDS);
+
+        metrics m2 = m;
+        CHECK(m2.enabled_ == true);
+        CHECK(m.to_string() == m2.to_string());
+
+        metrics m3(true);
+        m3.measure_add("other", 15);
+        m3 = m;
+        CHECK(m3.enabled_ == true);
+        CHECK(m.to_string() == m3.to_string());
+
+        metrics m4(std::move(m));
+        CHECK(m4.enabled_ == true);
+        CHECK(m4.to_string() == m3.to_string());
+    }
+
+    SECTION("Metrics hierarchy")
+    {
+        metrics m(true);
+        m.measure_add("metric.test.first", 10);
+
+        auto it = m.find("metric");
+        REQUIRE(it);
+        CHECK(it->value_ == 0);
+        CHECK(it->type_ == measurement_t::UNASSIGNED);
+
+        it = m.find("metric.test");
+        REQUIRE(it);
+        CHECK(it->value_ == 0);
+        CHECK(it->type_ == measurement_t::UNASSIGNED);
+
+        it = m.find("metric.not_found");
+        CHECK(!it);
+
+        it = m.find("metric.test.first");
+        REQUIRE(it);
+        CHECK(it->value_ == 10);
+        CHECK(it->type_ == measurement_t::VALUE);
+        CHECK(it->calls_ == 1);
+
+        m.measure_add("metric.test", 100);
+        it = m.find("metric.test");
+        REQUIRE(it);
+        CHECK(it->value_ == 100);
+        CHECK(it->type_ == measurement_t::VALUE);
+        CHECK(it->calls_ == 1);
+
+        metrics sub(m, "metric.test.");
+        sub.measure_add("first", 50);
+        sub.measure_add("second", 100, measurement_t::TIME_MICROSECONDS);
+        CHECK(m.find("metric.test.first")->value_ == 60); //10 + 50
+        it = m.find("metric.test.second");
+        REQUIRE(it);
+        CHECK(it->value_ == 100);
+        CHECK(it->type_ == measurement_t::TIME_MICROSECONDS);
+    }
+
+    SECTION("to_string")
+    {
+        metrics m(true);
+        CHECK(m.to_string() == "{}");
+        m.measure_add("new_metric", 10);
+        CHECK(m.to_string() == R"^({"new_metric":10})^");
+        m.measure_add("new_metric", 15);
+        CHECK(m.to_string() == R"^({"new_metric":25})^");
+
+        metrics m2(true);
+        m2.measure_add("metric.render.vortex", 10);
+        CHECK(m2.to_string() == R"^({"metric":{"render":{"vortex":10}}})^");
+
+        m2.measure_add("metric.render", 100);
+        CHECK(m2.to_string() == R"^({"metric":{"render":{"Value":100,"vortex":10}}})^");
+
+        metrics m3(true);
+        m3.measure_add("metric.a", 10);
+        m3.measure_add("metric.b", 20);
+        CHECK(m3.to_string() == R"^({"metric":{"a":10,"b":20}})^");
+
+        metrics m4(true);
+        m4.measure_add("time metric", 100, measurement_t::TIME_MICROSECONDS);
+        m4.measure_add("time metric", 150, measurement_t::TIME_MICROSECONDS);
+        CHECK(m4.to_string() == R"^({"time metric":{"Time (us)":250,"Calls":2}})^");
+    }
+
+} //Test case
+
+#endif /* MAPNIK_METRICS */


### PR DESCRIPTION
This is an attempt to improve the initial @rafatower 's PR to introduce an internal metrics system in Mapnik (#3705).

Essentially, this adds a new class `metrics` to support a tree-like structure with metrics generated during a request.
Currently metrics are only added in `feature_style_processor.hpp` as it's the common path for grids and images but the idea is to incrementally add them in more places to help us diagnose slow paths.

Initial tests (not in full depth) hasn't shown any kind of performance impact in tile generation times (not enabled at compilation vs enabled and requested vs enabled and not requested. All 3 show equivalent times), but fow now I've set up the metrics as disabled by default. Use `ENABLE_METRICS=True` to enable them in the configure call.

As I was using node-mapnik and it wasn't compatible with current master I've done all the development and testing with the v3.0.15 tag, but the MR over master should be almost automatic (I think right now I'd complain about conflicts with some #includes). Once this is accepted MRs would come to node-mapnik and tilelive-mapnik:
https://github.com/Algunenano/node-mapnik/commits/performance_stats
https://github.com/Algunenano/tilelive-mapnik/commits/performance_stats

When the full package is in action it allow us to extract information like this though Windshaft-CartoDB:
```json
{  
   "authorizedByAPIKey":1,
   "authorize":1,
   "res":5554,
   "getTileOrGrid":5554,
   "render-png":5554,
   "Mapnik":{  
      "Time (us)":5545412,
      "Calls":1,
      "Setup":{  
         "Time (us)":407477,
         "Calls":1,
         "Datasource: Get Features":{  
            "Time (us)":407449,
            "Calls":1
         }
      },
      "Render":{  
         "Time (us)":5137082,
         "Calls":1,
         "Style":{  
            "Time (us)":5137077,
            "Calls":1,
            "features":478587
         }
      }
   },
   "tiles in metatile":1,
   "total":5556
}
```
which now allows to start getting stats about, for example, %time in database vs %time rendering depending on the number of features retrieved.

Please have a look and let me know if I should modified anything or if you prefer the PR against Master directly.