### PR TITLE
Add support for scons 3.0.0.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -146,15 +146,15 @@ def color_print(color,text,newline=True):
     # 4 - blue
     text = "\033[9%sm%s\033[0m" % (color,text)
     if not newline:
-        print text,
+        print(text,)
     else:
-        print text
+        print(text)
 
 def regular_print(color,text,newline=True):
     if not newline:
-        print text,
+        print(text,)
     else:
-        print text
+        print(text)
 
 def call(cmd, silent=False):
     stdin, stderr = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE).communicate()
@@ -510,7 +510,7 @@ elif HELP_REQUESTED:
 # https://github.com/mapnik/mapnik/issues/2112
 if not os.path.exists(SCONS_LOCAL_LOG) and not os.path.exists(SCONS_CONFIGURE_CACHE) \
   and ('-c' in command_line_args or '--clean' in command_line_args):
-    print 'all good: nothing to clean, but you might want to run "make distclean"'
+    print('all good: nothing to clean, but you might want to run "make distclean"')
     Exit(0)
 
 # initially populate environment with defaults and any possible custom arguments
@@ -535,7 +535,7 @@ if not force_configure:
 # rebuilds, e.g. for folks following trunk
 for opt in pickle_store:
     if not opt in env:
-        #print 'missing opt', opt
+        #print('missing opt', opt)
         preconfigured = False
 
 # if custom arguments are supplied make sure to accept them
@@ -623,7 +623,7 @@ def parse_config(context, config, checks='--libs --cflags'):
             parsed = True
         except OSError, e:
             ret = False
-            print ' (xml2-config not found!)'
+            print(' (xml2-config not found!)')
     if not parsed:
         if config in ('GDAL_CONFIG'):
             # optional deps...
@@ -659,7 +659,7 @@ def get_pkg_lib(context, config, lib):
                 libname = 'gdal'
         except Exception, e:
             ret = False
-            print ' unable to determine library name:'# %s' % str(e)
+            print(' unable to determine library name:\'# %s' % str(e))
             return None
     context.Result( libname )
     return libname
@@ -1236,7 +1236,7 @@ if not preconfigured:
                     opts.files.append(conf)
                     color_print(4,"SCons CONFIG found: '%s', variables will be inherited..." % conf)
                     optfile = file(conf)
-                    #print optfile.read().replace("\n", " ").replace("'","").replace(" = ","=")
+                    #print(optfile.read().replace("\n", " ").replace("'","").replace(" = ","="))
                     optfile.close()
 
                 elif not conf == SCONS_LOCAL_CONFIG:
@@ -1792,7 +1792,7 @@ if not preconfigured:
                 env['HAS_CAIRO'] = False
                 env['SKIPPED_DEPS'].append('cairo')
             else:
-                print 'Checking for cairo lib and include paths... ',
+                print('Checking for cairo lib and include paths... ',)
                 cmd = 'pkg-config --libs --cflags cairo'
                 if env['RUNTIME_LINK'] == 'static':
                     cmd += ' --static'
@@ -1809,7 +1809,7 @@ if not preconfigured:
                         if not inc in env['CPPPATH']:
                             env["CAIRO_CPPPATHS"].append(inc)
                     env['HAS_CAIRO'] = True
-                    print 'yes'
+                    print('yes')
                 except OSError,e:
                     color_print(1,'no')
                     env['SKIPPED_DEPS'].append('cairo')

--- a/plugins/input/csv/build.py
+++ b/plugins/input/csv/build.py
@@ -29,7 +29,7 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
         can_build = True
 
 if not can_build:
-    print 'WARNING: skipping building the optional CSV datasource plugin which requires boost >= 1.56'
+    print('WARNING: skipping building the optional CSV datasource plugin which requires boost >= 1.56')
 else:
     Import ('plugin_base')
 

--- a/plugins/input/geojson/build.py
+++ b/plugins/input/geojson/build.py
@@ -29,7 +29,7 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
         can_build = True
 
 if not can_build:
-    print 'WARNING: skipping building the optional geojson datasource plugin which requires boost >= 1.56'
+    print('WARNING: skipping building the optional geojson datasource plugin which requires boost >= 1.56')
 else:
 
     Import ('plugin_base')

--- a/plugins/input/topojson/build.py
+++ b/plugins/input/topojson/build.py
@@ -29,7 +29,7 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
         can_build = True
 
 if not can_build:
-    print 'WARNING: skipping building the optional topojson datasource plugin which requires boost >= 1.56'
+    print('WARNING: skipping building the optional topojson datasource plugin which requires boost >= 1.56')
 else:
     Import ('plugin_base')
 

--- a/src/build.py
+++ b/src/build.py
@@ -35,7 +35,7 @@ def call(cmd, silent=True):
     if not stderr:
         return stdin.strip()
     elif not silent:
-        print stderr
+        print(stderr)
 
 def ldconfig(*args,**kwargs):
     call('ldconfig')

--- a/utils/mapnik-config/build.py
+++ b/utils/mapnik-config/build.py
@@ -43,7 +43,7 @@ def GetMapnikLibVersion():
     return version_string
 
 if (GetMapnikLibVersion() != config_env['MAPNIK_VERSION_STRING']):
-    print 'Error: version.hpp mismatch (%s) to cached value (%s): please reconfigure mapnik' % (GetMapnikLibVersion(),config_env['MAPNIK_VERSION_STRING'])
+    print('Error: version.hpp mismatch (%s) to cached value (%s): please reconfigure mapnik' % (GetMapnikLibVersion(),config_env['MAPNIK_VERSION_STRING']))
     Exit(1)
 
 config_variables = '''#!/usr/bin/env bash


### PR DESCRIPTION
Requires print function syntax as documented in the [release notes](http://scons.org/RELEASE.txt):
>        - Any print statements must now use python 3 syntax of "print()"

The mapnik 3.0.15 rebuild for GDAL 2.2.2 in Debian failed because scons was recently updated to 3.0.0 in Debian unstable:
```
scons: Reading SConscript files ...
  File "/<<BUILDDIR>>/mapnik-3.0.15+ds/build-python/SConstruct", line 145

    print text,

             ^

SyntaxError: invalid syntax

```
