### PR TITLE
ICU DATA: Default to icu-config if u_getDataDirectory fails

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -831,9 +831,16 @@ int main() {
         context.did_show_result=1
     if ret[0]:
         context.Result('u_getDataDirectory returned %s' % ret[1])
+        return ret[1].strip()
     else:
-        context.Result('Failed to detect (mapnik-config will have null value)')
-    return ret[1].strip()
+        ret = call("icu-config --icudatadir", silent=True)
+        if ret:
+            context.Result('icu-config returned %s' % ret)
+            return ret
+        else:
+            context.Result('Failed to detect (mapnik-config will have null value)')
+            return ''
+
 
 def CheckGdalData(context, silent=False):
 


### PR DESCRIPTION
Use `icu-config --icudatadir` to detect ICU_DATA if `u_getDataDirectory` fails.

Previous behaviour:
``` Checking for ICU data directory...Failed to detect (mapnik-config will have null value)```
```bash
$ ./utils/mapnik-config/mapnik-config --icu-data
$
```

With this PR and icu-config in the PATH:
```Checking for ICU data directory...icu-config returned /usr/share/icu/60.2```
```bash
$ ./utils/mapnik-config/mapnik-config --icu-data
/usr/share/icu/60.2
$
```