### PR TITLE
char_array_buffer should implement also seekpos()

### DIFF
--- a/include/mapnik/util/char_array_buffer.hpp
+++ b/include/mapnik/util/char_array_buffer.hpp
@@ -68,6 +68,13 @@ private:
         return end_ - current_;
     }
 
+    pos_type seekpos(pos_type off,
+                     std::ios_base::openmode /*which*/)
+    {
+        current_ = std::min(begin_ + off, end_);
+        return pos_type(off_type(current_ - begin_));
+    }
+
     pos_type seekoff(off_type off, std::ios_base::seekdir dir,
                      std::ios_base::openmode which = std::ios_base::in | std::ios_base::out )
     {

--- a/test/unit/util/char_array_buffer.cpp
+++ b/test/unit/util/char_array_buffer.cpp
@@ -1,0 +1,19 @@
+#include "catch.hpp"
+
+#include <mapnik/util/char_array_buffer.hpp>
+#include <istream>
+
+TEST_CASE("char_array_buffer") {
+
+SECTION("std::istream seekg, tellg") {
+
+    const std::size_t buffer_size = 66;
+    char buffer[buffer_size];
+    mapnik::util::char_array_buffer array_buff(buffer, buffer_size);
+    std::istream stream(&array_buff);
+
+    CHECK(stream.seekg(0).tellg() == 0);
+    CHECK(stream.seekg(buffer_size).tellg() == buffer_size);
+    CHECK(stream.seekg(70).tellg() == buffer_size);
+}
+}


### PR DESCRIPTION
A half of Tiff input works just out of pure luck, because [`tiff_size_proc()`](https://github.com/mapnik/mapnik/blob/5db45d9fa3ef0130eecc4e3d9f6cc24ff687889d/src/tiff_reader.cpp#L71-L79) is not being called. The [`char_array_buffer`](https://github.com/mapnik/mapnik/blob/5db45d9fa3ef0130eecc4e3d9f6cc24ff687889d/include/mapnik/util/char_array_buffer.hpp#L32) doesn't implement [`std::streambuf::seekpos()`](http://en.cppreference.com/w/cpp/io/basic_streambuf/pubseekpos), but needs it by [`std::istream::seekg()`](https://github.com/mapnik/mapnik/blob/5db45d9fa3ef0130eecc4e3d9f6cc24ff687889d/src/tiff_reader.cpp#L77).

If `std::streambuf::seekpos()` is not implemented, `std::istream::seekg()` sets `failbit` on the stream and reading fails.

This is exactly what happens on Gentoo where libtiff has [this patch](https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/tiff/files/tiff-4.0.7-pdfium-0021-oom-TIFFFillStrip.patch).
