### PR TITLE
WIP: gdal: Remove special logic for finding overviews.

### DIFF
--- a/plugins/input/gdal/gdal_featureset.hpp
+++ b/plugins/input/gdal/gdal_featureset.hpp
@@ -72,12 +72,6 @@ public:
     mapnik::feature_ptr next();
 
 private:
-    void find_best_overview(int bandNumber,
-                            int ideal_width,
-                            int ideal_height,
-                            int & current_width,
-                            int & current_height) const;
-
     mapnik::feature_ptr get_feature(mapnik::query const& q);
     mapnik::feature_ptr get_feature_at_point(mapnik::coord2d const& p);
     GDALDataset & dataset_;


### PR DESCRIPTION
Trying to fix https://github.com/mapnik/mapnik/issues/3966

Current status:

We now send the correct image extent to gdal when reading so that resampling and overview selection is done by gdal.

This solves my original problem but does not implement https://github.com/mapnik/mapnik/issues/3966#issuecomment-412839250

So if https://github.com/mapnik/mapnik/issues/3966#issuecomment-412839250 should also be implemented here I will need some guidance of where to get information about the resampling method and the warnings we should emit.