### PR TITLE
Fix build issue with MAPNIK_THREADSAFE disabled

### DIFF
--- a/plugins/input/gdal/gdal_datasource.cpp
+++ b/plugins/input/gdal/gdal_datasource.cpp
@@ -32,6 +32,8 @@
 
 #include <gdal_version.h>
 
+#include <mutex>
+
 using mapnik::datasource;
 using mapnik::parameters;
 

--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -41,6 +41,7 @@
 
 // stl
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 


### PR DESCRIPTION
This is just a couple of necessary includes so it builds when `MAPNIK_THREADSAFE` is disabled. Required by `std::once_flag`.

Let me know if you want a PR for the 3.x branch too (should be portable by straight cherry-pick).