### PR TITLE
Interior, polylabel: Scale precision by polygon size 

### DIFF
--- a/src/geometry/interior.cpp
+++ b/src/geometry/interior.cpp
@@ -145,15 +145,8 @@ struct cell
 };
 
 template <class T>
-boost::optional<point<T>> polylabel(polygon<T> const& polygon, T precision = 1)
+point<T> polylabel(polygon<T> const& polygon, box2d<T> const& bbox , T precision = 1)
 {
-    if (polygon.empty() || polygon.front().empty())
-    {
-        return boost::none;
-    }
-
-    // find the bounding box of the outer ring
-    const box2d<T> bbox = envelope(polygon.at(0));
     const point<T> size { bbox.width(), bbox.height() };
 
     const T cell_size = std::min(size.x, size.y);
@@ -169,14 +162,14 @@ boost::optional<point<T>> polylabel(polygon<T> const& polygon, T precision = 1)
 
     if (cell_size == 0)
     {
-        return point<T>{ bbox.minx(), bbox.miny() };
+        return { bbox.minx(), bbox.miny() };
     }
 
     point<T> centroid;
     if (!mapnik::geometry::centroid(polygon, centroid))
     {
         auto center = bbox.center();
-        return point<T>{ center.x, center.y };
+        return { center.x, center.y };
     }
 
     fitness_functor<T> fitness_func(centroid, size);
@@ -224,15 +217,18 @@ boost::optional<point<T>> polylabel(polygon<T> const& polygon, T precision = 1)
 template <class T>
 bool interior(polygon<T> const& polygon, double scale_factor, point<T> & pt)
 {
-    // This precision has been chosen to work well in the map (viewport) coordinates.
-    double precision = 10.0 * scale_factor;
-    if (boost::optional<point<T>> opt = detail::polylabel(polygon, precision))
+    if (polygon.empty() || polygon.front().empty())
     {
-        pt = *opt;
-        return true;
+        return false;
     }
 
-    return false;
+    const box2d<T> bbox = envelope(polygon.at(0));
+
+    // Let the precision be 1% of the polygon size to be independent to map scale.
+    double precision = (std::max(bbox.width(), bbox.height()) / 100.0) * scale_factor;
+
+    pt = detail::polylabel(polygon, bbox, precision);
+    return true;
 }
 
 template

--- a/src/geometry/polylabel.cpp
+++ b/src/geometry/polylabel.cpp
@@ -29,8 +29,9 @@ namespace mapnik { namespace geometry {
 template <class T>
 T polylabel_precision(polygon<T> const& polygon, double scale_factor)
 {
-    // This precision has been chosen to work well in the map (viewport) coordinates.
-    return 10.0 * scale_factor;
+    const box2d<T> bbox = mapnik::geometry::envelope(polygon);
+    // Let the precision be 1% of the polygon size to be independent to map scale.
+    return (std::max(bbox.width(), bbox.height()) / 100.0) * scale_factor;
 }
 
 template <class T>


### PR DESCRIPTION
It was a mistake to use a constant value as the precision parameter for interior and polylabel algorithms. These algorithms work on polygons in map (viewport) coordinates, thus the precision should scale with the polygon, to get consistent positions across zoom levels, for example.

This pull request fixes this by setting the precision to 1% of the polygon size.

Here is a demonstration of the problem:

![polygon-placement-scale-invariant-256-256-1 0-agg-reference](https://user-images.githubusercontent.com/1950911/35767743-2e7cc8fc-08f2-11e8-8630-fe882fd15c63.png)
![polygon-placement-scale-invariant-128-128-1 0-agg-reference](https://user-images.githubusercontent.com/1950911/35767741-2de23760-08f2-11e8-8de4-8aaf822086d6.png)

After the fix:
![polygon-placement-scale-invariant-256-256-1 0-agg](https://user-images.githubusercontent.com/1950911/35767742-2e277dd4-08f2-11e8-9003-6a030a2d16c1.png)
![polygon-placement-scale-invariant-128-128-1 0-agg](https://user-images.githubusercontent.com/1950911/35767740-2d8df592-08f2-11e8-8ee1-37eceb2deba6.png)

cc @kocio-pl