### PR TITLE
Avoid heap-buffer-overflow in agg::rasterizer_cells_aa<Cell>::sort_cells

### DIFF
--- a/deps/agg/include/agg_array.h
+++ b/deps/agg/include/agg_array.h
@@ -515,13 +515,11 @@ namespace agg
     {
         if(m_num_blocks)
         {
-            T** blk = m_blocks + m_num_blocks - 1;
-            while(m_num_blocks > 0)
+            for (unsigned i = 0; i < m_num_blocks; i++)
             {
-                pod_allocator<T>::deallocate(*blk, block_size);
-                --blk;
-                --m_num_blocks;
+                pod_allocator<T>::deallocate(m_blocks[i], block_size);
             }
+            m_num_blocks = 0;
         }
         pod_allocator<T*>::deallocate(m_blocks, m_max_blocks);
     }

--- a/deps/agg/include/agg_basics.h
+++ b/deps/agg/include/agg_basics.h
@@ -38,7 +38,7 @@ namespace agg
         //static T*   allocate(unsigned num)       { return static_cast<T*>(::operator new(sizeof(T)*num));}
         //static void deallocate(T* ptr, unsigned) { ::operator delete(ptr) ;}
         static T*   allocate(unsigned num)       { return new T [num]; }
-        static void deallocate(T* ptr, unsigned) { delete [] ptr;      }
+        static void deallocate(T* ptr, unsigned) { if (ptr) delete [] ptr; }
     };
 
     // Single object allocator. It's also can be replaced with your custom

--- a/deps/agg/include/agg_rasterizer_cells_aa.h
+++ b/deps/agg/include/agg_rasterizer_cells_aa.h
@@ -130,15 +130,13 @@ namespace agg
     {
         if(m_num_blocks)
         {
-            cell_type** ptr = m_cells + m_num_blocks - 1;
-            while(m_num_blocks > 0)
+            for (unsigned i = 0; i < m_num_blocks; i++)
             {
-                pod_allocator<cell_type>::deallocate(*ptr, cell_block_size);
-                ptr--;
-                --m_num_blocks;
+                pod_allocator<cell_type>::deallocate(m_cells[i], cell_block_size);
             }
-            pod_allocator<cell_type*>::deallocate(m_cells, m_max_blocks);
+            m_num_blocks = 0;
         }
+        pod_allocator<cell_type*>::deallocate(m_cells, m_max_blocks);
     }
 
     //------------------------------------------------------------------------
@@ -660,35 +658,35 @@ namespace agg
         m_sorted_y.zero();
 
         // Create the Y-histogram (count the numbers of cells for each Y)
-        cell_type** block_ptr = m_cells;
-        cell_type*  cell_ptr;
-        unsigned nb = m_num_cells >> cell_block_shift;
-        unsigned i;
-        while(nb > 0)
-        {
-            cell_ptr = *block_ptr++;
-            i = cell_block_size;
-            while(i > 0)
-            {
-                m_sorted_y[cell_ptr->y - m_min_y].start++;
-                ++cell_ptr;
-                --i;
-            }
-            --nb;
-        }
 
-        cell_ptr = *block_ptr++;
-        i = m_num_cells & cell_block_mask;
-        while(i > 0)
+        /* This code is simpler but it involves shifting and & every iteration: */
+//        for (unsigned n = 0; n < m_num_cells; n++)
+//        {
+//            unsigned block = n >> cell_block_shift;
+//            unsigned i = n & cell_block_mask;
+//            m_sorted_y[m_cells[block][i].y - m_min_y].start++;
+//        }
+        /* Instead we iterate and check full blocks first and then the last incomplete one */
+        unsigned processed_cells = 0;
+        for (unsigned block = 0; block < m_num_cells >> cell_block_shift; block++)
         {
-            m_sorted_y[cell_ptr->y - m_min_y].start++;
-            ++cell_ptr;
-            --i;
+            for (unsigned i = 0; i < cell_block_size; i++)
+            {
+                m_sorted_y[m_cells[block][i].y - m_min_y].start++;
+                processed_cells++;
+            }
+        }
+        if (processed_cells != m_num_cells)
+        {
+            unsigned block = m_num_cells >> cell_block_shift;
+            for (unsigned i = 0; i < m_num_cells - processed_cells; i++)
+            {
+                m_sorted_y[m_cells[block][i].y - m_min_y].start++;
+            }
         }
 
         // Convert the Y-histogram into the array of starting indexes
-        unsigned start = 0;
-        for(i = 0; i < m_sorted_y.size(); i++)
+        for(unsigned i = 0, start = 0; i < m_sorted_y.size(); i++)
         {
             unsigned v = m_sorted_y[i].start;
             m_sorted_y[i].start = start;
@@ -696,39 +694,45 @@ namespace agg
         }
 
         // Fill the cell pointer array sorted by Y
-        block_ptr = m_cells;
-        nb = m_num_cells >> cell_block_shift;
-        while(nb > 0)
+
+        /* As above, this is simpler code but uses >> and & each iteration */
+//        for (unsigned n = 0; n < m_num_cells; n++)
+//        {
+//            unsigned block = n >> cell_block_shift;
+//            unsigned i = n & cell_block_mask;
+//            cell_type* cell_n = &m_cells[block][i];
+//            sorted_y& curr_y = m_sorted_y[cell_n->y - m_min_y];
+//            m_sorted_cells[curr_y.start + curr_y.num] = cell_n;
+//            curr_y.num++;
+//        }
+        /* The equivalent code to the commented one but checking by block */
+        for (unsigned block = 0; block < m_num_cells >> cell_block_shift; block++)
         {
-            cell_ptr = *block_ptr++;
-            i = cell_block_size;
-            while(i > 0)
+            for (unsigned i = 0; i < cell_block_size; i++)
             {
-                sorted_y& curr_y = m_sorted_y[cell_ptr->y - m_min_y];
-                m_sorted_cells[curr_y.start + curr_y.num] = cell_ptr;
-                ++curr_y.num;
-                ++cell_ptr;
-                --i;
+                cell_type* cell_n = &m_cells[block][i];
+                sorted_y& curr_y = m_sorted_y[cell_n->y - m_min_y];
+                m_sorted_cells[curr_y.start + curr_y.num] = cell_n;
+                curr_y.num++;
             }
-            --nb;
         }
-        
-        cell_ptr = *block_ptr++;
-        i = m_num_cells & cell_block_mask;
-        while(i > 0)
+        if (processed_cells != m_num_cells)
         {
-            sorted_y& curr_y = m_sorted_y[cell_ptr->y - m_min_y];
-            m_sorted_cells[curr_y.start + curr_y.num] = cell_ptr;
-            ++curr_y.num;
-            ++cell_ptr;
-            --i;
+            unsigned block = m_num_cells >> cell_block_shift;
+            for (unsigned i = 0; i < m_num_cells - processed_cells; i++)
+            {
+                cell_type* cell_n = &m_cells[block][i];
+                sorted_y& curr_y = m_sorted_y[cell_n->y - m_min_y];
+                m_sorted_cells[curr_y.start + curr_y.num] = cell_n;
+                curr_y.num++;
+            }
         }
 
         // Finally arrange the X-arrays
-        for(i = 0; i < m_sorted_y.size(); i++)
+        for (unsigned i = 0; i < m_sorted_y.size(); i++)
         {
             const sorted_y& curr_y = m_sorted_y[i];
-            if(curr_y.num)
+            if (curr_y.num)
             {
                 qsort_cells(m_sorted_cells.data() + curr_y.start, curr_y.num);
             }


### PR DESCRIPTION
Extract from ASAN, it appears in CARTO's fork after updating the build to clang 5 (also tested with 8) and node 10 (it wasn't appearing with clang 3.9.1 and node 6). I'd expect it to appear in node-mapnik/master in a similar environment, but I haven't tested it.
```
$ ./node_modules/.bin/mocha -u tdd -t 5000 --exit test/image.svg.test.js --grep "should not error with async in non-strict mode on svg with validation and parse errors"

  mapnik.Image SVG
=================================================================
==4125==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x625003943900 at pc 0x7f3ffbd21206 bp 0x7f3ff7489950 sp 0x7f3ff7489948
READ of size 8 at 0x625003943900 thread T7
    #0 0x7f3ffbd21205 in agg::rasterizer_cells_aa<agg::cell_aa>::sort_cells() /usr/include/mapnik/agg/agg_rasterizer_cells_aa.h:680:20
    #1 0x7f3ffbd1fe0b in agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip<agg::ras_conv_int> >::rewind_scanlines() /usr/include/mapnik/agg/agg_rasterizer_scanline_aa.h:467:19
    #2 0x7f3ffbd1007c in void agg::render_scanlines<agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip<agg::ras_conv_int> >, agg::scanline_u8, agg::renderer_scanline_aa_solid<agg::renderer_base<agg::pixfmt_alpha_blend_rgba<agg::blender_rgba_pre<agg::rgba8T<agg::linear>, agg::order_rgba>, agg::row_ptr_cache<unsigned char>, unsigned int> > > >(agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip<agg::ras_conv_int> >&, agg::scanline_u8&, agg::renderer_scanline_aa_solid<agg::renderer_base<agg::pixfmt_alpha_blend_rgba<agg::blender_rgba_pre<agg::rgba8T<agg::linear>, agg::order_rgba>, agg::row_ptr_cache<unsigned char>, unsigned int> > >&) /usr/include/mapnik/agg/agg_renderer_scanline.h:464:16
```

This wasn't easy to understand as reversed `while`s with unsigned are tricky. You can see 8722def as proof, as it solved a different issue around the same code.

The issue appears to happen when the last block of cells is full, as `cell_ptr = *block_ptr++;`  checks and deference the next block even though it has already finished. The following lines (`i = m_num_cells & cell_block_mask; while(i > 0)...` would do nothing (since i == 0), but the damage is already done in the derefence.
This could have been fixed with less modifications, but since I felt that the code was excessively complex with the inverse while loops, I've changed if to use a classic for-loop instead, which makes it more readable.

I've left a comment to show that the code could be much simpler by possibly taking a performance hit and calculating the block and displacement of each cell:
```c++
        for (unsigned n = 0; n < m_num_cells; n++)
        {
            unsigned block = n >> cell_block_shift;
            unsigned i = n & cell_block_mask;
            m_sorted_y[m_cells[block][i].y - m_min_y].start++;
        }
```

To avoid this performance change we separate full blocks and then *if needed* we check the last one, as it was done before:
```c++
        unsigned processed_cells = 0;
        for (unsigned block = 0; block < m_num_cells >> cell_block_shift; block++)
        {
            for (unsigned i = 0; i < cell_block_size; i++)
            {
                m_sorted_y[m_cells[block][i].y - m_min_y].start++;
                processed_cells++;
            }
        }
        if (processed_cells != m_num_cells)
        {
            unsigned block = m_num_cells >> cell_block_shift;
            for (unsigned i = 0; i < m_num_cells - processed_cells; i++)
            {
                m_sorted_y[m_cells[block][i].y - m_min_y].start++;
            }
        }
``` 

