### PR TITLE
Cairo: set version of SVG to 1.2

### DIFF
--- a/src/cairo_io.cpp
+++ b/src/cairo_io.cpp
@@ -82,6 +82,7 @@ void save_to_cairo_file(mapnik::Map const& map,
         else if (type == "svg")
         {
             surface = cairo_surface_ptr(cairo_svg_surface_create(filename.c_str(),width,height),cairo_surface_closer());
+            cairo_svg_surface_restrict_to_version(surface.get(), CAIRO_SVG_VERSION_1_2);
         }
 #endif
 #ifdef CAIRO_HAS_PS_SURFACE

--- a/test/unit/renderer/cairo_io.cpp
+++ b/test/unit/renderer/cairo_io.cpp
@@ -1,0 +1,34 @@
+#include "catch.hpp"
+
+#include <mapnik/cairo_io.hpp>
+#include <mapnik/util/fs.hpp>
+
+#pragma GCC diagnostic push
+#include <mapnik/warning_ignore.hpp>
+#include <boost/filesystem/convenience.hpp>
+#pragma GCC diagnostic pop
+
+#include <fstream>
+
+#if defined(HAVE_CAIRO)
+TEST_CASE("cairo_io") {
+
+SECTION("save_to_cairo_file - SVG") {
+    std::string directory_name("/tmp/mapnik-tests/");
+    boost::filesystem::create_directories(directory_name);
+    REQUIRE(mapnik::util::exists(directory_name));
+
+    std::string output_file(directory_name + "test_save_to_cairo_file.svg");
+
+    mapnik::Map map(256, 256);
+    mapnik::save_to_cairo_file(map, output_file);
+
+    std::ifstream stream(output_file, std::ios_base::in | std::ios_base::binary);
+    std::string actual_output(std::istreambuf_iterator<char>(stream.rdbuf()), std::istreambuf_iterator<char>());
+
+    // Check the Cairo SVG surface is using SVG 1.2
+    CHECK(actual_output.find("version=\"1.2\"") != std::string::npos);
+}
+
+}
+#endif

--- a/test/visual/renderer.hpp
+++ b/test/visual/renderer.hpp
@@ -180,7 +180,17 @@ struct cairo_vector_renderer : vector_renderer_base
 };
 
 #ifdef CAIRO_HAS_SVG_SURFACE
-struct cairo_svg_renderer : cairo_vector_renderer<cairo_svg_surface_create_for_stream>
+inline cairo_surface_t *create_svg_1_2(cairo_write_func_t write_func,
+                                       void *closure,
+                                       double width,
+                                       double height)
+{
+    cairo_surface_t * surface = cairo_svg_surface_create_for_stream(write_func, closure, width, height);
+    cairo_svg_surface_restrict_to_version(surface, CAIRO_SVG_VERSION_1_2);
+    return surface;
+}
+
+struct cairo_svg_renderer : cairo_vector_renderer<create_svg_1_2>
 {
     static constexpr const char * name = "cairo-svg";
     static constexpr const char * ext = ".svg";


### PR DESCRIPTION
This partially solves https://github.com/mapnik/mapnik/issues/3749.

The problem was that Cairo SVG surface is using SVG version 1.1 by default, where `comp-op` is not supported:
https://github.com/behdad/cairo/blob/7a923b1ff5bf3e2b79ce4f2fe14d352faef5bccb/src/cairo-svg-surface.c#L276

SVG version can be upgraded to 1.2 by calling the following function on the surface:

```c++
cairo_svg_surface_restrict_to_version(surface, CAIRO_SVG_VERSION_1_2);
```

Partial solution it is because the SVG surface can be created outside of Mapnik. In such case responsibility for setting the SVG version is on the caller of Mapnik.
