### PR TITLE
postgis: Thread safe ConnectionManager

### DIFF
--- a/plugins/input/postgis/connection_manager.hpp
+++ b/plugins/input/postgis/connection_manager.hpp
@@ -115,6 +115,9 @@ public:
 
     bool registerPool(ConnectionCreator<Connection> const& creator,unsigned initialSize,unsigned maxSize)
     {
+#ifdef MAPNIK_THREADSAFE
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         ContType::const_iterator itr = pools_.find(creator.id());
 
         if (itr != pools_.end())
@@ -134,6 +137,9 @@ public:
 
     std::shared_ptr<PoolType> getPool(std::string const& key)
     {
+#ifdef MAPNIK_THREADSAFE
+        std::lock_guard<std::mutex> lock(mutex_);
+#endif
         ContType::const_iterator itr=pools_.find(key);
         if (itr!=pools_.end())
         {


### PR DESCRIPTION
Since [`mapnik::Pool`](https://github.com/mapnik/mapnik/blob/d8dbe11fd09f55ba6b59c9e497a5a21335acb15b/include/mapnik/pool.hpp#L42) can be thread safe, `ConnectionManager` should be as well.

Otherwise concurrent Postgis datasource initialization can lead to a crash.

