### PR TITLE
Glibcxx fix redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,15 +106,13 @@ script:
  # (and might work) for the next build
  - DURATION=2400
  - scripts/travis-command-wrapper.py -s "date" -i 120 --deadline=$(( $(date +%s) + ${DURATION} )) make
- # dump glibcxx symbols >= 3.4.20 (if this returns output
- # then it means the binaries will not run on ubuntu trusty without upgrading libstdc++)
- - nm src/libmapnik* | grep "GLIBCXX_3.4.2[0-9]" || true
  - RESULT=0
  - make test || RESULT=$?
  # we allow visual failures with g++ for now: https://github.com/mapnik/mapnik/issues/3567
  - if [[ ${RESULT} != 0 ]] && [[ ${CXX} =~ 'clang++' ]]; then false; fi;
  - enabled ${COVERAGE} coverage
  - enabled ${BENCH} make bench
+ - ./scripts/check_glibcxx.sh
 
 after_success:
  - enabled ${TRIGGER} trigger_downstream

--- a/scripts/check_glibcxx.sh
+++ b/scripts/check_glibcxx.sh
@@ -12,6 +12,9 @@ if ENABLE_GLIBC_WORKAROUND is set.
 If symbols >= 3.4.20 then it means the binaries would not run on ubuntu trusty without upgrading libstdc++
 
 '
+
+FINAL_RETURN_CODE=0
+
 function check() {
     local RESULT=0
     nm ${1} | grep "GLIBCXX_3.4.2[0-9]" > /tmp/out.txt || RESULT=$?
@@ -19,13 +22,15 @@ function check() {
         echo "Success: GLIBCXX_3.4.2[0-9] symbols not present in binary (as expected)"
     else
         echo "$(cat /tmp/out.txt | c++filt)"
-        exit 1
+        if [[ ${ENABLE_GLIBC_WORKAROUND:-false} == true ]]; then
+            FINAL_RETURN_CODE=1
+        fi
     fi
 }
 
-if [[ ${ENABLE_GLIBC_WORKAROUND:-false} == true ]]; then
-    for i in src/libmapnik*; do
-        echo "checking $i"
-        check $i
-    done
-fi
+for i in src/libmapnik*; do
+    echo "checking $i"
+    check $i
+done
+
+return ${FINAL_RETURN_CODE}

--- a/scripts/check_glibcxx.sh
+++ b/scripts/check_glibcxx.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+shopt -s nullglob
+
+: '
+
+Ensure no GLIBCXX_3.4.2x symbols are present in the binary
+if ENABLE_GLIBC_WORKAROUND is set.
+
+If symbols >= 3.4.20 then it means the binaries would not run on ubuntu trusty without upgrading libstdc++
+
+'
+function check() {
+    local RESULT=0
+    nm ${1} | grep "GLIBCXX_3.4.2[0-9]" > /tmp/out.txt || RESULT=$?
+    if [[ ${RESULT} != 0 ]]; then
+        echo "Success: GLIBCXX_3.4.2[0-9] symbols not present in binary (as expected)"
+    else
+        echo "$(cat /tmp/out.txt | c++filt)"
+        exit 1
+    fi
+}
+
+if [[ ${ENABLE_GLIBC_WORKAROUND:-false} == true ]]; then
+    for i in src/libmapnik*; do
+        echo "checking $i"
+        check $i
+    done
+fi

--- a/src/build.py
+++ b/src/build.py
@@ -313,6 +313,13 @@ cairo/process_markers_symbolizer.cpp
 cairo/process_group_symbolizer.cpp
 """)
 
+if env['ENABLE_GLIBC_WORKAROUND']:
+    source += Split(
+            """
+            glibc_workaround.cpp
+            """
+        )
+
 if env['HAS_CAIRO']:
     lib_env.AppendUnique(LIBPATH=env['CAIRO_LIBPATHS'])
     lib_env.Append(CPPDEFINES = '-DHAVE_CAIRO')


### PR DESCRIPTION
This finishes the work from #3792 by actually adding the workaround and adding a script that tests the symbols we'd expect are gone are actually gone - if not it fails.