### PR TITLE
Respect raster_has_nodata

### DIFF
--- a/plugins/input/gdal/gdal_featureset.cpp
+++ b/plugins/input/gdal/gdal_featureset.cpp
@@ -586,8 +586,14 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
             }
             mapnik::raster_ptr raster = std::make_shared<mapnik::raster>(feature_raster_extent, intersect, image, filter_factor);
             // set nodata value to be used in raster colorizer
-            if (nodata_value_) raster->set_nodata(*nodata_value_);
-            else raster->set_nodata(raster_nodata);
+            if (nodata_value_)
+            {
+                raster->set_nodata(*nodata_value_);
+            }
+            else if (raster_has_nodata)
+            {
+                raster->set_nodata(raster_nodata);
+            }
             feature->set_raster(raster);
         }
         // report actual/original source nodata in feature attributes


### PR DESCRIPTION
Addresses https://github.com/mapnik/mapnik/issues/3856.

The problem was that nodata value was set to the `mapnik::raster` even though it should not. The value of [`raster_has_nodata`](https://github.com/mapnik/mapnik/blob/533c6d6e5b8f13295205955b6ceb2f08606264a8/plugins/input/gdal/gdal_featureset.cpp#L376) was not respected.

The reason why it was throwing SIGILL with `-fsanitize=undefined` is that GDAL returned an out of range nodata value (-10000000000) from [`GDALRasterBand::GetNoDataValue()`](http://www.gdal.org/classGDALRasterBand.html#abf5ddfd58352f8b2f98af8ab48786d9c) and the conversion from `double` to `span_gen_type::value_type` caused the crash:

```c++
int main()
{
    unsigned char i = 256.0;
}
```

```console
 $ clang++ -std=c++14 -fsanitize=undefined-trap -fsanitize-undefined-trap-on-error -o trap trap.cpp && ./trap
trap.cpp:4:23: warning: implicit conversion from 'double' to 'unsigned char' changes value from 256 to 255 [-Wliteral-conversion]
    unsigned char i = 256.0;
                  ~   ^~~~~
1 warning generated.
[1]    5339 illegal hardware instruction  ./trap

```