### PR TITLE
postgis: always put decimal point in substituted tokens in SQL

### DIFF
--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -49,7 +49,6 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
-#include <iomanip>
 
 DATASOURCE_PLUGIN(pgraster_datasource)
 
@@ -598,6 +597,7 @@ layer_descriptor pgraster_datasource::get_descriptor() const
 std::string pgraster_datasource::sql_bbox(box2d<double> const& env) const
 {
     std::ostringstream b;
+    b.precision(16);
 
     if (srid_ > 0)
     {
@@ -605,7 +605,6 @@ std::string pgraster_datasource::sql_bbox(box2d<double> const& env) const
     }
 
     b << "'BOX(";
-    b << std::setprecision(16);
     b << env.minx() << " " << env.miny() << ",";
     b << env.maxx() << " " << env.maxy() << ")'::box2d";
 
@@ -636,6 +635,9 @@ std::string pgraster_datasource::populate_tokens(std::string const& sql,
     std::cmatch m;
     char const* start = sql.data();
     char const* end = start + sql.size();
+
+    populated_sql.precision(16);
+    populated_sql << std::showpoint;
 
     while (std::regex_search(start, end, m, re_tokens_))
     {

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -47,7 +47,6 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
-#include <iomanip>
 
 DATASOURCE_PLUGIN(postgis_datasource)
 
@@ -508,6 +507,7 @@ layer_descriptor postgis_datasource::get_descriptor() const
 std::string postgis_datasource::sql_bbox(box2d<double> const& env) const
 {
     std::ostringstream b;
+    b.precision(16);
 
     if (srid_ > 0)
     {
@@ -515,7 +515,6 @@ std::string postgis_datasource::sql_bbox(box2d<double> const& env) const
     }
 
     b << "'BOX3D(";
-    b << std::setprecision(16);
     b << env.minx() << " " << env.miny() << ",";
     b << env.maxx() << " " << env.maxy() << ")'::box3d";
 
@@ -547,6 +546,9 @@ std::string postgis_datasource::populate_tokens(
     std::cmatch m;
     char const* start = sql.data();
     char const* end = start + sql.size();
+
+    populated_sql.precision(16);
+    populated_sql << std::showpoint;
 
     while (std::regex_search(start, end, m, re_tokens_))
     {

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -290,6 +290,26 @@ TEST_CASE("postgis") {
             REQUIRE(ext.maxy() == 4);
         }
 
+        SECTION("Postgis substitutes numeric !tokens! always with decimal point")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "(SELECT geom,"
+                                     " pg_typeof(!pixel_width!)::text as t_pixel_width,"
+                                     " pg_typeof(!pixel_height!)::text as t_pixel_height,"
+                                     " pg_typeof(!scale_denominator!)::text as t_scale_denom"
+                              " FROM public.test LIMIT 1) as data";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+            auto featureset = all_features(ds);
+            auto feature = featureset->next();
+            CHECKED_IF(feature != nullptr)
+            {
+                CHECK(feature->get("t_pixel_width").to_string() == "numeric");
+                CHECK(feature->get("t_pixel_height").to_string() == "numeric");
+                CHECK(feature->get("t_scale_denom").to_string() == "numeric");
+            }
+        }
+
         SECTION("Postgis doesn't interpret @domain in email address as @variable")
         {
             mapnik::parameters params(base_params);


### PR DESCRIPTION
Closes #2361 

Also increases precision of substituted numbers to 16 decimal digits (that's roughly the limit of `double`).
