### PR TITLE
PROJ_LIB: Fix detection code

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -867,6 +867,7 @@ def CheckProjData(context, silent=False):
 // This is narly, could eventually be replaced using https://github.com/OSGeo/proj.4/pull/551]
 #include <proj_api.h>
 #include <iostream>
+#include <cstring>
 
 static void my_proj4_logger(void * user_data, int /*level*/, const char * msg)
 {


### PR DESCRIPTION
I was getting this error message:
```
Checking for PROJ_LIB directory...Failed to detect (mapnik-config will have null value)
```

And this was due to a missing include:
```
/bin/clang++ -o .sconf_temp/conftest_24.o -c -std=c++14 -march=native -mtune=native -O2 -pipe -fstack-protector-strong -fno-plt -Wall -Wextra -Wconversion -g3 -gdwarf-4 -fno-omit-frame-pointer -DBOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL -DMAPNIK_MEMORY_MAPPED_FILE -DMAPNIK_HAS_DLCFN -DBIGINT -DBOOST_REGEX_HAS_ICU -DHAVE_JPEG -DMAPNIK_USE_PROJ4 -DHAVE_PNG -DHAVE_WEBP -DHAVE_TIFF -Iinclude -I/usr/include -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libxml2 .sconf_temp/conftest_24.cpp
.sconf_temp/conftest_24.cpp:30:42: error: use of undeclared identifier 'strlen'
        osFilename = osMsg.substr(nPos + strlen("fopen("));
```

Clang:
```$ clang++ --version
clang version 5.0.1 (tags/RELEASE_501/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
