### PR TITLE
Fix memory leak when color font used

### DIFF
--- a/src/text/renderer.cpp
+++ b/src/text/renderer.cpp
@@ -220,11 +220,7 @@ void agg_text_renderer<T>::render(glyph_positions const& pos)
                 if (!error)
                 {
                     FT_BitmapGlyph bit = reinterpret_cast<FT_BitmapGlyph>(g);
-                    if (bit->bitmap.pixel_mode == FT_PIXEL_MODE_BGRA)
-                    {
-                        continue;
-                    }
-                    else
+                    if (bit->bitmap.pixel_mode != FT_PIXEL_MODE_BGRA)
                     {
                         composite_bitmap(pixmap_,
                                          &bit->bitmap,


### PR DESCRIPTION
The `continue` prevented `FT_Done_Glyph()` from being called.

I was thinking about using `unique_ptr` which would also ensure deallocation in case of exception. Please let me know if it is preferred.