### PR TITLE
Fix filtering of vertices in offset_converter

### DIFF
--- a/include/mapnik/offset_converter.hpp
+++ b/include/mapnik/offset_converter.hpp
@@ -129,6 +129,14 @@ struct offset_converter
             //break; // uncomment this to see all the curls
 
             vertex2d const& u0 = vertices_[i];
+
+            // End or beginning of a line or ring must not be filtered out
+            // to not to join lines or rings together.
+            if (u0.cmd == SEG_CLOSE || u0.cmd == SEG_MOVETO)
+            {
+                break;
+            }
+
             vertex2d const& u1 = vertices_[i+1];
             double const dx = u0.x - cur_.x;
             double const dy = u0.y - cur_.y;

--- a/test/unit/vertex_adapter/offset_converter.cpp
+++ b/test/unit/vertex_adapter/offset_converter.cpp
@@ -336,4 +336,49 @@ SECTION("s curve") {
     }
 }
 
+SECTION("offsect converter does not skip SEG_MOVETO or SEG_CLOSE vertices") {
+
+    const double offset = 0.2;
+
+    fake_path path = {};
+    path.vertices_.emplace_back(-2, -2, mapnik::SEG_MOVETO);
+    path.vertices_.emplace_back( 2, -2, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back( 2,  2, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back(-2,  2, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back(-2,  -1.9, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back( 0,  0, mapnik::SEG_CLOSE);
+    path.vertices_.emplace_back(-1.9, -1.9, mapnik::SEG_MOVETO);
+    path.vertices_.emplace_back( 1, -1, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back( 1,  1, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back(-1,  1, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back(-1, -1, mapnik::SEG_LINETO);
+    path.vertices_.emplace_back( 0,  0, mapnik::SEG_CLOSE);
+    path.rewind(0);
+
+    mapnik::offset_converter<fake_path> off_path(path);
+    off_path.set_offset(offset);
+
+    unsigned cmd;
+    double x, y;
+
+    unsigned move_to_count = 0;
+    unsigned close_count = 0;
+
+    while((cmd = off_path.vertex(&x, &y)) != mapnik::SEG_END)
+    {
+        switch (cmd)
+        {
+            case mapnik::SEG_MOVETO:
+                move_to_count++;
+            break;
+            case mapnik::SEG_CLOSE:
+                close_count++;
+            break;
+        }
+    }
+
+    CHECK(move_to_count == 2);
+    CHECK(close_count == 2);
+}
+
 }


### PR DESCRIPTION
The `offset_converter` generates many possible candidate vertices for the offsetted path which are then filtered to get rid of ["the curls"](https://github.com/mapnik/mapnik/issues/3041).

This filtration can erroneously remove vertices with `SEG_MOVETO` or `SEG_CLOSE` commands and lead to inadvertent joining of lines or rings.

A visual test before the fix:
![multipolygon-two-holes-geojson-clip-300-300-2 0-agg-reference](https://user-images.githubusercontent.com/1950911/35438428-c8df1e8e-0296-11e8-9c91-5ac38990cf21.png)

After the fix:
![multipolygon-two-holes-geojson-clip-300-300-2 0-agg-reference2](https://user-images.githubusercontent.com/1950911/35438427-c8bbebb2-0296-11e8-848a-ea07e297d18a.png)
