### PR TITLE
Compatibility patch for Boost GIL v1.68

### DIFF
--- a/deps/boost/gil/extension/toolbox/hsl.hpp
+++ b/deps/boost/gil/extension/toolbox/hsl.hpp
@@ -43,8 +43,12 @@ typedef mpl::vector3< hsl_color_space::hue_t
 /// \ingroup LayoutModel
 typedef layout<hsl_t> hsl_layout_t;
 
-
+#if BOOST_VERSION >= 106800
+using bits32f = boost::gil::float32_t;
+GIL_DEFINE_ALL_TYPEDEFS( 32f, float32_t, hsl );
+#else
 GIL_DEFINE_ALL_TYPEDEFS( 32f, hsl );
+#endif
 
 /// \ingroup ColorConvert
 /// \brief RGB to HSL

--- a/deps/boost/gil/extension/toolbox/hsv.hpp
+++ b/deps/boost/gil/extension/toolbox/hsv.hpp
@@ -44,7 +44,13 @@ typedef mpl::vector3< hsv_color_space::hue_t
 typedef layout<hsv_t> hsv_layout_t;
 
 
-GIL_DEFINE_ALL_TYPEDEFS( 32f, hsv )
+#if BOOST_VERSION >= 106800
+using bits32 = uint32_t;
+using bits32f = float32_t;
+GIL_DEFINE_ALL_TYPEDEFS( 32f, float32_t, hsv )
+#else
+GIL_DEFINE_ALL_TYPEDEFS( 32f, hsv );
+#endif
 
 /// \ingroup ColorConvert
 /// \brief RGB to HSV

--- a/include/mapnik/image_filter.hpp
+++ b/include/mapnik/image_filter.hpp
@@ -47,6 +47,14 @@
 // stl
 #include <cmath>
 
+#if BOOST_VERSION >= 106800
+namespace boost {
+namespace gil {
+    using bits32f = boost::gil::float32_t;
+}
+}
+#endif
+
 // 8-bit YUV
 //Y = ( (  66 * R + 129 * G +  25 * B + 128) >> 8) +  16
 //U = ( ( -38 * R -  74 * G + 112 * B + 128) >> 8) + 128


### PR DESCRIPTION
A number of basic typedef were removed in the Boost GIL 1.68 release,
notably `bits32` and `bits32f`. Additionally the
`GIL_DEFINE_ALL_TYPEDEFS` macro signature changed.

This commit introduces compatibility type aliases and conditionally
calls the new macro if `BOOST_VERSION` is high enough.

Based on the output of:
```
% grep -r bits32 . | cut -d: -f1 | sort -u 
./deps/boost/gil/extension/toolbox/hsl.hpp
./deps/boost/gil/extension/toolbox/hsv.hpp
./include/mapnik/image_filter.hpp
``` 
…it seems this covers all the uses of at least the bits32* typedefs.