### PR TITLE
visual tests: allow to ignore particular renderer

### DIFF
--- a/test/visual/config.hpp
+++ b/test/visual/config.hpp
@@ -25,6 +25,7 @@
 
 // stl
 #include <vector>
+#include <set>
 #include <string>
 #include <chrono>
 
@@ -50,13 +51,15 @@ struct config
                scales({ 1.0, 2.0 }),
                sizes({ { 500, 100 } }),
                tiles({ { 1, 1 } }),
-               bbox() { }
+               bbox(),
+               ignored_renderers() { }
 
     bool status;
     std::vector<double> scales;
     std::vector<map_size> sizes;
     std::vector<map_size> tiles;
     mapnik::box2d<double> bbox;
+    std::set<std::string> ignored_renderers;
 };
 
 enum result_state : std::uint8_t

--- a/test/visual/config.hpp
+++ b/test/visual/config.hpp
@@ -31,6 +31,8 @@
 // boost
 #include <boost/filesystem.hpp>
 
+#include <mapnik/geometry/box2d.hpp>
+
 namespace visual_tests
 {
 
@@ -47,12 +49,14 @@ struct config
     config() : status(true),
                scales({ 1.0, 2.0 }),
                sizes({ { 500, 100 } }),
-               tiles({ { 1, 1 } }) { }
+               tiles({ { 1, 1 } }),
+               bbox() { }
 
     bool status;
     std::vector<double> scales;
     std::vector<map_size> sizes;
     std::vector<map_size> tiles;
+    mapnik::box2d<double> bbox;
 };
 
 enum result_state : std::uint8_t

--- a/test/visual/runner.hpp
+++ b/test/visual/runner.hpp
@@ -57,6 +57,7 @@ private:
     result_list test_one(path_type const & style_path,
                          report_type & report,
                          std::atomic<std::size_t> & fail_limit) const;
+    void parse_params(mapnik::parameters const & params, config & cfg) const;
 
     const path_type styles_dir_;
     const config defaults_;


### PR DESCRIPTION
Renderer can be disabled in the style this way:

```xml
<Parameters>
    <Parameter name="cairo">off</Parameter>
</Parameters>
```

Refs https://github.com/mapnik/mapnik/pull/3758#issuecomment-329164057. 