### PR TITLE
don't error oddly if compiler is not found

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1275,7 +1275,10 @@ if not preconfigured:
     color_print(4,"Configuring on %s in *%s*..." % (env['PLATFORM'],mode))
 
     cxx_version = call("%s --version" % env["CXX"] ,silent=True)
-    color_print(5, "CXX %s" % cxx_version.decode("utf8"))
+    if cxx_version:
+        color_print(5, "CXX %s" % cxx_version.decode("utf8"))
+    else:
+        color_print(5, "Could not detect CXX compiler")
 
     env['MISSING_DEPS'] = []
     env['SKIPPED_DEPS'] = []


### PR DESCRIPTION
Before this change if `c++` did not exist on the system you'd see this confusing error:

```
./configure 
Inheriting from mapnik-settings.env
scons: Reading SConscript files ...

Welcome to Mapnik...

Configuring build environment...
SCons CONFIG found: 'config.py', variables will be inherited...
Configuring on Linux in *release mode*...
AttributeError: 'NoneType' object has no attribute 'decode':
  File "/root/mapnik/SConstruct", line 1278:
    color_print(5, "CXX %s" % cxx_version.decode("utf8"))

real	0m0.393s
user	0m0.294s
sys	0m0.043s
```