### PR TITLE
scons configure cleanup

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -812,7 +812,7 @@ def CheckIcuData(context, silent=False):
 
     if not silent:
         context.Message('Checking for ICU data directory...')
-    ret = context.TryRun("""
+    ret, out = context.TryRun("""
 
 #include <unicode/putil.h>
 #include <iostream>
@@ -829,9 +829,10 @@ int main() {
 """, '.cpp')
     if silent:
         context.did_show_result=1
-    if ret[0]:
-        context.Result('u_getDataDirectory returned %s' % ret[1])
-        return ret[1].strip()
+    if ret:
+        value = out.strip()
+        context.Result('u_getDataDirectory returned %s' % value)
+        return value
     else:
         ret = call("icu-config --icudatadir", silent=True)
         if ret:
@@ -845,8 +846,8 @@ int main() {
 def CheckGdalData(context, silent=False):
 
     if not silent:
-        context.Message('Checking for GDAL data directory...')
-    ret = context.TryRun("""
+        context.Message('Checking for GDAL data directory... ')
+    ret, out = context.TryRun("""
 
 #include "cpl_config.h"
 #include <iostream>
@@ -857,19 +858,20 @@ int main() {
 }
 
 """, '.cpp')
+    value = out.strip()
     if silent:
         context.did_show_result=1
-    if ret[0]:
-        context.Result('GDAL_PREFIX returned %s' % ret[1])
+    if ret:
+        context.Result('GDAL_PREFIX returned %s' % value)
     else:
         context.Result('Failed to detect (mapnik-config will have null value)')
-    return ret[1].strip()
+    return value
 
 def CheckProjData(context, silent=False):
 
     if not silent:
         context.Message('Checking for PROJ_LIB directory...')
-    ret = context.TryRun("""
+    ret, out = context.TryRun("""
 
 // This is narly, could eventually be replaced using https://github.com/OSGeo/proj.4/pull/551]
 #include <proj_api.h>
@@ -919,20 +921,21 @@ int main() {
 }
 
 """, '.cpp')
+    value = out.strip()
     if silent:
         context.did_show_result=1
-    if ret[0]:
-        context.Result('pj_open_lib returned %s' % ret[1])
+    if ret:
+        context.Result('pj_open_lib returned %s' % value)
     else:
         context.Result('Failed to detect (mapnik-config will have null value)')
-    return ret[1].strip()
+    return value
 
 def CheckCairoHasFreetype(context, silent=False):
     if not silent:
         context.Message('Checking for cairo freetype font support ... ')
     context.env.AppendUnique(CPPPATH=copy(env['CAIRO_CPPPATHS']))
 
-    ret = context.TryRun("""
+    ret, out = context.TryRun("""
 
 #include <cairo-features.h>
 
@@ -945,7 +948,7 @@ int main()
     #endif
 }
 
-""", '.cpp')[0]
+""", '.cpp')
     if silent:
         context.did_show_result=1
     context.Result(ret)
@@ -972,7 +975,7 @@ int main()
     return ret
 
 def GetBoostLibVersion(context):
-    ret = context.TryRun("""
+    ret, out = context.TryRun("""
 
 #include <boost/version.hpp>
 #include <iostream>
@@ -987,8 +990,8 @@ return 0;
 """, '.cpp')
     # hack to avoid printed output
     context.did_show_result=1
-    context.Result(ret[0])
-    return ret[1].strip()
+    context.Result(ret)
+    return out.strip()
 
 def CheckBoostScopedEnum(context, silent=False):
     if not silent:
@@ -1089,7 +1092,8 @@ def boost_regex_has_icu(context):
             if lib_name in context.env['LIBS']:
                 context.env['LIBS'].remove(lib_name)
             context.env.Append(LIBS=lib_name)
-    ret = context.TryRun("""
+    context.Message('Checking if boost_regex was built with ICU unicode support... ')
+    ret, out = context.TryRun("""
 
 #include <boost/regex/icu.hpp>
 #include <unicode/unistr.h>
@@ -1109,11 +1113,8 @@ int main()
 }
 
 """, '.cpp')
-    context.Message('Checking if boost_regex was built with ICU unicode support... ')
-    context.Result(ret[0])
-    if ret[0]:
-        return True
-    return False
+    context.Result(ret)
+    return ret
 
 def sqlite_has_rtree(context, silent=False):
     """ check an sqlite3 install has rtree support.
@@ -1122,7 +1123,9 @@ def sqlite_has_rtree(context, silent=False):
     http://www.sqlite.org/c3ref/compileoption_get.html
     """
 
-    ret = context.TryRun("""
+    if not silent:
+        context.Message('Checking if SQLite supports RTREE... ')
+    ret, out = context.TryRun("""
 
 #include <sqlite3.h>
 #include <stdio.h>
@@ -1154,17 +1157,15 @@ int main()
 }
 
 """, '.c')
-    if not silent:
-        context.Message('Checking if SQLite supports RTREE... ')
     if silent:
         context.did_show_result=1
-    context.Result(ret[0])
-    if ret[0]:
-        return True
-    return False
+    context.Result(ret)
+    return ret
 
 def supports_cxx14(context,silent=False):
-    ret = context.TryRun("""
+    if not silent:
+        context.Message('Checking if compiler (%s) supports -std=c++14 flag... ' % context.env.get('CXX','CXX'))
+    ret, out = context.TryRun("""
 
 int main()
 {
@@ -1176,14 +1177,10 @@ int main()
 }
 
 """, '.cpp')
-    if not silent:
-        context.Message('Checking if compiler (%s) supports -std=c++14 flag... ' % context.env.get('CXX','CXX'))
     if silent:
         context.did_show_result=1
-    context.Result(ret[0])
-    if ret[0]:
-        return True
-    return False
+    context.Result(ret)
+    return ret
 
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -188,13 +188,6 @@ def create_uninstall_target(env, path, is_glob=False):
                 ])
                 env.Alias("uninstall", "uninstall-"+path)
 
-def shortest_name(libs):
-    name = '-'*200
-    for lib in libs:
-        if len(name) > len(lib):
-            name = lib
-    return name
-
 def rm_path(item,set,_env):
     for i in _env[set]:
         if i.startswith(item):
@@ -726,7 +719,7 @@ def FindBoost(context, prefixes, thread_flag):
         if len(libItems) >= 1 and len(incItems) >= 1:
             BOOST_LIB_DIR = os.path.dirname(libItems[0])
             BOOST_INCLUDE_DIR = incItems[0].rstrip('boost/')
-            shortest_lib_name = shortest_name(libItems)
+            shortest_lib_name = min(libItems, key=len)
             match = re.search(r'%s(.*)\..*' % search_lib, shortest_lib_name)
             if hasattr(match,'groups'):
                 BOOST_APPEND = match.groups()[0]

--- a/SConstruct
+++ b/SConstruct
@@ -491,6 +491,12 @@ for opt in opts.options:
     if opt.key not in pickle_store:
         pickle_store.append(opt.key)
 
+def rollback_option(env, variable):
+    global opts
+    for item in opts.options:
+        if item.key == variable:
+            env[variable] = item.default
+
 # Method of adding configure behavior to Scons adapted from:
 # http://freeorion.svn.sourceforge.net/svnroot/freeorion/trunk/FreeOrion/SConstruct
 preconfigured = False
@@ -631,7 +637,7 @@ def parse_config(context, config, checks='--libs --cflags'):
             # optional deps...
             if tool not in env['SKIPPED_DEPS']:
                 env['SKIPPED_DEPS'].append(tool)
-            conf.rollback_option(config)
+            rollback_option(env, config)
         else: # freetype and libxml2, not optional
             if tool not in env['MISSING_DEPS']:
                 env['MISSING_DEPS'].append(tool)
@@ -681,7 +687,7 @@ def parse_pg_config(context, config):
         env.Append(LIBS = lpq)
     else:
         env['SKIPPED_DEPS'].append(tool)
-        conf.rollback_option(config)
+        rollback_option(env, config)
     context.Result( ret )
     return ret
 
@@ -694,13 +700,6 @@ def ogr_enabled(context):
             env['SKIPPED_DEPS'].append('ogr')
     context.Result( ret )
     return ret
-
-def rollback_option(context,variable):
-    global opts
-    env = context.env
-    for item in opts.options:
-        if item.key == variable:
-            env[variable] = item.default
 
 def FindBoost(context, prefixes, thread_flag):
     """Routine to auto-find boost header dir, lib dir, and library naming structure.
@@ -1200,7 +1199,6 @@ conf_tests = { 'prioritize_paths'      : prioritize_paths,
                'parse_pg_config'       : parse_pg_config,
                'ogr_enabled'           : ogr_enabled,
                'get_pkg_lib'           : get_pkg_lib,
-               'rollback_option'       : rollback_option,
                'icu_at_least'          : icu_at_least,
                'harfbuzz_version'      : harfbuzz_version,
                'harfbuzz_with_freetype_support': harfbuzz_with_freetype_support,


### PR DESCRIPTION
This fixes a bunch of issues with conftests.

- consistently call `context.Message` before `context.TryRun`
  many conftests called these in reverse order, making`config.py` difficult to follow because sometimes the "Checking feature... " line came before the C source that's checking it, sometimes after
- remove "hacks to avoid printed output"
  I get the idea, `context.did_show_result=1` to replace dull `context.Result` output with fancy `color_print`. That's nice when everything works, but isn't very helpful when something's wrong -- you have to piece together output from terminal and `config.log` because the log is incomplete
- slightly improve HarfBuzz and ICU checks
- change `rollback_option` conftest, which isn't a proper conftest, into a regular global function

- consistently unpack `context.TryRun` result tuple, like so
    ```py
    ret, out = context.TryRun(...)
    ```
  In most places `ret = context.TryRun(...)` was the whole tuple, and in one place `ret = context.TryRun(...)[0]` was just the result status. It's better to be consistent and I think naming the two parts of the return value is clearer than using `ret[0], ret[1]`.
