### PR TITLE
Sconf TryAction replacement

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -760,6 +760,8 @@ def ogr_enabled(context):
     context.Message( 'Checking if gdal is ogr enabled... ')
     context.sconf.cached = False
     ret, out = config_command(env['GDAL_CONFIG'], '--ogr-enabled')
+    if ret and out:
+        ret = (out == 'yes')
     if not ret:
         if 'ogr' not in env['SKIPPED_DEPS']:
             env['SKIPPED_DEPS'].append('ogr')


### PR DESCRIPTION
Closes #3918

Our configure tests use `context.TryAction("shell command")` to invoke `pkg-config, pg-config, etc.`. The `shell command` there MUST overwrite file `$TARGET`. If a `TryAction` succeeds without overwriting `$TARGET`, the file may still exist and likely be a binary compiled from a different test. This is because every `context.TryBuild` (which all of the `Try*` methods end up calling) generates a filename of the form `.sconf_temp/conftest_NN` for `$TARGET` and expects the action to update that file. When the order of checks in SConstruct changes, the NN sequence changes as well, and so checks get assigned different target files.

I've considered fixing those actions by redirecting output to `> $TARGET`. But all the conftest caching machinery seems unnecessary for the simple, quick checks that `pkg-config` and the likes perform.

So I instead decided to circumvent the sconf caching mechanism and invoke the command directly via `subprocess.Popen`. There was already a function in SConstruct named `call` which was *almost* usable for that purpose, but didn't return the exit status and didn't write errors to `config.log`. As the new `config_command` function can fulfil what `call(..., silent=True)` did, and the only two occurrences of `call(..., silent=False)` were with `pg-config`, where a failure will be reported among disabled optional dependencies anyway, I replaced `call` with `config_command` everywhere.

I haven't tested the python 3 paths, though. I'm still running with python2.7 as the default, and python3.4 which scons refuses to run with (3.5+ they say).
