### PR TITLE
Improve padding calculation

### DIFF
--- a/include/mapnik/offset_converter.hpp
+++ b/include/mapnik/offset_converter.hpp
@@ -40,6 +40,8 @@
 namespace mapnik
 {
 
+static constexpr double offset_converter_default_threshold = 5.0;
+
 template <typename Geometry>
 struct offset_converter
 {
@@ -48,7 +50,7 @@ struct offset_converter
     offset_converter(Geometry & geom)
         : geom_(geom)
         , offset_(0.0)
-        , threshold_(5.0)
+        , threshold_(offset_converter_default_threshold)
         , half_turn_segments_(16)
         , status_(initial)
         , pre_first_(vertex2d::no_init)

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -132,12 +132,11 @@ private:
         box2d<double> clip_box = clipping_extent(common_);
         if (clip)
         {
-            double padding = (double)(common_.query_extent_.width() / common_.width_);
-            if (half_stroke > 1)
-                padding *= half_stroke;
-            if (std::fabs(offset) > 0)
-                padding *= std::fabs(offset) * 1.2;
-            padding *= common_.scale_factor_;
+            double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+            double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                              (std::fabs(offset) * offset_converter_default_threshold)));
+            double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
             clip_box.pad(padding);
         }
         using vertex_converter_type = vertex_converter<clip_line_tag, transform_tag,

--- a/src/agg/process_line_symbolizer.cpp
+++ b/src/agg/process_line_symbolizer.cpp
@@ -140,23 +140,12 @@ void agg_renderer<T0,T1>::process(line_symbolizer const& sym,
     line_rasterizer_enum rasterizer_e = get<line_rasterizer_enum, keys::line_rasterizer>(sym, feature, common_.vars_);
     if (clip)
     {
-        double padding = static_cast<double>(common_.query_extent_.width() / common_.width_);
-        double half_stroke = 0.5 * width;
-        if (half_stroke > 1)
-        {
-            padding *= half_stroke;
-        }
-        if (std::fabs(offset) > 0)
-        {
-            padding *= std::fabs(offset) * 1.2;
-        }
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
 
-        padding *= common_.scale_factor_;
         clip_box.pad(padding);
-        // debugging
-        //box2d<double> inverse = query_extent_;
-        //inverse.pad(-padding);
-        //draw_geo_extent(inverse,mapnik::color("red"));
     }
 
     if (rasterizer_e == RASTERIZER_FAST)

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -133,13 +133,11 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/common_.width_);
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
 

--- a/src/cairo/process_line_symbolizer.cpp
+++ b/src/cairo/process_line_symbolizer.cpp
@@ -73,13 +73,11 @@ void cairo_renderer<T>::process(line_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/common_.width_);
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
     using vertex_converter_type =  vertex_converter<clip_line_tag,

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -97,13 +97,11 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/pixmap_.width());
-        double half_stroke = stroke_width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(stroke_width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
 

--- a/src/grid/process_line_symbolizer.cpp
+++ b/src/grid/process_line_symbolizer.cpp
@@ -84,13 +84,11 @@ void grid_renderer<T>::process(line_symbolizer const& sym,
 
     if (clip)
     {
-        double padding = (double)(common_.query_extent_.width()/pixmap_.width());
-        double half_stroke = width/2.0;
-        if (half_stroke > 1)
-            padding *= half_stroke;
-        if (std::fabs(offset) > 0)
-            padding *= std::fabs(offset) * 1.2;
-        padding *= common_.scale_factor_;
+        double pad_per_pixel = static_cast<double>(common_.query_extent_.width()/common_.width_);
+        double pixels = std::ceil(std::max(width / 2.0 + std::fabs(offset),
+                                          (std::fabs(offset) * offset_converter_default_threshold)));
+        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+
         clipping_extent.pad(padding);
     }
     using vertex_converter_type = vertex_converter<clip_line_tag, clip_poly_tag, transform_tag,


### PR DESCRIPTION
Improve how the extra padding is calculated when clipping polygons and lines. This gets rid of the magical `padding *= std::fabs(offset) * 1.2;` but, since the offset converter relies in another magical number (`threshold_`) it has to reference that one to properly calculate the padding.

This fixes 2 main issues:
* An offseted tile border might be shown in the image under certain conditions.
* The offset of a polygon vertex might be omitted from the render if the distance from the internal vertex to the clipped size is too close (under the threshold limit).

These 2 examples show the changes (before and after): 
![image](https://user-images.githubusercontent.com/664253/41053225-40718b72-69bb-11e8-9085-26dc866dff78.png).

I don't see any noticeable performance impact (it varies depending if the formula increases or reduces the clip size): 
[pre_offset_fix_vs_post_offset_fix.pdf](https://github.com/mapnik/mapnik/files/2077317/pre_offset_fix_vs_post_offset_fix.pdf)

PR with the visual changes and a couple of extra tests: https://github.com/mapnik/test-data-visual/pull/68
