### PR TITLE
Replaced old-style exception for Python 3 compatibility.

### DIFF
--- a/utils/pgsql2sqlite/build.py
+++ b/utils/pgsql2sqlite/build.py
@@ -46,7 +46,7 @@ if env['RUNTIME_LINK'] == 'static':
     cmd = 'pkg-config libpq --libs --static'
     try:
         program_env.ParseConfig(cmd)
-    except OSError, e:
+    except OSError as e:
         program_env.Append(LIBS='pq')
 else:
     program_env.Append(LIBS='pq')


### PR DESCRIPTION
I'm not sure if this is a one-time orphan or a widespread convention in the codebase, but I had to switch from the older comma style to "as" style to make build.py work on Python 3.