### PR TITLE
[WIP] Marker symbolizer: Cache marker images for faster rendering

### DIFF
--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -34,6 +34,7 @@
 #include <mapnik/attribute.hpp>
 #include <mapnik/text/font_feature_settings.hpp>
 #include <mapnik/util/variant.hpp>
+#include <mapnik/marker.hpp>
 
 // stl
 #include <memory>
@@ -73,8 +74,6 @@ struct enumeration_wrapper
         return value;
     }
 };
-
-using dash_array = std::vector<std::pair<double,double> >;
 
 class text_placements;
 using text_placements_ptr = std::shared_ptr<text_placements>;
@@ -139,7 +138,15 @@ struct MAPNIK_DECL text_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL shield_symbolizer : public text_symbolizer {};
 struct MAPNIK_DECL line_pattern_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL polygon_pattern_symbolizer : public symbolizer_base {};
-struct MAPNIK_DECL markers_symbolizer : public symbolizer_base {};
+// Marker symbolizer with cached attributes
+struct MAPNIK_DECL markers_symbolizer : public symbolizer_base
+{
+    enum cache_status { UNCHECKED, UNCACHEABLE, CACHEABLE };
+
+    std::shared_ptr<mapnik::svg_attribute_type> cached_attributes = nullptr;
+    svg_path_ptr cached_ellipse = nullptr;
+    cache_status cacheable = UNCHECKED;
+};
 struct MAPNIK_DECL raster_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL building_symbolizer : public symbolizer_base {};
 struct MAPNIK_DECL group_symbolizer : public symbolizer_base {};

--- a/src/agg/process_markers_symbolizer.cpp
+++ b/src/agg/process_markers_symbolizer.cpp
@@ -58,7 +58,7 @@ struct agg_markers_renderer_context : markers_renderer_context
     using vertex_source_type = typename SvgRenderer::vertex_source_type;
     using pixfmt_type = typename renderer_base::pixfmt_type;
 
-    agg_markers_renderer_context(symbolizer_base const& sym,
+    agg_markers_renderer_context(markers_symbolizer const& sym,
                                  feature_impl const& feature,
                                  attributes const& vars,
                                  BufferType & buf,
@@ -66,7 +66,8 @@ struct agg_markers_renderer_context : markers_renderer_context
       : buf_(buf),
         pixf_(buf_),
         renb_(pixf_),
-        ras_(ras)
+        ras_(ras),
+        sym_cacheable(sym.cacheable == markers_symbolizer::cache_status::CACHEABLE)
     {
         auto comp_op = get<composite_mode_e, keys::comp_op>(sym, feature, vars);
         pixf_.comp_op(static_cast<agg::comp_op_e>(comp_op));
@@ -78,9 +79,144 @@ struct agg_markers_renderer_context : markers_renderer_context
                                markers_dispatch_params const& params,
                                agg::trans_affine const& marker_tr)
     {
-        SvgRenderer svg_renderer(path, attrs);
-        render_vector_marker(svg_renderer, ras_, renb_, src->bounding_box(),
-                             marker_tr, params.opacity, params.snap_to_pixels);
+        // Check that the symbolizer is cacheable (doesn't use expressions)
+        // and the transform doesn't use any scaling/shearing.
+        bool mark_cacheable = (std::fabs(1.0 - marker_tr.sx)  < agg::affine_epsilon)
+                           && (std::fabs(0.0 - marker_tr.shy) < agg::affine_epsilon)
+                           && (std::fabs(0.0 - marker_tr.shx) < agg::affine_epsilon)
+                           && (std::fabs(1.0 - marker_tr.sy)  < agg::affine_epsilon);
+        if (!sym_cacheable || !mark_cacheable)
+        {
+            // Fallback to non-cached rendering path
+            SvgRenderer svg_renderer(path, attrs);
+            render_vector_marker(svg_renderer, ras_, renb_, src->bounding_box(),
+                                 marker_tr, params.opacity, params.snap_to_pixels);
+            return;
+        }
+
+        for (auto & attr : attrs)
+        {
+            using mapnik::svg::path_attributes;
+            auto & cattr = const_cast<path_attributes &>(attr);
+            constexpr int sampling_rate = path_attributes::sampling_rate;
+            // Calculate canvas offsets
+            double margin = 0.0;
+            if (cattr.stroke_flag || cattr.stroke_gradient.get_gradient_type() != NO_GRADIENT)
+            {
+                margin = std::abs(cattr.stroke_width);
+            }
+            double x0 = std::floor(src->bounding_box().minx() - margin);
+            double y0 = std::floor(src->bounding_box().miny() - margin);
+
+            // Now calculate subpixel offset and sample index
+            double dx = marker_tr.tx - std::floor(marker_tr.tx);
+            double dy = marker_tr.ty - std::floor(marker_tr.ty);
+
+            double sample_x = std::floor(dx * sampling_rate);
+            double sample_y = std::floor(dy * sampling_rate);
+
+            const int sample_idx = static_cast<int>(sample_y) *
+                                   sampling_rate + static_cast<int>(sample_x);
+
+
+            if (cattr.cached_images.empty())
+            {
+                cattr.cached_images.resize(sampling_rate * sampling_rate);
+            }
+
+            path_attributes::cache_line & cl = cattr.cached_images[sample_idx];
+            if (!cl.set)
+            {
+                std::shared_ptr<image_rgba8> fill_img = nullptr;
+                std::shared_ptr<image_rgba8> stroke_img = nullptr;
+
+                // Calculate canvas size
+                int width  = static_cast<int>(std::ceil(src->bounding_box().width()  + 2.0 * margin)) + 2;
+                int height = static_cast<int>(std::ceil(src->bounding_box().height() + 2.0 * margin)) + 2;
+
+                // Reset clip box
+                ras_.clip_box(0, 0, width, height);
+
+                // Build local transformation matrix by resetting translation coordinates
+                agg::trans_affine marker_tr_copy(marker_tr);
+                marker_tr_copy.tx = dx - x0;
+                marker_tr_copy.ty = dy - y0;
+
+                // Create fill image
+                if (cattr.fill_flag || cattr.fill_gradient.get_gradient_type() != NO_GRADIENT)
+                {
+                    fill_img = std::make_shared<image_rgba8>(width, height, true);
+
+                    agg::rendering_buffer buf(fill_img->bytes(), fill_img->width(), fill_img->height(), fill_img->row_size());
+                    pixfmt_type pixf(buf);
+                    renderer_base renb(pixf);
+
+                    auto cattr_copy = cattr;
+                    cattr_copy.stroke_flag = false;
+                    cattr_copy.stroke_gradient.set_gradient_type(NO_GRADIENT);
+                    svg_attribute_type attrs_copy;
+                    attrs_copy.push_back(cattr_copy);
+
+                    SvgRenderer svg_renderer(path, attrs_copy);
+                    render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(),
+                                         marker_tr_copy, 1.0, params.snap_to_pixels);
+
+                    if (std::all_of(fill_img->begin(), fill_img->end(), [](uint32_t val) { return val == 0; }))
+                    {
+                        fill_img.reset(); // optimization, can ignore image
+                    }
+                }
+
+                // Create stroke image
+                if (cattr.stroke_flag || cattr.stroke_gradient.get_gradient_type() != NO_GRADIENT)
+                {
+                    stroke_img = std::make_shared<image_rgba8>(width, height, true);
+
+                    agg::rendering_buffer buf(stroke_img->bytes(), stroke_img->width(), stroke_img->height(), stroke_img->row_size());
+                    pixfmt_type pixf(buf);
+                    renderer_base renb(pixf);
+
+                    auto cattr_copy = cattr;
+                    cattr_copy.fill_flag = false;
+                    cattr_copy.fill_gradient.set_gradient_type(NO_GRADIENT);
+                    svg_attribute_type attrs_copy;
+                    attrs_copy.push_back(cattr_copy);
+
+                    SvgRenderer svg_renderer(path, attrs_copy);
+                    render_vector_marker(svg_renderer, ras_, renb, src->bounding_box(),
+                                         marker_tr_copy, 1.0, params.snap_to_pixels);
+
+                    if (std::all_of(stroke_img->begin(), stroke_img->end(), [](uint32_t val) { return val == 0; }))
+                    {
+                        stroke_img.reset(); // optimization, can ignore image
+                    }
+                }
+
+                // Update cache with the new images
+                cl.set = true;
+                cl.fill_img = fill_img;
+                cl.stroke_img = stroke_img;
+
+                // Restore clip box
+                ras_.clip_box(0, 0, pixf_.width(), pixf_.height());
+            }
+
+            // Set up blitting transformation. We will add a small offset due to sampling
+            agg::trans_affine marker_tr_copy(marker_tr);
+            marker_tr_copy.translate(x0 - dx, y0 - dy);
+
+            // Blit stroke and fill images
+            if (cl.fill_img)
+            {
+                render_raster_marker(renb_, ras_, *cl.fill_img, marker_tr_copy,
+                                    params.opacity, params.scale_factor, params.snap_to_pixels);
+            }
+            if (cl.stroke_img)
+            {
+                render_raster_marker(renb_, ras_, *cl.stroke_img, marker_tr_copy,
+                                    params.opacity, params.scale_factor, params.snap_to_pixels);
+            }
+        }
     }
 
 
@@ -99,6 +235,7 @@ private:
     pixfmt_type pixf_;
     renderer_base renb_;
     RasterizerType & ras_;
+    bool sym_cacheable;
 };
 
 } // namespace detail


### PR DESCRIPTION
This adds an image cache to speed up the marker symbolizer.

What is does is, if the marker symbolizer is cacheable (for now it just checks that it doesn't use expressions), it caches the associated `svg::path_attributes`. Then the `svg::path_attributes` contain a vector of images associated with that marker (the same marker rendered with `sampling_rate` (8) precision).

This PR comes from the [Carto fork](https://github.com/CartoDB/mapnik). Apart from some minor changes, there we also have metrics and a flag to enable or disable it per map (currently it's always on).

Main drawbacks I see:
* Breaks `const` since the cached is held internally (in the attributes and the symbolizer). We tried having a global cache (as with the marker_cache singleton) but it required to be pretty big (thousands of images) and to use synchronization (mutexes for multithread support) and it'd still work poorly in high contention scenarios. Also, having it associated with the symbolizer means that when the it disappears so do the associated images (no need to hack around a LRU policy).
* Some subpixel changes (check failed tests).
* The `symbolizer` variant grows in size. I haven't seen anywhere something like an array of thousands of symbolizers, so it shouldn't have any impact.

Main benefits:
* Faster rendering. Here are some measurements from our fork (Response time for the complete stack) requesting tiles with N points with the same style: [cache_off_vs_cache_on.pdf](https://github.com/mapnik/mapnik/files/2026900/cache_off_vs_cache_on.pdf)


Please let me know of any comments or improvements that could be made to have this accepted.
