### PR TITLE
Add command line options for map size to mapnik-render.

### DIFF
--- a/utils/mapnik-render/mapnik-render.cpp
+++ b/utils/mapnik-render/mapnik-render.cpp
@@ -29,6 +29,8 @@ int main (int argc,char** argv)
     bool params_as_variables = false;
     mapnik::logger logger;
     logger.set_severity(mapnik::logger::error);
+    int map_width = 600;
+    int map_height = 400;
 
     try
     {
@@ -41,6 +43,8 @@ int main (int argc,char** argv)
             ("xml",po::value<std::string>(),"xml map to read")
             ("img",po::value<std::string>(),"image to render")
             ("scale-factor",po::value<double>(),"scale factor for rendering")
+            ("map-width",po::value<int>(),"map width in pixels")
+            ("map-height",po::value<int>(),"map height in pixels")
             ("variables","make map parameters available as render-time variables")
             ;
 
@@ -103,9 +107,17 @@ int main (int argc,char** argv)
             params_as_variables = true;
         }
 
+        if (vm.count("map-width")) {
+          map_width = vm["map-width"].as<int>();
+        }
+
+        if (vm.count("map-height")) {
+          map_height = vm["map-height"].as<int>();
+        }
+
         mapnik::datasource_cache::instance().register_datasources("./plugins/input/");
         mapnik::freetype_engine::register_fonts("./fonts",true);
-        mapnik::Map map(600,400);
+        mapnik::Map map(map_width,map_height);
         mapnik::load_map(map,xml_file,true);
         map.zoom_all();
         mapnik::image_rgba8 im(map.width(),map.height());


### PR DESCRIPTION
Makes mapnik-renderer more useful on its own.