### PR TITLE
Address undefined behaviour in agg

### DIFF
--- a/deps/agg/include/agg_basics.h
+++ b/deps/agg/include/agg_basics.h
@@ -16,7 +16,10 @@
 #ifndef AGG_BASICS_INCLUDED
 #define AGG_BASICS_INCLUDED
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
+
 #include "agg_config.h"
 
 //---------------------------------------------------------AGG_CUSTOM_ALLOCATOR
@@ -121,19 +124,23 @@ namespace agg
 
     AGG_INLINE int iround(double v)
     {
-        return int((v < 0.0) ? v - 0.5 : v + 0.5);
+        return static_cast<int>(v < 0.0 ?
+            std::max(v - 0.5, static_cast<double>(std::numeric_limits<int>::lowest())) :
+            std::min(v + 0.5, static_cast<double>(std::numeric_limits<int>::max()))
+        );
     }
     AGG_INLINE int uround(double v)
     {
-        return unsigned(v + 0.5);
+        return static_cast<unsigned>(v < 0.0 ? 0 :
+			std::min(v + 0.5, static_cast<double>(std::numeric_limits<int>::max())));
     }
     AGG_INLINE unsigned ufloor(double v)
     {
-        return unsigned(v);
+        return static_cast<unsigned>(v);
     }
     AGG_INLINE unsigned uceil(double v)
     {
-        return unsigned(std::ceil(v));
+        return static_cast<unsigned>(std::ceil(v));
     }
 
     //---------------------------------------------------------------saturation

--- a/deps/agg/include/agg_line_aa_basics.h
+++ b/deps/agg/include/agg_line_aa_basics.h
@@ -82,10 +82,10 @@ namespace agg
     {
         //---------------------------------------------------------------------
         line_parameters() {}
-        line_parameters(int x1_, int y1_, int x2_, int y2_, int len_) :
+        line_parameters(long int x1_, long int y1_, long int x2_, long int y2_, int len_) :
             x1(x1_), y1(y1_), x2(x2_), y2(y2_),
-            dx(std::abs(x2_ - x1_)),
-            dy(std::abs(y2_ - y1_)),
+            dx(agg::iround(std::abs(x2_ - x1_))),
+            dy(agg::iround(std::abs(y2_ - y1_))),
             sx((x2_ > x1_) ? 1 : -1),
             sy((y2_ > y1_) ? 1 : -1),
             vertical(dy >= dx),

--- a/deps/agg/include/agg_rasterizer_cells_aa.h
+++ b/deps/agg/include/agg_rasterizer_cells_aa.h
@@ -214,8 +214,8 @@ namespace agg
                                                             int x1, int y1, 
                                                             int x2, int y2)
     {
-        int ex1 = x1 >> poly_subpixel_shift;
-        int ex2 = x2 >> poly_subpixel_shift;
+        int ex1 = x1 / poly_subpixel_scale;
+        int ex2 = x2 / poly_subpixel_scale;
         int fx1 = x1 & poly_subpixel_mask;
         int fx2 = x2 & poly_subpixel_mask;
 
@@ -319,7 +319,7 @@ namespace agg
     {
         enum dx_limit_e { dx_limit = 16384 << poly_subpixel_shift };
 
-        int dx = x2 - x1;
+        long int dx = static_cast<long int>(x2) - static_cast<long int>(x1);
 
         if(dx >= dx_limit || dx <= -dx_limit)
         {
@@ -335,11 +335,11 @@ namespace agg
             line(cx, cy, x2, y2);
         }
 
-        int dy = y2 - y1;
-        int ex1 = x1 >> poly_subpixel_shift;
-        int ex2 = x2 >> poly_subpixel_shift;
-        int ey1 = y1 >> poly_subpixel_shift;
-        int ey2 = y2 >> poly_subpixel_shift;
+        int dy = agg::iround(static_cast<double>(y2) - static_cast<double>(y1));
+        int ex1 = x1 / poly_subpixel_scale;
+        int ex2 = x2 / poly_subpixel_scale;
+        int ey1 = y1 / poly_subpixel_scale;
+        int ey2 = y2 / poly_subpixel_scale;
         int fy1 = y1 & poly_subpixel_mask;
         int fy2 = y2 & poly_subpixel_mask;
 
@@ -371,8 +371,8 @@ namespace agg
         incr  = 1;
         if(dx == 0)
         {
-            int ex = x1 >> poly_subpixel_shift;
-            int two_fx = (x1 - (ex << poly_subpixel_shift)) << 1;
+            int ex = x1 / poly_subpixel_scale;
+            int two_fx = (x1 - (ex * poly_subpixel_scale)) * 2;
             int area;
 
             first = poly_subpixel_scale;
@@ -434,7 +434,7 @@ namespace agg
         render_hline(ey1, x1, fy1, x_from, first);
 
         ey1 += incr;
-        set_curr_cell(x_from >> poly_subpixel_shift, ey1);
+        set_curr_cell(x_from / poly_subpixel_scale, ey1);
 
         if(ey1 != ey2)
         {
@@ -464,7 +464,7 @@ namespace agg
                 x_from = x_to;
 
                 ey1 += incr;
-                set_curr_cell(x_from >> poly_subpixel_shift, ey1);
+                set_curr_cell(x_from / poly_subpixel_scale, ey1);
             }
         }
         render_hline(ey1, x_from, poly_subpixel_scale - first, x2, fy2);

--- a/deps/agg/include/agg_rasterizer_outline_aa.h
+++ b/deps/agg/include/agg_rasterizer_outline_aa.h
@@ -47,8 +47,8 @@ namespace agg
 
         bool operator () (const line_aa_vertex& val)
         {
-            double dx = val.x - x;
-            double dy = val.y - y;
+            double dx = static_cast<double>(val.x) - x;
+            double dy = static_cast<double>(val.y) - y;
             return (len = uround(sqrt(dx * dx + dy * dy))) > 
                    (line_subpixel_scale + line_subpixel_scale / 2);
         }

--- a/deps/agg/include/agg_rasterizer_scanline_aa.h
+++ b/deps/agg/include/agg_rasterizer_scanline_aa.h
@@ -61,7 +61,7 @@ namespace agg
 
         int not_equal(int ex, int ey, const cell_aa&) const
         {
-            return (ex - x) | (ey - y);
+            return (ex != x) || (ey != y);
         }
     };
 

--- a/deps/agg/include/agg_rasterizer_sl_clip.h
+++ b/deps/agg/include/agg_rasterizer_sl_clip.h
@@ -17,6 +17,9 @@
 
 #include "agg_clip_liang_barsky.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace agg
 {
     //--------------------------------------------------------poly_max_coord_e
@@ -31,6 +34,7 @@ namespace agg
         typedef int coord_type;
         static AGG_INLINE int mul_div(double a, double b, double c)
         {
+            if (std::abs(c) < std::numeric_limits<double>::epsilon()) return 0;
             return iround(a * b / c);
         }
         static int xi(int v) { return v; }
@@ -145,8 +149,8 @@ namespace agg
         //------------------------------------------------------------------------
         template<class Rasterizer>
         AGG_INLINE void line_clip_y(Rasterizer& ras,
-                                    coord_type x1, coord_type y1, 
-                                    coord_type x2, coord_type y2, 
+                                    double x1, double y1,
+                                    double x2, double y2,
                                     unsigned   f1, unsigned   f2) const
         {
             f1 &= 10;
@@ -164,10 +168,10 @@ namespace agg
                     return;
                 }
 
-                coord_type tx1 = x1;
-                coord_type ty1 = y1;
-                coord_type tx2 = x2;
-                coord_type ty2 = y2;
+                double tx1 = x1;
+                double ty1 = y1;
+                double tx2 = x2;
+                double ty2 = y2;
 
                 if(f1 & 8) // y1 < clip.y1
                 {
@@ -192,8 +196,9 @@ namespace agg
                     tx2 = x1 + Conv::mul_div(m_clip_box.y2-y1, x2-x1, y2-y1);
                     ty2 = m_clip_box.y2;
                 }
-                ras.line(Conv::xi(tx1), Conv::yi(ty1), 
-                         Conv::xi(tx2), Conv::yi(ty2)); 
+
+                ras.line(Conv::xi(iround(tx1)), Conv::yi(iround(ty1)),
+                         Conv::xi(iround(tx2)), Conv::yi(iround(ty2)));
             }
         }
 

--- a/deps/agg/include/agg_rasterizer_sl_clip.h
+++ b/deps/agg/include/agg_rasterizer_sl_clip.h
@@ -149,8 +149,8 @@ namespace agg
         //------------------------------------------------------------------------
         template<class Rasterizer>
         AGG_INLINE void line_clip_y(Rasterizer& ras,
-                                    double x1, double y1,
-                                    double x2, double y2,
+                                    coord_type x1, coord_type y1,
+                                    coord_type x2, coord_type y2,
                                     unsigned   f1, unsigned   f2) const
         {
             f1 &= 10;
@@ -173,32 +173,46 @@ namespace agg
                 double tx2 = x2;
                 double ty2 = y2;
 
+                double sub_by1_y1 = std::max(static_cast<double>(std::numeric_limits<coord_type>::lowest()),
+                                             static_cast<double>(m_clip_box.y1) - ty1);
+                double sub_by2_y1 = std::max(static_cast<double>(std::numeric_limits<coord_type>::lowest()),
+                                             static_cast<double>(m_clip_box.y2) - ty1);
+                double sub_y2_y1 = std::max(static_cast<double>(std::numeric_limits<coord_type>::lowest()),
+                                            ty2 - ty1);
+                double sub_x2_x1 = std::max(static_cast<double>(std::numeric_limits<coord_type>::lowest()),
+                                            tx2 - tx1);
+
                 if(f1 & 8) // y1 < clip.y1
                 {
-                    tx1 = x1 + Conv::mul_div(m_clip_box.y1-y1, x2-x1, y2-y1);
+                    tx1 = x1 + Conv::mul_div(sub_by1_y1, sub_x2_x1, sub_y2_y1);
                     ty1 = m_clip_box.y1;
                 }
 
                 if(f1 & 2) // y1 > clip.y2
                 {
-                    tx1 = x1 + Conv::mul_div(m_clip_box.y2-y1, x2-x1, y2-y1);
+                    tx1 = x1 + Conv::mul_div(sub_by2_y1, sub_x2_x1, sub_y2_y1);
                     ty1 = m_clip_box.y2;
                 }
 
                 if(f2 & 8) // y2 < clip.y1
                 {
-                    tx2 = x1 + Conv::mul_div(m_clip_box.y1-y1, x2-x1, y2-y1);
+                    tx2 = x1 + Conv::mul_div(sub_by1_y1, sub_x2_x1, sub_y2_y1);
                     ty2 = m_clip_box.y1;
                 }
 
                 if(f2 & 2) // y2 > clip.y2
                 {
-                    tx2 = x1 + Conv::mul_div(m_clip_box.y2-y1, x2-x1, y2-y1);
+                    tx2 = x1 + Conv::mul_div(sub_by2_y1, sub_x2_x1, sub_y2_y1);
                     ty2 = m_clip_box.y2;
                 }
 
-                ras.line(Conv::xi(iround(tx1)), Conv::yi(iround(ty1)),
-                         Conv::xi(iround(tx2)), Conv::yi(iround(ty2)));
+                tx1 = std::min(static_cast<double>(std::numeric_limits<coord_type>::max()), tx1);
+                ty1 = std::min(static_cast<double>(std::numeric_limits<coord_type>::max()), ty1);
+                tx2 = std::min(static_cast<double>(std::numeric_limits<coord_type>::max()), tx2);
+                ty2 = std::min(static_cast<double>(std::numeric_limits<coord_type>::max()), ty2);
+
+                ras.line(Conv::xi(tx1), Conv::yi(ty1),
+                         Conv::xi(tx2), Conv::yi(ty2));
             }
         }
 

--- a/deps/agg/include/agg_rasterizer_sl_clip.h
+++ b/deps/agg/include/agg_rasterizer_sl_clip.h
@@ -227,6 +227,11 @@ namespace agg
                 coord_type y3, y4;
                 unsigned   f3, f4;
 
+                double sub_bx1_x1 = static_cast<double>(m_clip_box.x1) - static_cast<double>(x1);
+                double sub_bx2_x1 = static_cast<double>(m_clip_box.x2) - static_cast<double>(x1);
+                double sub_y2_y1 = static_cast<double>(y2) - static_cast<double>(y1);
+                double sub_x2_x1 = static_cast<double>(x2) - static_cast<double>(x1);
+
                 switch(((f1 & 5) << 1) | (f2 & 5))
                 {
                 case 0: // Visible by X
@@ -234,14 +239,14 @@ namespace agg
                     break;
 
                 case 1: // x2 > clip.x2
-                    y3 = y1 + Conv::mul_div(m_clip_box.x2-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx2_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     line_clip_y(ras, x1, y1, m_clip_box.x2, y3, f1, f3);
                     line_clip_y(ras, m_clip_box.x2, y3, m_clip_box.x2, y2, f3, f2);
                     break;
 
                 case 2: // x1 > clip.x2
-                    y3 = y1 + Conv::mul_div(m_clip_box.x2-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx2_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     line_clip_y(ras, m_clip_box.x2, y1, m_clip_box.x2, y3, f1, f3);
                     line_clip_y(ras, m_clip_box.x2, y3, x2, y2, f3, f2);
@@ -252,15 +257,15 @@ namespace agg
                     break;
 
                 case 4: // x2 < clip.x1
-                    y3 = y1 + Conv::mul_div(m_clip_box.x1-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx1_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     line_clip_y(ras, x1, y1, m_clip_box.x1, y3, f1, f3);
                     line_clip_y(ras, m_clip_box.x1, y3, m_clip_box.x1, y2, f3, f2);
                     break;
 
                 case 6: // x1 > clip.x2 && x2 < clip.x1
-                    y3 = y1 + Conv::mul_div(m_clip_box.x2-x1, y2-y1, x2-x1);
-                    y4 = y1 + Conv::mul_div(m_clip_box.x1-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx2_x1, sub_y2_y1, sub_x2_x1);
+                    y4 = y1 + Conv::mul_div(sub_bx1_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     f4 = clipping_flags_y(y4, m_clip_box);
                     line_clip_y(ras, m_clip_box.x2, y1, m_clip_box.x2, y3, f1, f3);
@@ -269,15 +274,15 @@ namespace agg
                     break;
 
                 case 8: // x1 < clip.x1
-                    y3 = y1 + Conv::mul_div(m_clip_box.x1-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx1_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     line_clip_y(ras, m_clip_box.x1, y1, m_clip_box.x1, y3, f1, f3);
                     line_clip_y(ras, m_clip_box.x1, y3, x2, y2, f3, f2);
                     break;
 
                 case 9:  // x1 < clip.x1 && x2 > clip.x2
-                    y3 = y1 + Conv::mul_div(m_clip_box.x1-x1, y2-y1, x2-x1);
-                    y4 = y1 + Conv::mul_div(m_clip_box.x2-x1, y2-y1, x2-x1);
+                    y3 = y1 + Conv::mul_div(sub_bx1_x1, sub_y2_y1, sub_x2_x1);
+                    y4 = y1 + Conv::mul_div(sub_bx2_x1, sub_y2_y1, sub_x2_x1);
                     f3 = clipping_flags_y(y3, m_clip_box);
                     f4 = clipping_flags_y(y4, m_clip_box);
                     line_clip_y(ras, m_clip_box.x1, y1, m_clip_box.x1, y3, f1, f3);

--- a/deps/agg/include/agg_renderer_outline_image.h
+++ b/deps/agg/include/agg_renderer_outline_image.h
@@ -984,7 +984,7 @@ namespace agg
                         line3_no_clip(lp, sx, sy, ex, ey);
                     }
                 }
-                m_start = start + uround(lp.len / m_scale_x);
+                m_start = uround(static_cast<double>(start) + (static_cast<double>(lp.len) / m_scale_x));
             }
             else
             {

--- a/deps/agg/src/agg_line_aa_basics.cpp
+++ b/deps/agg/src/agg_line_aa_basics.cpp
@@ -13,8 +13,9 @@
 //          http://www.antigrain.com
 //----------------------------------------------------------------------------
 
-#include <math.h>
 #include "agg_line_aa_basics.h"
+
+#include <cmath>
 
 namespace agg
 {
@@ -52,27 +53,38 @@ void bisectrix(const line_parameters& l1,
                const line_parameters& l2,
                int* x, int* y)
 {
-    double k = double(l2.len) / double(l1.len);
-    double tx = l2.x2 - (l2.x1 - l1.x1) * k;
-    double ty = l2.y2 - (l2.y1 - l1.y1) * k;
+	double l1_x1 = static_cast<double>(l1.x1);
+	double l1_y1 = static_cast<double>(l1.y1);
+	double l2_x1 = static_cast<double>(l2.x1);
+	double l2_x2 = static_cast<double>(l2.x2);
+	double l2_y1 = static_cast<double>(l2.y1);
+	double l2_y2 = static_cast<double>(l2.y2);;
+
+    double k = static_cast<double>(l2.len) / static_cast<double>(l1.len);
+    double tx = l2_x2 - (l2_x1 - l1_x1) * k;
+    double ty = l2_y2 - (l2_y1 - l1_y1) * k;
 
     //All bisectrices must be on the right of the line
     //If the next point is on the left (l1 => l2.2)
     //then the bisectix should be rotated by 180 degrees.
-    if(double(l2.x2 - l2.x1) * double(l2.y1 - l1.y1) <
-       double(l2.y2 - l2.y1) * double(l2.x1 - l1.x1) + 100.0)
+    if((l2_x2 - l2_x1) * (l2_y1 - l1_y1) <
+       (l2_y2 - l2_y1) * (l2_x1 - l1_x1) + 100.0)
     {
-        tx -= (tx - l2.x1) * 2.0;
-        ty -= (ty - l2.y1) * 2.0;
+        tx -= (tx - l2_x1) * 2.0;
+        ty -= (ty - l2_y1) * 2.0;
     }
 
     // Check if the bisectrix is too short
-    double dx = tx - l2.x1;
-    double dy = ty - l2.y1;
-    if((int)sqrt(dx * dx + dy * dy) < line_subpixel_scale)
+    double dx = tx - l2_x1;
+    double dy = ty - l2_y1;
+    if(std::sqrt(dx * dx + dy * dy) < static_cast<double>(line_subpixel_scale))
     {
-        *x = (l2.x1 + l2.x1 + (l2.y1 - l1.y1) + (l2.y2 - l2.y1)) >> 1;
-        *y = (l2.y1 + l2.y1 - (l2.x1 - l1.x1) - (l2.x2 - l2.x1)) >> 1;
+//        *x = (l2.x1 + l2.x1 + (l2.y1 - l1.y1) + (l2.y2 - l2.y1)) >> 1;
+//        *y = (l2.y1 + l2.y1 - (l2.x1 - l1.x1) - (l2.x2 - l2.x1)) >> 1;
+        double x_value = (l2_x1 + l2_x1 + (l2_y1 - l1_y1) + (l2_y2 - l2_y1)) / 2;
+        double y_value = (l2_y1 + l2_y1 - (l2_x1 - l1_x1) - (l2_x2 - l2_x1)) / 2;
+        *x = iround(x_value);
+        *y = iround(y_value);
         return;
     }
     *x = iround(tx);

--- a/include/mapnik/geometry/box2d.hpp
+++ b/include/mapnik/geometry/box2d.hpp
@@ -26,6 +26,7 @@
 // mapnik
 #include <mapnik/config.hpp>
 #include <mapnik/coord.hpp>
+#include <mapnik/safe_cast.hpp>
 
 #pragma GCC diagnostic push
 #include <mapnik/warning_ignore.hpp>
@@ -76,10 +77,10 @@ public:
     // converting ctor
     template <typename T1>
     explicit box2d(box2d<T1> other)
-        : minx_(static_cast<value_type>(other.minx())),
-        miny_(static_cast<value_type>(other.miny())),
-        maxx_(static_cast<value_type>(other.maxx())),
-        maxy_(static_cast<value_type>(other.maxy()))
+        : minx_(safe_cast<value_type>(other.minx())),
+        miny_(safe_cast<value_type>(other.miny())),
+        maxx_(safe_cast<value_type>(other.maxx())),
+        maxy_(safe_cast<value_type>(other.maxy()))
         {}
     box2d_type& operator=(box2d_type other);
     T minx() const;

--- a/src/agg/process_debug_symbolizer.cpp
+++ b/src/agg/process_debug_symbolizer.cpp
@@ -32,6 +32,7 @@
 #include <mapnik/transform_path_adapter.hpp>
 #include <mapnik/agg_helpers.hpp>
 #include <mapnik/util/is_clockwise.hpp>
+#include <mapnik/safe_cast.hpp>
 
 #pragma GCC diagnostic push
 #include <mapnik/warning_ignore_agg.hpp>
@@ -50,17 +51,17 @@ namespace {
 template <typename T>
 void draw_rect(T &pixmap, box2d<double> const& box)
 {
-    int x0 = static_cast<int>(box.minx());
-    int x1 = static_cast<int>(box.maxx());
-    int y0 = static_cast<int>(box.miny());
-    int y1 = static_cast<int>(box.maxy());
+    std::size_t x0 = safe_cast<std::size_t >(box.minx());
+    std::size_t x1 = safe_cast<std::size_t >(box.maxx());
+    std::size_t y0 = safe_cast<std::size_t >(box.miny());
+    std::size_t y1 = safe_cast<std::size_t >(box.maxy());
     unsigned color1 = 0xff0000ff;
-    for (int x=x0; x<x1; x++)
+    for (std::size_t x = x0; x < x1; x++)
     {
         mapnik::set_pixel(pixmap, x, y0, color1);
         mapnik::set_pixel(pixmap, x, y1, color1);
     }
-    for (int y=y0; y<y1; y++)
+    for (std::size_t y = y0; y < y1; y++)
     {
         mapnik::set_pixel(pixmap, x0, y, color1);
         mapnik::set_pixel(pixmap, x1, y, color1);

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -198,7 +198,8 @@ struct agg_renderer_process_visitor_l
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
         if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
-        image_rgba8 image(bbox_image.width(), bbox_image.height());
+        using pixel_type = mapnik::image_rgba8::pixel::type;
+        mapnik::image_rgba8 image(safe_cast<pixel_type>(bbox_image.width()), safe_cast<pixel_type>(bbox_image.height()));
         render_pattern<buffer_type>(marker, image_tr, 1.0, image);
         render_by_pattern_type(image);
     }

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -32,6 +32,7 @@
 #include <mapnik/vertex_converters.hpp>
 #include <mapnik/vertex_processor.hpp>
 #include <mapnik/parse_path.hpp>
+#include <mapnik/safe_cast.hpp>
 #include <mapnik/symbolizer.hpp>
 #include <mapnik/svg/svg_converter.hpp>
 #include <mapnik/svg/svg_renderer_agg.hpp>
@@ -84,7 +85,8 @@ struct agg_renderer_process_visitor_p
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
         if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
-        mapnik::image_rgba8 image(bbox_image.width(), bbox_image.height());
+        using pixel_type = mapnik::image_rgba8::pixel::type;
+        mapnik::image_rgba8 image(safe_cast<pixel_type>(bbox_image.width()), safe_cast<pixel_type>(bbox_image.height()));
         render_pattern<buffer_type>(marker, image_tr, 1.0, image);
         render(image);
     }

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -69,7 +69,8 @@ struct prepare_pattern_visitor
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
         if (image_transform) evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
         mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
-        mapnik::image_rgba8 image(bbox_image.width(), bbox_image.height());
+        using pixel_type = mapnik::image_rgba8::pixel::type;
+        mapnik::image_rgba8 image(safe_cast<pixel_type>(bbox_image.width()), safe_cast<pixel_type>(bbox_image.height()));
         render_pattern<image_rgba8>(marker, image_tr, 1.0, image);
         width_ = image.width();
         height_ = image.height();


### PR DESCRIPTION
This fixes multiple warnings that appear when running under clang's undefined behaviour sanitizer, most of them related to integer overflows so most of the time I've chosen to cast to double when necessary (if it were using `int32_t` then I'd have chosen `int64_t`, but since as far as I can remember `int` doesn't have a guaranteed size It could happen that int == long int in some architectures).

To test I'm building with clang `8.0.0` and:
```
  python scons/scons.py configure \
    PREFIX="/usr" \
    DESTDIR="$pkgdir" \
    INPUT_PLUGINS=all \
    ENABLE_STATS=False \
    CPP_TESTS=True \
    DEBUG=False \
    ENABLE_LOG=False \
    OPTIMIZATION=0 \
    CUSTOM_CXXFLAGS="-march=native -mtune=native -O0 -pipe -fno-plt -Wall -Wextra -g3 -gdwarf-4 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsanitize=undefined -fsanitize-undefined-trap-on-error" \
    CUSTOM_DEFINES="-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1" \
    CC="clang" \
    CXX="clang++"
```

The vital part is the `-fsanitize=undefined -fsanitize-undefined-trap-on-error"` so the visual tests crash and generate a coredump and `OPTIMIZATION=0` so you get the exact point of the crash instead of only an aproximate line. I've also run this under gcc (8.2) after this patch is applied and found nothing.

I've tried to add a task in travis to build with ubsan but failed miserably, but it'd be nice to have it run automatically as done in node-mapnik. keep in mind that by using "trap on error" you don't need the ubsan library during runtime, which makes it simpler to build and test.

In my branch these changes required updating some reference images (https://github.com/CartoDB/test-data-visual/commit/804aa4b52e7bdda050f0c2fdcce62abca158b84a).
