### PR TITLE
Marker symbolizer: Fix bug with lines with 0 length

### DIFF
--- a/include/mapnik/geom_util.hpp
+++ b/include/mapnik/geom_util.hpp
@@ -314,6 +314,12 @@ bool middle_point(PathType & path, double & x, double & y, boost::optional<doubl
     path.rewind(0);
     unsigned command = path.vertex(&x0,&y0);
     if (command == SEG_END) return false;
+    if (std::abs(mid_length) < std::numeric_limits<double>::epsilon())
+    {
+        x = x0;
+        y = y0;
+        return true;
+    }
     double dist = 0.0;
     while (SEG_END != (command = path.vertex(&x1, &y1)))
     {


### PR DESCRIPTION
I've found an issue where a line without length, which may happen when simplifying the geometries, isn't being drawn due to a bug in the `middle_point` function. With this kind of line, you get a `mid_length` of 0 and the length of the first segment is also `0`, so when you reach [the conditional](https://github.com/mapnik/mapnik/blob/b7e486d3c357b533985497ad24c7a003c06a72ee/include/mapnik/geom_util.hpp#L323) `0 >= 0` so `r = (0 - 0) / 0` which leads to r = NaN, thus both x and y are set to NaN.

To solve this, if the length of the line is 0 I've changed it to simply return the first point.

I don't know what's the current procedure to add another visual test in `test-data-visual`. Here is a zip with the map config to reproduce the issue, with the current output (`-reference.png`) and the one after the changes: [tmp.zip](https://github.com/mapnik/mapnik/files/1994925/tmp.zip). Let me know if you'd rather have a PR there.
