### PR TITLE
Ensure 'scaling' and `comp-op` stored as enumeration_wrappers + fix image `scaling` property    

### DIFF
--- a/include/mapnik/symbolizer.hpp
+++ b/include/mapnik/symbolizer.hpp
@@ -97,6 +97,7 @@ enum class property_types : std::uint8_t
     target_font_feature_settings,
     target_line_pattern,
     target_smooth_algorithm,
+    target_scaling_method
 };
 
 template <typename T>

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -68,10 +68,11 @@ struct enumeration_wrapper
     explicit enumeration_wrapper(T value_)
         : value(value_) {}
 
-    inline operator int() const
+    inline bool operator==(enumeration_wrapper const& rhs) const
     {
-        return value;
+        return value == rhs.value;
     }
+
 };
 
 using dash_array = std::vector<std::pair<double,double> >;
@@ -82,8 +83,8 @@ using text_placements_ptr = std::shared_ptr<text_placements>;
 namespace detail {
 
 using value_base_type = util::variant<value_bool,
-                                      value_integer,
                                       enumeration_wrapper,
+                                      value_integer,
                                       value_double,
                                       std::string,
                                       color,

--- a/src/symbolizer_keys.cpp
+++ b/src/symbolizer_keys.cpp
@@ -90,7 +90,12 @@ static const property_meta_type key_meta[const_max_key] =
     property_meta_type{ "shield-dy", nullptr, property_types::target_double },
     property_meta_type{ "unlock-image", nullptr, property_types::target_bool },
     property_meta_type{ "mode", nullptr, property_types::target_double },
-    property_meta_type{ "scaling", nullptr, property_types::target_double },
+    property_meta_type{ "scaling",
+                        [](enumeration_wrapper e)
+                        {
+                            return *scaling_method_to_string(scaling_method_e(e.value));
+                        },
+                        property_types::target_scaling_method},
     property_meta_type{ "filter-factor",  nullptr, property_types::target_double },
     property_meta_type{ "mesh-size", nullptr, property_types::target_double },
     property_meta_type{ "premultiplied",  nullptr, property_types::target_bool },


### PR DESCRIPTION
* add missing image `scaling` property meta type 
* replace to integer conversion with comparison operator in enumeration_wrapper 
* change order in value_base_type (ref #4045)