### PR TITLE
Export all text_placements_ classes from mapnik.dll

### DIFF
--- a/include/mapnik/text/placements/list.hpp
+++ b/include/mapnik/text/placements/list.hpp
@@ -30,7 +30,7 @@ class feature_impl;
 struct attribute;
 
 // Tries a list of placements.
-class text_placements_list: public text_placements
+class MAPNIK_DECL text_placements_list: public text_placements
 {
 public:
     text_placements_list();
@@ -47,7 +47,7 @@ private:
 
 // List placement strategy.
 // See parent class for documentation of each function.
-class text_placement_info_list : public text_placement_info
+class MAPNIK_DECL text_placement_info_list : public text_placement_info
 {
 public:
     text_placement_info_list(text_placements_list const* parent, double _scale_factor) :

--- a/include/mapnik/text/placements/simple.hpp
+++ b/include/mapnik/text/placements/simple.hpp
@@ -33,7 +33,7 @@ class feature_impl;
 struct attribute;
 
 // Automatically generates placement options from a user selected list of directions and text sizes.
-class text_placements_simple: public text_placements
+class MAPNIK_DECL text_placements_simple: public text_placements
 {
 public:
     text_placements_simple(symbolizer_base::value_type const& positions);
@@ -53,7 +53,7 @@ private:
 
 // Simple placement strategy.
 // See parent class for documentation of each function.
-class text_placement_info_simple : public text_placement_info
+class MAPNIK_DECL text_placement_info_simple : public text_placement_info
 {
 public:
     text_placement_info_simple(text_placements_simple const* parent,


### PR DESCRIPTION
Previously, only text_placements_dummy had a MAPNIK_DECL annotation.
This commit adds that annotation to text_placements_simple and
text_placements_list, so that they are also exposed from the Windows DLL
build.