### PR TITLE
Remove -Wc++14-extensions flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1942,7 +1942,7 @@ if not preconfigured:
         common_cxx_flags = '-fvisibility=hidden -fvisibility-inlines-hidden -Wall %s %s -ftemplate-depth-300 -Wsign-compare ' % (env['WARNING_CXXFLAGS'], pthread)
 
         if 'clang++' in env['CXX']:
-            common_cxx_flags += ' -Wno-unsequenced  -Wtautological-compare -Wheader-hygiene -Wc++14-extensions '
+            common_cxx_flags += ' -Wno-unsequenced  -Wtautological-compare -Wheader-hygiene '
         if env['DEBUG']:
             env.Append(CXXFLAGS = common_cxx_flags + '-O0')
         else:


### PR DESCRIPTION
This `-Wc++14-extensions` is not supported by `g++-6`. This branch is to test if it is actually needed. I can see it was added in 064b99168.