### PR TITLE
[WIP] experimental Spirit X3 hacks

### DIFF
--- a/include/mapnik/json/topojson_grammar_x3.hpp
+++ b/include/mapnik/json/topojson_grammar_x3.hpp
@@ -25,24 +25,21 @@
 
 // mapnik
 #include <mapnik/json/topology.hpp>
+#include <mapnik/util/spirit_rule.hpp>
 
-#pragma GCC diagnostic push
-#include <mapnik/warning_ignore.hpp>
-#include <boost/spirit/home/x3.hpp>
-#pragma GCC diagnostic pop
+namespace mapnik { namespace topojson { namespace grammar {
 
-namespace mapnik { namespace json { namespace grammar {
+MAPNIK_SPIRIT_EXTERN_RULE(start_rule, topojson::topology);
 
-namespace x3 = boost::spirit::x3;
+}}} // namespace mapnik::topojson::grammar
 
-using topojson_grammar_type = x3::rule<class topojson_rule_tag, topojson::topology>;
+namespace mapnik { namespace json {
 
-BOOST_SPIRIT_DECLARE(topojson_grammar_type);
-
+inline auto topojson_grammar()
+{
+    return topojson::grammar::start_rule;
 }
 
-grammar::topojson_grammar_type const& topojson_grammar();
-
-}}
+}} // namespace mapnik::json
 
 #endif //MAPNIK_TOPOJSON_GRAMMAR_X3_HPP

--- a/include/mapnik/json/topojson_grammar_x3_def.hpp
+++ b/include/mapnik/json/topojson_grammar_x3_def.hpp
@@ -42,7 +42,7 @@ BOOST_FUSION_ADAPT_STRUCT(
 
 BOOST_FUSION_ADAPT_STRUCT(
     mapnik::topojson::arc,
-    (std::list<mapnik::topojson::coordinate>, coordinates)
+    (mapnik::topojson::position_array, coordinates)
     )
 
 BOOST_FUSION_ADAPT_STRUCT(
@@ -63,7 +63,6 @@ BOOST_FUSION_ADAPT_STRUCT(
 
 namespace mapnik { namespace json { namespace grammar {
 
-using index_type = topojson::index_type;
 struct create_point
 {
     using result_type = mapnik::topojson::point;
@@ -88,10 +87,10 @@ struct create_multi_point
     result_type operator()(T0 & coords, T1 & props) const
     {
         mapnik::topojson::multi_point mpt;
-        if (coords.template is<std::vector<mapnik::topojson::coordinate>>())
+        if (coords.template is<topojson::position_array>())
         {
-            auto const& points = coords.template get<std::vector<mapnik::topojson::coordinate>>();
-            mpt. points = points;
+            auto const& points = coords.template get<topojson::position_array>();
+            mpt.points = points;
             mpt.props = props;
         }
         return mpt;
@@ -105,10 +104,10 @@ struct create_line_string
     result_type operator()(T0 & arcs, T1 & props) const
     {
         mapnik::topojson::linestring line;
-        if (arcs.template is<std::vector<index_type>>())
+        if (arcs.template is<topojson::index_array>())
         {
-            auto const& arcs_ = arcs.template get<std::vector<index_type>>();
-            line.rings = arcs_;
+            auto const& arcs_ = arcs.template get<topojson::index_array>();
+            line.arcs = arcs_;
             line.props = props;
         }
         return line;
@@ -122,9 +121,9 @@ struct create_multi_line_string
     result_type operator()(T0 & arcs, T1 & props) const
     {
         mapnik::topojson::multi_linestring mline;
-        if (arcs.template is<std::vector<std::vector<index_type>>>())
+        if (arcs.template is<topojson::index_array2>())
         {
-            auto const& arcs_ = arcs.template get<std::vector<std::vector<index_type>>>();
+            auto const& arcs_ = arcs.template get<topojson::index_array2>();
             mline.lines = arcs_;
             mline.props = props;
         }
@@ -139,9 +138,9 @@ struct create_polygon
     result_type operator()(T0 & arcs, T1 & props) const
     {
         mapnik::topojson::polygon poly;
-        if (arcs.template is<std::vector<std::vector<index_type>>>())
+        if (arcs.template is<topojson::index_array2>())
         {
-            auto const& arcs_ = arcs.template get<std::vector<std::vector<index_type>>>();
+            auto const& arcs_ = arcs.template get<topojson::index_array2>();
             poly.rings = arcs_;
             poly.props = props;
         }
@@ -156,9 +155,9 @@ struct create_multi_polygon
     result_type operator()(T0 & arcs, T1 & props) const
     {
         mapnik::topojson::multi_polygon mpoly;
-        if (arcs.template is<std::vector<std::vector<std::vector<index_type>>>>())
+        if (arcs.template is<topojson::index_array3>())
         {
-            auto const& arcs_ = arcs.template get<std::vector<std::vector<std::vector<index_type>>>>();
+            auto const& arcs_ = arcs.template get<topojson::index_array3>();
             mpoly.polygons = arcs_;
             mpoly.props = props;
         }
@@ -285,10 +284,13 @@ auto const& json_string = json::unicode_string_grammar();
 auto const& json_value = json::generic_json_grammar();
 }
 
-using coordinates_type = util::variant<topojson::coordinate,std::vector<topojson::coordinate>>;
-using arcs_type = util::variant<std::vector<index_type>,
-                                std::vector<std::vector<index_type>>,
-                                std::vector<std::vector<std::vector<index_type>>>>;
+using coordinates_type = util::variant<topojson::coordinate,
+                                       topojson::position_array>;
+
+using arcs_type = util::variant<topojson::empty,
+                                topojson::index_array,
+                                topojson::index_array2,
+                                topojson::index_array3>;
 
 struct topojson_geometry_type_ : x3::symbols<int>
 {
@@ -324,8 +326,8 @@ x3::rule<class coordinate_tag, mapnik::topojson::coordinate> const coordinate = 
 x3::rule<class coordinates_tag, coordinates_type> const coordinates = "Coordinates";
 x3::rule<class arc_tag, mapnik::topojson::arc> const arc = "Arc";
 x3::rule<class arcs_tag, std::vector<mapnik::topojson::arc>> const arcs = "Arcs";
-x3::rule<class ring_type, std::vector<index_type>> const ring = "Ring";
-x3::rule<class rings_type, std::vector<std::vector<index_type>>> const rings = "Rings";
+x3::rule<class ring_type, topojson::index_array> const ring = "Ring";
+x3::rule<class rings_type, topojson::index_array2> const rings = "Rings";
 x3::rule<class rings_array_type, arcs_type> const rings_array = "Rings Array";
 
 // defs

--- a/include/mapnik/json/topojson_utils.hpp
+++ b/include/mapnik/json/topojson_utils.hpp
@@ -90,7 +90,7 @@ struct bounding_box_visitor
         bool first = true;
         if (num_arcs_ > 0)
         {
-            for (auto index : line.rings)
+            for (auto index : line.arcs)
             {
                 index_type arc_index = index < 0 ? std::abs(index) - 1 : index;
                 if (arc_index >= 0 && arc_index < static_cast<int>(num_arcs_))
@@ -327,7 +327,7 @@ struct feature_generator
         {
             mapnik::geometry::line_string<double> line_string;
 
-            for (auto index : line.rings)
+            for (auto index : line.arcs)
             {
                 index_type arc_index = index < 0 ? std::abs(index) - 1 : index;
                 if (arc_index >= 0 && arc_index < static_cast<int>(num_arcs_))

--- a/include/mapnik/json/topology.hpp
+++ b/include/mapnik/json/topology.hpp
@@ -20,8 +20,8 @@
  *
  *****************************************************************************/
 
-#ifndef MAPNIK_TOPOLOGY_HPP
-#define MAPNIK_TOPOLOGY_HPP
+#ifndef MAPNIK_JSON_TOPOLOGY_HPP
+#define MAPNIK_JSON_TOPOLOGY_HPP
 
 #include <mapnik/json/json_value.hpp>
 #include <mapnik/util/variant.hpp>
@@ -33,11 +33,13 @@
 
 #include <tuple>
 #include <vector>
-#include <list>
 
 namespace mapnik { namespace topojson {
 
 using index_type = int;
+using index_array = std::vector<index_type>;
+using index_array2 = std::vector<index_array>;
+using index_array3 = std::vector<index_array2>;
 
 struct coordinate
 {
@@ -45,7 +47,9 @@ struct coordinate
     double y;
 };
 
-using property = std::tuple<std::string, json::json_value >;
+using position_array = std::vector<coordinate>;
+
+using property = std::tuple<std::string, json::json_value>;
 using properties = std::vector<property>;
 
 struct point
@@ -56,31 +60,31 @@ struct point
 
 struct multi_point
 {
-    std::vector<coordinate> points;
+    position_array points;
     boost::optional<properties> props;
 };
 
 struct linestring
 {
-    std::vector<index_type> rings ;
+    index_array arcs;
     boost::optional<properties> props;
 };
 
 struct multi_linestring
 {
-    std::vector<std::vector<index_type> > lines;
+    index_array2 lines;
     boost::optional<properties> props;
 };
 
 struct polygon
 {
-    std::vector<std::vector<index_type> > rings;
+    index_array2 rings;
     boost::optional<properties> props;
 };
 
 struct multi_polygon
 {
-    std::vector<std::vector<std::vector<index_type> > > polygons;
+    index_array3 polygons;
     boost::optional<properties> props;
 };
 
@@ -98,7 +102,7 @@ using pair_type = std::tuple<double,double>;
 
 struct arc
 {
-    std::list<coordinate> coordinates;
+    position_array coordinates;
 };
 
 struct transform
@@ -127,4 +131,4 @@ struct topology
 
 }}
 
-#endif // MAPNIK_TOPOLOGY_HPP
+#endif // MAPNIK_JSON_TOPOLOGY_HPP

--- a/include/mapnik/util/spirit_rule.hpp
+++ b/include/mapnik/util/spirit_rule.hpp
@@ -1,0 +1,214 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2018 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_UTIL_SPIRIT_RULE_HPP
+#define MAPNIK_UTIL_SPIRIT_RULE_HPP
+
+#pragma GCC diagnostic push
+#include <mapnik/warning_ignore.hpp>
+#include <boost/spirit/home/x3.hpp>
+#pragma GCC diagnostic pop
+
+namespace mapnik { namespace util { namespace spirit {
+
+namespace x3 = boost::spirit::x3;
+
+using x3::operator |    ; // alternative
+using x3::operator &    ; // and predicate
+using x3::operator !    ; // not predicate
+using x3::operator *    ; // kleene star
+using x3::operator +    ; // one or more
+using x3::operator -    ; // difference, optional
+using x3::operator %    ; // list
+using x3::operator >    ; // expectation
+using x3::operator >>   ; // sequence
+
+template <typename T>
+struct actual_attribute_type
+{
+    using type = T;
+};
+
+template <>
+struct actual_attribute_type<x3::unused_type>
+{
+    using type = x3::unused_type const;
+};
+
+// We need ADL to find the `parse_rule` function template defined here.
+// Had we used `x3::rule<TagName, Attribute>`, this namespace would not
+// be considered. One method to get the attention of ADL is wrapping
+// the TagName in a class template declared here (need not be defined).
+// Hence we use `x3::rule<id<TagName>, Attribute>`.
+template <typename TagName>
+struct id;
+
+template <typename TagName>
+struct rule_proxy
+{
+    using base_type = rule_proxy<TagName>;
+    using type = TagName;
+
+    template <typename T = x3::unused_type>
+    using actual_attribute_t = typename actual_attribute_type<T>::type;
+
+    template <typename T = x3::unused_type>
+    using proxy_attribute_t = T;
+
+    template <typename... Attribute>
+    using proxy_rule_t = x3::rule<id<TagName>, Attribute...>;
+
+    // subscript operator cannot be non-member
+    template <typename Action>
+    decltype(auto)
+    operator[] (Action func) const
+    {
+        return as_spirit_parser(*this)[func];
+    }
+
+    // constexpr constructor ensures that non-local instances are
+    // initialized before use (even from another translation unit)
+    constexpr rule_proxy(char const* name_)
+        : name(name_) {}
+
+    char const* name;
+};
+
+template <typename TagName>
+typename TagName::rule_type
+as_spirit_parser(rule_proxy<TagName> const& rule)
+{
+    return { rule.name };
+}
+
+// Spirit functions keep fully spelling out x3::rule<ID, Attribute>.
+// This alias template hides the ID wrapper and Attribute parameter
+// to make error messages inside `parse_rule` a bit shorter.
+template <typename TagName>
+using rule_t = x3::rule<id<TagName>, typename TagName::attribute_type>;
+
+template <typename TagName, typename Iterator,
+          typename Context, typename ActualAttribute>
+bool parse_rule(rule_t<TagName> rule,
+                Iterator & first, Iterator const& last,
+                Context const& ctx, ActualAttribute & attr)
+{
+    // "error: no member named 'parse' in 'TagName'" pointing on the
+    // next line means MAPNIK_SPIRIT_RULE(TagName) was used without
+    // subsequent MAPNIK_SPIRIT_RULE_DEF(TagName) = expression;
+    // the trailing comment should be included in the error message
+    return TagName::def(rule).parse // ~~~~~~ missing MAPNIK_SPIRIT_RULE_DEF ~~~~~~
+           (first, last, ctx, x3::unused, attr);
+}
+
+}}} // namespace mapnik::util::spirit
+
+///     MAPNIK_SPIRIT_RULE(Name, Attribute = unused_type)
+#define MAPNIK_SPIRIT_RULE(Name, ...)                               \
+        template <typename TagName>                                 \
+        extern TagName _rule_def_;                                  \
+        /* the implicit specialization of _rule_def_<T> serves   */ \
+        /* only to catch errors, the variable is not defined     */ \
+        struct Name : mapnik::util::spirit::rule_proxy<Name>        \
+        {                                                           \
+            static Name const proxy;   /* holds rule name string */ \
+                                                                    \
+            using actual_type = actual_attribute_t<__VA_ARGS__>;    \
+            using attribute_type = proxy_attribute_t<__VA_ARGS__>;  \
+            using rule_type = proxy_rule_t<__VA_ARGS__>;            \
+            using base_type::base_type;   /* inherit constructor */ \
+                                                                    \
+            template <typename TagName>                             \
+            static decltype(auto)                                   \
+            def(mapnik::util::spirit::rule_t<TagName>)              \
+            {                                                       \
+                return _rule_def_<TagName>;                         \
+            }                                                       \
+            /* in order to defer the instantiation of variable   */ \
+            /* template _rule_def_<T> until after its explicit   */ \
+            /* specialization, the getter cannot just tell the   */ \
+            /* compiler that T will be the Name defined hereby,  */ \
+            /* it must use an unknown template parameter         */ \
+        };                                                          \
+        /* `struct Name` is the type, `Name` is the variable     */ \
+        struct Name const Name = Name::proxy                        \
+        /* ; expected */
+
+///     MAPNIK_SPIRIT_RULE_DEF(Name) = parsing expression;
+#define MAPNIK_SPIRIT_RULE_DEF(Name)                                \
+        template <> auto const _rule_def_<struct Name>              \
+                               = as_spirit_parser(Name::proxy)      \
+        /***/
+
+///     MAPNIK_SPIRIT_RULE_NAME(TagName) = "Fancy rule name";
+#define MAPNIK_SPIRIT_RULE_NAME(TagName)                            \
+        struct TagName const TagName::proxy                         \
+        /***/
+
+///     MAPNIK_SPIRIT_LOCAL_RULE(TagName, Attribute = unused_type)
+#define MAPNIK_SPIRIT_LOCAL_RULE(TagName, ...)                      \
+        MAPNIK_SPIRIT_RULE(TagName, __VA_ARGS__);                   \
+        MAPNIK_SPIRIT_RULE_DEF(TagName)                             \
+        /* = parsing expression; expected */
+
+///     MAPNIK_SPIRIT_EXTERN_RULE(TagName, Attribute = unused_type)
+#define MAPNIK_SPIRIT_EXTERN_RULE(TagName, ...)                     \
+        MAPNIK_SPIRIT_RULE(TagName, __VA_ARGS__);                   \
+        MAPNIK_SPIRIT_declare_parse_rule_(~, ~, TagName)            \
+        /* ; expected */
+
+///     MAPNIK_SPIRIT_EXTERN_RULE_DEF(TagName)
+#define MAPNIK_SPIRIT_EXTERN_RULE_DEF(TagName)                      \
+        MAPNIK_SPIRIT_define_parse_rule_(~, ~, TagName)             \
+        MAPNIK_SPIRIT_RULE_DEF(TagName)                             \
+        /* = parsing expression; expected */
+
+///     MAPNIK_SPIRIT_INSTANTIATE(TagName, Iterator, Context)
+#define MAPNIK_SPIRIT_INSTANTIATE(TagName, Iterator, Context)               \
+        template bool parse_rule<Iterator, Context, TagName::actual_type>   \
+                                (TagName::rule_type rule,                   \
+                                 Iterator & first, Iterator const& last,    \
+                                 Context const& ctx,                        \
+                                 TagName::actual_type & attr)               \
+        /* ; expected */
+
+// The following two macros were originally intended to be called from
+// a variadic macro similar to BOOST_SPIRIT_DEFINE. In case this usage
+// needs to be re-introduced, I kept the two initial arguments that were
+// used by BOOST_PP_SEQ_FOR_EACH, although they're unused now.
+
+#define MAPNIK_SPIRIT_declare_parse_rule_(r, data, TagName)                 \
+        template <typename Iterator, typename Context, typename Attribute>  \
+        bool parse_rule(TagName::rule_type rule,                            \
+                        Iterator & first, Iterator const& last,             \
+                        Context const& ctx, Attribute & attr)               \
+        /***/
+
+#define MAPNIK_SPIRIT_define_parse_rule_(r, data, TagName)          \
+        MAPNIK_SPIRIT_declare_parse_rule_(r, data, TagName)         \
+        {                                                           \
+            return mapnik::util::spirit::parse_rule                 \
+                   (rule, first, last, ctx, attr);                  \
+        }                                                           \
+        /***/
+
+#endif // MAPNIK_UTIL_SPIRIT_RULE_HPP

--- a/src/json/topojson_grammar_x3.cpp
+++ b/src/json/topojson_grammar_x3.cpp
@@ -23,15 +23,30 @@
 #include <mapnik/json/json_grammar_config.hpp>
 #include <mapnik/json/topojson_grammar_x3_def.hpp>
 
-namespace mapnik { namespace json { namespace grammar {
+namespace mapnik { namespace topojson { namespace grammar {
 
-BOOST_SPIRIT_INSTANTIATE(topojson_grammar_type, iterator_type, phrase_parse_context_type);
+using json::grammar::iterator_type;
+using json::grammar::phrase_parse_context_type;
 
-}
+MAPNIK_SPIRIT_INSTANTIATE(start_rule, iterator_type, phrase_parse_context_type);
 
-grammar::topojson_grammar_type const& topojson_grammar()
-{
-    return grammar::topology;
-}
+MAPNIK_SPIRIT_RULE_NAME(arc) = "Arc";
+MAPNIK_SPIRIT_RULE_NAME(arcs) = "Arcs";
+MAPNIK_SPIRIT_RULE_NAME(bbox) = "Bounding box";
+MAPNIK_SPIRIT_RULE_NAME(empty_array) = "Empty array";
+MAPNIK_SPIRIT_RULE_NAME(geometry_collection) = "Geometry collection";
+MAPNIK_SPIRIT_RULE_NAME(geometry) = "Geometry object";
+MAPNIK_SPIRIT_RULE_NAME(geometry_tuple) = "Geometry tuple";
+MAPNIK_SPIRIT_RULE_NAME(line_indices) = "Array of Line/Ring arc indices";
+MAPNIK_SPIRIT_RULE_NAME(mpoly_indices) = "Array of MultiPolygon arc indices";
+MAPNIK_SPIRIT_RULE_NAME(objects) = "Objects";
+MAPNIK_SPIRIT_RULE_NAME(poly_indices) = "Array of MultiLine/Polygon arc indices";
+MAPNIK_SPIRIT_RULE_NAME(position) = "Position";
+MAPNIK_SPIRIT_RULE_NAME(positions) = "Array of positions";
+MAPNIK_SPIRIT_RULE_NAME(properties) = "Properties";
+MAPNIK_SPIRIT_RULE_NAME(property) = "Property";
+MAPNIK_SPIRIT_RULE_NAME(rings_array) = "Array of arc indices";
+MAPNIK_SPIRIT_RULE_NAME(start_rule) = "Topology";
+MAPNIK_SPIRIT_RULE_NAME(transform) = "Transform";
 
-}}
+}}}

--- a/test/unit/datasource/topojson.cpp
+++ b/test/unit/datasource/topojson.cpp
@@ -121,6 +121,63 @@ TEST_CASE("TopoJSON")
               )));
     }
 
+    SECTION("Empty MultiPoint")
+    {
+        mapnik::topojson::topology topo;
+        REQUIRE(parse_topology_string(HEREDOC(
+                {
+                    "type" : "Topology",
+                    "objects" : {
+                        "THING" : {
+                            "type" : "MultiPoint",
+                            "coordinates" : []
+                        }
+                    },
+                    "arcs" : []
+                }
+                ), topo));
+        REQUIRE(topo.geometries.size() == 1);
+        REQUIRE(topo.geometries.at(0).get<mapnik::topojson::multi_point>().points.empty());
+    }
+
+    SECTION("Empty MultiLineString")
+    {
+        mapnik::topojson::topology topo;
+        REQUIRE(parse_topology_string(HEREDOC(
+                {
+                    "type" : "Topology",
+                    "objects" : {
+                        "THING" : {
+                            "type" : "MultiLineString",
+                            "arcs" : []
+                        }
+                    },
+                    "arcs" : []
+                }
+                ), topo));
+        REQUIRE(topo.geometries.size() == 1);
+        REQUIRE(topo.geometries.at(0).get<mapnik::topojson::multi_linestring>().lines.empty());
+    }
+
+    SECTION("Empty MultiPolygon")
+    {
+        mapnik::topojson::topology topo;
+        REQUIRE(parse_topology_string(HEREDOC(
+                {
+                    "type" : "Topology",
+                    "objects" : {
+                        "THING" : {
+                            "type" : "MultiPolygon",
+                            "arcs" : []
+                        }
+                    },
+                    "arcs" : []
+                }
+                ), topo));
+        REQUIRE(topo.geometries.size() == 1);
+        REQUIRE(topo.geometries.at(0).get<mapnik::topojson::multi_polygon>().polygons.empty());
+    }
+
     SECTION("geometry parsing")
     {
         mapnik::value_integer feature_id = 0;


### PR DESCRIPTION
This is an experiment I started because I hate how Spirit X3 separates rules from parsing expressions with the `_def` suffix. Jumping between where a rule is used in the grammar and where it's defined is awkward because they're different identifiers. Well, I could make vim do that with a keystroke, but I chose not to write vimscript for this.

C++ allows a name to refer to a type and a variable (or function) at the same time. They don't shadow each other. Although the variable/function takes precedence where it's syntactically allowed, you can always get to the type with an explicit *class-key* (`struct`, `enum`, ...). So I use the same name for the `Tag` type used to differentiate `x3::rule` specializations, and for the variable used in parsing expressions.

Rule parsing expressions are stored in a variable template specialized on the `Tag` type. After testing a few variations of this approach, I found it's already been explored (https://github.com/djowel/spirit_x3/issues/17).

So there are no suffixes, everything related to a rule is designated by a single name.

```c++
struct MyRule { static MyRule proxy; ... }; // type named MyRule
struct MyRule const MyRule = MyRule::proxy; // variable named MyRule
MyRule MyRule::proxy = "Some nonterminal";
template <> auto const _rule_def_<MyRule> = ... parsing expression ...
```

The `MyRule` variable could've been simply an `x3::rule` instance, but that would suffer from initialization order issues because `x3::rule` constructor is not `constexpr`. So I instead made the `struct MyRule` type usable in parsing expressions (it converts to an `x3::rule`).

So far I've only converted TopoJSON grammar to this style (despite my opinion that Spirit is not the right tool to parse JSON-based protocols and that this grammar is flawed, I had my hands on it when I got the idea :)). With gcc-6, `topojson_grammar_x3.o` size dropped by ~30k (~10%), that accounts for ~1% of `libmapnik-json.a`. I'm curious whether other grammars will also shrink. I kinda expected the opposite, as I made `x3::rule` type signatures longer. Perhaps the reduction is due to `BOOST_SPIRIT_DEFINE` putting parsing expressions in function-local static variables, whose names are really long, because they include both the function type and the variable type.
