### PR TITLE
3.0.x fix glibcxx symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang"
-      env: JOBS=8 CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9" ENABLE_GLIBC_WORKAROUND=True TRIGGER=true
+      env: JOBS=8 CXX="ccache clang++-3.9 -Qunused-arguments" CC="clang-3.9" ENABLE_GLIBC_WORKAROUND=true TRIGGER=true
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
@@ -95,7 +95,7 @@ before_script:
 
 script:
  - export SCONSFLAGS='--debug=time'
- - configure BENCHMARK=${BENCH} ENABLE_GLIBC_WORKAROUND=${ENABLE_GLIBC_WORKAROUND:-False}
+ - configure BENCHMARK=${BENCH} ENABLE_GLIBC_WORKAROUND=${ENABLE_GLIBC_WORKAROUND:-false}
  - cat config.log
  # we limit the `make` to 40 min
  # to ensure that slow builds still upload their

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,6 +45,7 @@ function install() {
 }
 
 ICU_VERSION="57.1"
+BOOST_VERSION="1.65.1"
 
 function install_mason_deps() {
     install ccache 3.3.1
@@ -64,15 +65,15 @@ function install_mason_deps() {
     # here by default helps make mapnik-vector-tile builds easier
     install webp 0.6.0 libwebp
     install libgdal 2.1.3 libgdal
-    install boost 1.63.0
-    install boost_libsystem 1.63.0
-    install boost_libfilesystem 1.63.0
-    install boost_libprogram_options 1.63.0
-    install boost_libregex_icu57 1.63.0
+    install boost ${BOOST_VERSION}
+    install boost_libsystem ${BOOST_VERSION}
+    install boost_libfilesystem ${BOOST_VERSION}
+    install boost_libprogram_options ${BOOST_VERSION}
+    install boost_libregex_icu57 ${BOOST_VERSION}
     # technically boost thread and python are not a core dep, but installing
     # here by default helps make python-mapnik builds easier
-    install boost_libthread 1.63.0
-    install boost_libpython 1.63.0
+    install boost_libthread ${BOOST_VERSION}
+    install boost_libpython ${BOOST_VERSION}
     install freetype 2.7.1 libfreetype
     install harfbuzz 1.4.4-ft libharfbuzz
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,7 @@ todo
 - shrink icu data
 '
 
-MASON_VERSION="v0.11.1"
+MASON_VERSION="v0.17.0"
 
 function setup_mason() {
     if [[ ! -d ./.mason ]]; then


### PR DESCRIPTION
A followup to #3792 (which was also ported to v3.0.x). This fixes the build to:

 - ensure we error if symbols >= GLIBCXX_3.4.20 are present
 - upgrades the boost mason package to avoid GLIBCXX_3.4.21 symbols

TODO:

 - [x]  confirm this is working
 - [x] cherry-pick da86e99 back to master
 - [ ] add note about when this can be removed