### PR TITLE
Fix vertex_adapter test

### DIFF
--- a/test/unit/vertex_adapter/vertex_adapter.cpp
+++ b/test/unit/vertex_adapter/vertex_adapter.cpp
@@ -273,7 +273,7 @@ SECTION("polygon with empty exterior ring") {
     g.emplace_back();
 
     mapnik::geometry::polygon_vertex_adapter<double> va(g);
-    double x,y;
+    double x = 0, y = 0;
     unsigned cmd;
 
     cmd = va.vertex(&x,&y);


### PR DESCRIPTION
Vertex with command `SEG_END` doesn't yield any coordinates so the variables have to be initialized.