### PR TITLE
New raster colorizer mode for Terrain-RGB

### DIFF
--- a/include/mapnik/raster_colorizer.hpp
+++ b/include/mapnik/raster_colorizer.hpp
@@ -61,9 +61,11 @@ class raster;
 enum colorizer_mode_enum : std::uint8_t
 {
     COLORIZER_INHERIT = 0,    //!< The stop inherits the mode from the colorizer
-    COLORIZER_LINEAR = 1,     //!< Linear interpolation between colors
+    COLORIZER_LINEAR = 1,     //!< Linear interpolation between colors, each channel separately
     COLORIZER_DISCRETE = 2,   //!< Single color for stop
     COLORIZER_EXACT = 3,      //!< Only the exact value specified for the stop gets translated, others use the default
+    COLORIZER_LINEAR_RGBA = 4,//!< Linear interpolation between colors, all channels combined as RGBA value
+    COLORIZER_LINEAR_BGRA = 5,//!< Linear interpolation between colors, all channels combined as BGRA value
     colorizer_mode_enum_MAX
 };
 

--- a/src/raster_colorizer.cpp
+++ b/src/raster_colorizer.cpp
@@ -42,6 +42,8 @@ static const char *colorizer_mode_strings[] = {
     "linear",
     "discrete",
     "exact",
+    "linear-rgba",
+    "linear-bgra",
     ""
 };
 
@@ -255,6 +257,35 @@ unsigned raster_colorizer::get_color(float val) const
             outputColor.set_alpha(a);
         }
 
+    }
+    break;
+    case COLORIZER_LINEAR_RGBA:
+    {
+        if(nextStopValue == stopValue)
+        {
+            return stopColor.rgba();
+        }
+
+        double fraction = (val - stopValue) / (nextStopValue - stopValue);
+        double colorStart = static_cast<double>(stopColor.rgba());
+        double colorEnd = static_cast<double>(nextStopColor.rgba());
+        outputColor = color(colorStart + fraction * (colorEnd - colorStart));
+    }
+    break;
+    case COLORIZER_LINEAR_BGRA:
+    {
+        if(nextStopValue == stopValue)
+        {
+            return stopColor.rgba();
+        }
+
+        double fraction = (val - stopValue) / (nextStopValue - stopValue);
+        std::swap(stopColor.red_, stopColor.blue_);
+        std::swap(nextStopColor.red_, nextStopColor.blue_);
+        double colorStart = static_cast<double>(stopColor.rgba());
+        double colorEnd = static_cast<double>(nextStopColor.rgba());
+        outputColor = color(colorStart + fraction * (colorEnd - colorStart));
+        std::swap(outputColor.red_, outputColor.blue_);
     }
     break;
     case COLORIZER_DISCRETE:


### PR DESCRIPTION
Allows to easily generate Terrain-RGB from a raster:

```xml
<RasterSymbolizer scaling="bicubic">
    <RasterColorizer default-mode="linear-bgra">
        <stop value="-10000" color="#000000"/>
        <stop value="1667721.5" color="#FFFFFF"/>
    </RasterColorizer>
</RasterSymbolizer>
```
These stops are computed from `height = -10000 + ((R * 256 * 256 + G * 256 + B) * 0.1)`.

![15-17225-11673](https://user-images.githubusercontent.com/1950911/57953551-aa877900-78f0-11e9-83b4-f63c67582219.png)

The `linear-rgba` was added for complementarity, but has no application curretly.
