### PR TITLE
Qualify ICU types explicitly

### DIFF
--- a/include/mapnik/text/scrptrun.hpp
+++ b/include/mapnik/text/scrptrun.hpp
@@ -37,7 +37,7 @@ struct ParenStackEntry
     UScriptCode scriptCode = USCRIPT_INVALID_CODE;
 };
 
-class ScriptRun : public UObject {
+class ScriptRun : public icu::UObject {
 public:
     ScriptRun();
 

--- a/src/text/text_layout.cpp
+++ b/src/text/text_layout.cpp
@@ -207,6 +207,7 @@ void text_layout::layout()
 // At the end everything that is left over is added as the final line.
 void text_layout::break_line_icu(std::pair<unsigned, unsigned> && line_limits)
 {
+    using BreakIterator = icu::BreakIterator;
     text_line line(line_limits.first, line_limits.second);
     shape_text(line);
 
@@ -228,7 +229,7 @@ void text_layout::break_line_icu(std::pair<unsigned, unsigned> && line_limits)
     }
 
     mapnik::value_unicode_string const& text = itemizer_.text();
-    Locale locale; // TODO: Is the default constructor correct?
+    icu::Locale locale; // TODO: Is the default constructor correct?
     UErrorCode status = U_ZERO_ERROR;
     std::unique_ptr<BreakIterator> breakitr(BreakIterator::createLineInstance(locale, status));
 
@@ -336,6 +337,7 @@ inline int adjust_last_break_position (int pos, bool repeat_wrap_char)
 
 void text_layout::break_line(std::pair<unsigned, unsigned> && line_limits)
 {
+    using BreakIterator = icu::BreakIterator;
     text_line line(line_limits.first, line_limits.second);
     shape_text(line);
     double scaled_wrap_width = wrap_width_ * scale_factor_;


### PR DESCRIPTION
ICU 61 has dropped the global `using namespace icu;` and the build breaks
http://site.icu-project.org/download/61#TOC-Migration-Issues

```
In file included from src/text/scrptrun.cpp:23:
include/mapnik/text/scrptrun.hpp:40:26: error: unknown class name 'UObject'; did you mean 'icu_61::UObject'?
class ScriptRun : public UObject {
                         ^~~~~~~
                         icu_61::UObject
```