### PR TITLE
Glibcxx fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,9 @@ script:
  # (and might work) for the next build
  - DURATION=2400
  - scripts/travis-command-wrapper.py -s "date" -i 120 --deadline=$(( $(date +%s) + ${DURATION} )) make
+ # dump glibcxx symbols >= 3.4.20 (if this returns output
+ # then it means the binaries will not run on ubuntu trusty without upgrading libstdc++)
+ - nm src/libmapnik* | grep "GLIBCXX_3.4.2[0-9]" || true
  - RESULT=0
  - make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang"
-      env: JOBS=8 CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9" TRIGGER=true
+      env: JOBS=8 CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9" ENABLE_GLIBC_WORKAROUND=True TRIGGER=true
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
@@ -98,7 +98,7 @@ before_script:
 
 script:
  - export SCONSFLAGS='--debug=time'
- - configure BENCHMARK=${BENCH}
+ - configure BENCHMARK=${BENCH} ENABLE_GLIBC_WORKAROUND=${ENABLE_GLIBC_WORKAROUND:-False}
  - cat config.log
  # we limit the `make` to 40 min
  # to ensure that slow builds still upload their

--- a/SConstruct
+++ b/SConstruct
@@ -309,6 +309,7 @@ opts.AddVariables(
     BoolVariable('USE_CONFIG', "Use SCons user '%s' file (will also write variables after successful configuration)", 'True'),
     BoolVariable('NO_ATEXIT', 'Will prevent Singletons from being deleted atexit of main thread', 'False'),
     BoolVariable('NO_DLCLOSE', 'Will prevent plugins from being unloaded', 'False'),
+    BoolVariable('ENABLE_GLIBC_WORKAROUND', "Workaround known GLIBC symbol exports to allow building against libstdc++-4.8 without binaries needing throw_out_of_range_fmt", 'False'),
     # http://www.scons.org/wiki/GoFastButton
     # http://stackoverflow.com/questions/1318863/how-to-optimize-an-scons-script
     BoolVariable('FAST', "Make SCons faster at the cost of less precise dependency tracking", 'False'),
@@ -1878,6 +1879,9 @@ if not preconfigured:
 
         if env['NO_DLCLOSE'] or env['COVERAGE']:
             env.Append(CPPDEFINES = '-DMAPNIK_NO_DLCLOSE')
+
+        if env['ENABLE_GLIBC_WORKAROUND']:
+            env.Append(CPPDEFINES = '-DMAPNIK_ENABLE_GLIBC_WORKAROUND')
 
         # Mac OSX (Darwin) special settings
         if env['PLATFORM'] == 'Darwin':

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,7 @@ todo
 - shrink icu data
 '
 
-MASON_VERSION="v0.11.1"
+MASON_VERSION="7026e94"
 
 function setup_mason() {
     if [[ ! -d ./.mason ]]; then
@@ -45,6 +45,7 @@ function install() {
 }
 
 ICU_VERSION="57.1"
+BOOST_VERSION="1.65.1"
 
 function install_mason_deps() {
     install ccache 3.3.1
@@ -61,15 +62,15 @@ function install_mason_deps() {
     install cairo 1.14.8 libcairo
     install webp 0.6.0 libwebp
     install libgdal 2.1.3 libgdal
-    install boost 1.63.0
-    install boost_libsystem 1.63.0
-    install boost_libfilesystem 1.63.0
-    install boost_libprogram_options 1.63.0
-    install boost_libregex_icu57 1.63.0
+    install boost ${BOOST_VERSION}
+    install boost_libsystem ${BOOST_VERSION}
+    install boost_libfilesystem ${BOOST_VERSION}
+    install boost_libprogram_options ${BOOST_VERSION}
+    install boost_libregex_icu57 ${BOOST_VERSION}
     # technically boost thread and python are not a core dep, but installing
     # here by default helps make python-mapnik builds easier
-    install boost_libthread 1.63.0
-    install boost_libpython 1.63.0
+    install boost_libthread ${BOOST_VERSION}
+    install boost_libpython ${BOOST_VERSION}
     install freetype 2.7.1 libfreetype
     install harfbuzz 1.4.4-ft libharfbuzz
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,7 +45,7 @@ function install() {
 }
 
 ICU_VERSION="57.1"
-BOOST_VERSION="1.65.1"
+BOOST_VERSION="1.64.0"
 
 function install_mason_deps() {
     install ccache 3.3.1

--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ database:
     - ./.mason/mason link clang++ ${LLVM_VERSION}
     - ./configure CC="$(pwd)/mason_packages/.link/bin/clang" CXX="$(pwd)/mason_packages/.link/bin/ccache $(pwd)/mason_packages/.link/bin/clang++ -Qunused-arguments"
     - make
+    - nm src/libmapnik* | grep "GLIBCXX_3.4.2[0-9]" || true
   override:
     - psql -c 'create database template_postgis;'
     - psql -c 'create extension postgis;' -d template_postgis

--- a/src/font_engine_freetype.cpp
+++ b/src/font_engine_freetype.cpp
@@ -53,6 +53,16 @@ namespace mapnik
 {
 template class MAPNIK_DECL singleton<freetype_engine, CreateUsingNew>;
 
+void freetype_engine::clear()
+{
+#ifdef MAPNIK_THREADSAFE
+    std::lock_guard<std::mutex> lock(mutex_);
+#endif
+    global_font_file_mapping_.clear();
+    global_memory_fonts_.clear();
+}
+
+
 bool freetype_engine::is_font_file(std::string const& file_name)
 {
     // only accept files that will be matched by freetype2's `figurefiletype()`

--- a/src/font_engine_freetype.cpp
+++ b/src/font_engine_freetype.cpp
@@ -53,15 +53,6 @@ namespace mapnik
 {
 template class MAPNIK_DECL singleton<freetype_engine, CreateUsingNew>;
 
-void freetype_engine::clear()
-{
-#ifdef MAPNIK_THREADSAFE
-    std::lock_guard<std::mutex> lock(mutex_);
-#endif
-    global_font_file_mapping_.clear();
-    global_memory_fonts_.clear();
-}
-
 
 bool freetype_engine::is_font_file(std::string const& file_name)
 {

--- a/src/glibc_workaround.cpp
+++ b/src/glibc_workaround.cpp
@@ -1,0 +1,26 @@
+#ifdef __linux__
+
+#ifdef MAPNIK_ENABLE_GLIBC_WORKAROUND
+
+#include <stdexcept>
+
+// https://github.com/bitcoin/bitcoin/pull/4042
+// allows building against libstdc++-dev-4.9 while avoiding
+// GLIBCXX_3.4.20 dep
+// This is needed because libstdc++ itself uses this API - its not
+// just an issue of your code using it, ughhh
+
+namespace std
+{
+
+void __throw_out_of_range_fmt(const char *, ...) __attribute__((__noreturn__));
+void __throw_out_of_range_fmt(const char *err, ...)
+{
+    // Safe and over-simplified version. Ignore the format and print it as-is.
+    __throw_out_of_range(err);
+}
+}
+
+#endif // MAPNIK_ENABLE_GLIBC_WORKAROUND
+
+#endif // __linux__


### PR DESCRIPTION
Currently mapnik, when built with libstdc++-5-dev on linux (and the existing boost mason packages) ends up depending on these GLIBCXX symbols:

```
                 U _ZNSt11logic_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt12length_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt12out_of_rangeC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt13runtime_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt13runtime_errorC2EPKc@@GLIBCXX_3.4.21
                 U _ZNSt16invalid_argumentC1EPKc@@GLIBCXX_3.4.21
                 U _ZSt24__throw_out_of_range_fmtPKcz@@GLIBCXX_3.4.20
                 U _ZNSt11logic_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt12length_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt12out_of_rangeC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt13runtime_errorC1EPKc@@GLIBCXX_3.4.21
                 U _ZNSt13runtime_errorC2EPKc@@GLIBCXX_3.4.21
                 U _ZNSt16invalid_argumentC1EPKc@@GLIBCXX_3.4.21
                 U _ZSt24__throw_out_of_range_fmtPKcz@@GLIBCXX_3.4.20
```

These symbols are not available in the libstdc++6.so versions on ubuntu trusty or amazon linux 2017.09 and older (they are only available in the default libstdc++6.so installed on ubuntu xenial and above).

In order to allow mapnik binaries to run on AWS lambda we need to drop the dependence on these symbols, which can be done by:

 - building boost libraries against libstdc++-4.9-dev instead of libstdc++-5-dev
 - building mapnik against libstdc++-4.9-dev instead of libstdc++-5-dev
 - applying a shim to avoid `throw_out_of_range_fmt@GLIBCXX_3.4.20` getting linked (to avoid needing to build against libstdc++-4.8-dev which has known bugs)
