### PR TITLE
Handle unicode file path on windows in command line tools

### DIFF
--- a/utils/shapeindex/shapeindex.cpp
+++ b/utils/shapeindex/shapeindex.cpp
@@ -40,7 +40,12 @@
 const int DEFAULT_DEPTH = 8;
 const double DEFAULT_RATIO = 0.55;
 
+#ifdef _WINDOWS
+#include <windows.h>
+int main ()
+#else
 int main (int argc,char** argv)
+#endif
 {
     using namespace mapnik;
     namespace po = boost::program_options;
@@ -67,7 +72,15 @@ int main (int argc,char** argv)
         po::positional_options_description p;
         p.add("shape_files",-1);
         po::variables_map vm;
+#ifdef _WINDOWS
+        std::vector<std::string> args;
+        const auto wargs = po::split_winmain(GetCommandLineW());
+        for( auto it = wargs.begin() + 1; it != wargs.end(); ++it )
+            args.push_back(mapnik::utf16_to_utf8(*it));
+        po::store(po::command_line_parser(args).options(desc).positional(p).run(), vm);
+#else
         po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+#endif
         po::notify(vm);
 
         if (vm.count("version"))
@@ -278,7 +291,11 @@ int main (int argc,char** argv)
         if (count > 0)
         {
             std::clog << " number shapes=" << count << std::endl;
+#ifdef _WINDOWS
+            std::ofstream file(mapnik::utf8_to_utf16(shapename+".index").c_str(), std::ios::trunc | std::ios::binary);
+#else
             std::ofstream file((shapename+".index").c_str(), std::ios::trunc | std::ios::binary);
+#endif
             if (!file)
             {
                 std::clog << "cannot open index file for writing file \""


### PR DESCRIPTION
Unicode file paths are not being handled properly in command line tools on windows, for instance:
```
$ ./shapeindex.exe "jp\ ゑ/out/mapnik/lod_4/road.shp"
max tree depth:8
split ratio:0.55
processing ../../out/vc140_x64/generate-5dkdsc/jp\ ?/out/mapnik/lod_4/road.shp
Error : file ../../out/vc140_x64/generate-5dkdsc/jp\ ?/out/mapnik/lod_4/road.shp does not exist
done!
```
The changes in this PR fix it:
```
$ ./shapeindex.exe "jp ゑ/out/mapnik/lod_4/road.shp"
max tree depth:8
split ratio:0.55
processing jp ゑ/out/mapnik/lod_4/road.shp
9994
length=54
version=1000
type=3
extent:box2d(-15.7564999998877191,28.0960000049605405,-15.4129999990117490,28.1060000083986559)
 number shapes=1
 number nodes=1
done!
```
If you're interested in the fix I can spend a bit more time and
* move the code in fs.cpp or some similar util file in order to hide the ifdef _WINDOWS
* fix other command line tools (mapnik-index, mapnik-render, ogrindex, svg2png)
* maybe add some tests but I couldn't find any on shapeindex ?
