### PR TITLE
Ditch rint

### DIFF
--- a/include/mapnik/global.hpp
+++ b/include/mapnik/global.hpp
@@ -111,12 +111,6 @@ inline void read_double_xdr(const char* data, double & val)
 }
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
-// msvc doesn't have rint in <cmath>
-inline int rint(double val)
-{
-    return int(std::floor(val + 0.5));
-}
-
 inline double round(double val)
 {
     return std::floor(val);
@@ -124,7 +118,5 @@ inline double round(double val)
 #endif
 
 }
-
-
 
 #endif // MAPNIK_GLOBAL_HPP

--- a/plugins/input/gdal/gdal_featureset.cpp
+++ b/plugins/input/gdal/gdal_featureset.cpp
@@ -194,10 +194,10 @@ feature_ptr gdal_featureset::get_feature(mapnik::query const& q)
     }
 
     //select minimum raster containing whole box
-    int x_off = rint(box.minx() - margin_x);
-    int y_off = rint(box.miny() - margin_y);
-    int end_x = rint(box.maxx() + margin_x);
-    int end_y = rint(box.maxy() + margin_y);
+    int x_off = static_cast<int>(std::floor((box.minx() - margin_x) + .5));
+    int y_off = static_cast<int>(std::floor((box.miny() - margin_y) + .5));
+    int end_x = static_cast<int>(std::floor((box.maxx() + margin_x) + .5));
+    int end_y = static_cast<int>(std::floor((box.maxy() + margin_y) + .5));
     MAPNIK_LOG_DEBUG(gdal) << "gdal_featureset: x_off=" << x_off;
     MAPNIK_LOG_DEBUG(gdal) << "gdal_featureset: y_off=" << y_off;
     MAPNIK_LOG_DEBUG(gdal) << "gdal_featureset: end_x=" << end_x;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -611,7 +611,7 @@ struct convert<value_integer>
 
     value_integer operator()(value_double val) const
     {
-        return static_cast<value_integer>(rint(val));
+        return static_cast<value_integer>(std::floor(val) + .5);
     }
 
     value_integer operator()(value_bool val) const


### PR DESCRIPTION
Removes all usages of rint from the codebase, in favor of the standard
rounding and casting formula used throughout the codebase:

  static_cast<int>(std::floor(<val> + .5))

Fixes #2392