### PR TITLE
postgis: Exclude password from ConnectionCreator::id()

### DIFF
--- a/plugins/input/postgis/connection_manager.hpp
+++ b/plugins/input/postgis/connection_manager.hpp
@@ -67,7 +67,7 @@ public:
 
     inline std::string id() const
     {
-        return connection_string();
+        return connection_string_safe();
     }
 
     inline std::string connection_string() const

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -28,6 +28,7 @@
 #include <mapnik/geometry/geometry_type.hpp>
 #include <mapnik/unicode.hpp>
 #include <mapnik/util/fs.hpp>
+#include "../../../plugins/input/postgis/connection_manager.hpp"
 
 /*
   Compile and run just this test:
@@ -405,4 +406,21 @@ TEST_CASE("postgis") {
 */
 
     }
+}
+
+
+TEST_CASE("ConnectionCreator") {
+
+SECTION("ConnectionCreator::id() should not expose password")
+{
+    ConnectionCreator<Connection> creator(boost::optional<std::string>("host"),
+                                          boost::optional<std::string>("12345"),
+                                          boost::optional<std::string>("dbname"),
+                                          boost::optional<std::string>("user"),
+                                          boost::optional<std::string>("pass"),
+                                          boost::optional<std::string>("111"));
+
+    CHECK(creator.id() == "host=host port=12345 dbname=dbname user=user connect_timeout=111");
+}
+
 }


### PR DESCRIPTION
`ConnectionCreator::id()` is used [to identify](https://github.com/mapnik/mapnik/blob/d8dbe11fd09f55ba6b59c9e497a5a21335acb15b/plugins/input/postgis/connection_manager.hpp#L118) connection parameters for pooling.

There are at least two issues with password included in the id:

- Password is not necessary for the connection identification. There already was an accident with leaking database password: 9afaf091b16d3230aa8df731aed78583a5863bdb.
- When password is not required by the database, user can accidentally use multiple different passwords without noticing.  This leads to allocating more connection pools and increase of connection consumption.