### PR TITLE
Only throw on duplicate styles in strict mode

### DIFF
--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -545,11 +545,25 @@ void map_parser::parse_style(Map & map, xml_node const& node)
 
         if (!map.insert_style(name, std::move(style)))
         {
-            if (strict_ && map.find_style(name))
+            boost::optional<const feature_type_style &> dupe = map.find_style(name);
+            if (strict_)
             {
-                throw config_error("duplicate style name");
+                if (dupe)
+                {
+                    throw config_error("duplicate style name");
+                }
+                throw config_error("failed to insert style to the map");
             }
-            throw config_error("failed to insert style to the map");
+            else
+            {
+                std::string s_err("failed to insert style '");
+                s_err += name + "' to the map";
+                if (dupe)
+                {
+                    s_err += " since it was already added";
+                }
+                MAPNIK_LOG_ERROR(load_map) << "map_parser: " << s_err;
+            }
         }
     }
     catch (config_error const& ex)

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -545,7 +545,7 @@ void map_parser::parse_style(Map & map, xml_node const& node)
 
         if (!map.insert_style(name, std::move(style)))
         {
-            if (map.find_style(name))
+            if (strict_ && map.find_style(name))
             {
                 throw config_error("duplicate style name");
             }

--- a/test/standalone/map_xml_test.cpp
+++ b/test/standalone/map_xml_test.cpp
@@ -156,6 +156,20 @@ TEST_CASE("map xml I/O") {
         }
     } // END SECTION
 
+    SECTION("duplicate styles only throw in strict mode") {
+        std::vector<bfs::path> broken_maps;
+        add_xml_files("test/data/broken_maps", broken_maps);
+        std::string duplicate_stylename("test/data/broken_maps/duplicate_stylename.xml");
+        CAPTURE(duplicate_stylename);
+
+        mapnik::Map m(256, 256);
+        REQUIRE(m.register_fonts("fonts", true));
+        REQUIRE_NOTHROW(mapnik::load_map(m, duplicate_stylename, false));
+        mapnik::Map m2(256, 256);
+        REQUIRE(m2.register_fonts("fonts", true));
+        REQUIRE_THROWS(mapnik::load_map(m2, duplicate_stylename, true));
+    } // END SECTION
+
     SECTION("broken maps") {
         std::vector<bfs::path> broken_maps;
         add_xml_files("test/data/broken_maps", broken_maps);

--- a/test/standalone/map_xml_test.cpp
+++ b/test/standalone/map_xml_test.cpp
@@ -157,11 +157,8 @@ TEST_CASE("map xml I/O") {
     } // END SECTION
 
     SECTION("duplicate styles only throw in strict mode") {
-        std::vector<bfs::path> broken_maps;
-        add_xml_files("test/data/broken_maps", broken_maps);
         std::string duplicate_stylename("test/data/broken_maps/duplicate_stylename.xml");
         CAPTURE(duplicate_stylename);
-
         mapnik::Map m(256, 256);
         REQUIRE(m.register_fonts("fonts", true));
         REQUIRE_NOTHROW(mapnik::load_map(m, duplicate_stylename, false));


### PR DESCRIPTION
#3770 added a throw on duplicate styles. I hit this in a system which I need back compatibility (can't easily avoid duplicate styles names). So, I think this check should only happen in strict mode. 

/cc @talaj - sound good? One question I have is that I would assume this change would make the tests fail that you added in #3770 (unless the tests are put in strict mode). Any idea why they don't fail with this change as is? 