### PR TITLE
PostGIS+PGraster: pass exact floating-point numbers in SQL queries

### DIFF
--- a/plugins/input/pgcommon/sql_utils.hpp
+++ b/plugins/input/pgcommon/sql_utils.hpp
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2019 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef MAPNIK_PLUGINS_INPUT_PGCOMMON_SQL_UTILS_HPP
+#define MAPNIK_PLUGINS_INPUT_PGCOMMON_SQL_UTILS_HPP
+
+// mapnik
+#include <mapnik/geometry/box2d.hpp>
+
+// stl
+#include <algorithm>
+#include <cstdio>
+#include <ostream>
+
+namespace mapnik { namespace pgcommon {
+
+
+// sql_bbox
+
+struct sql_bbox : box2d<double>
+{
+    int srid_;
+
+    sql_bbox(box2d<double> const& box, int srid)
+        : box2d<double>(box), srid_(srid) {}
+};
+
+inline std::ostream & operator << (std::ostream & os, sql_bbox const& box)
+{
+    char const fmt[] = "ST_MakeEnvelope(float8 '%a', float8 '%a', "
+                                       "float8 '%a', float8 '%a', %d)";
+    char buf[sizeof(fmt) + 4 * 25 + sizeof(int[3])];
+    int len = std::snprintf(buf, sizeof(buf), fmt,
+            box.minx(), box.miny(), box.maxx(), box.maxy(),
+            std::max(box.srid_, 0));
+    return os.write(buf, std::min(len, int(sizeof(buf)) - 1));
+}
+
+
+}} // namespace mapnik::pgcommon
+
+#endif // MAPNIK_PLUGINS_INPUT_PGCOMMON_SQL_UTILS_HPP

--- a/plugins/input/pgcommon/sql_utils.hpp
+++ b/plugins/input/pgcommon/sql_utils.hpp
@@ -34,6 +34,48 @@
 namespace mapnik { namespace pgcommon {
 
 
+// sql_float4
+
+struct sql_float4
+{
+    float value;
+};
+
+inline sql_float4 sql_float(float value)
+{
+    return {value};
+}
+
+inline std::ostream & operator << (std::ostream & os, sql_float4 sf)
+{
+    char const fmt[] = "float4 '%a'";
+    char buf[sizeof(fmt) + 25];
+    int len = std::snprintf(buf, sizeof(buf), fmt, sf.value);
+    return os.write(buf, std::min(len, int(sizeof(buf)) - 1));
+}
+
+
+// sql_float8
+
+struct sql_float8
+{
+    double value;
+};
+
+inline sql_float8 sql_float(double value)
+{
+    return {value};
+}
+
+inline std::ostream & operator << (std::ostream & os, sql_float8 sf)
+{
+    char const fmt[] = "float8 '%a'";
+    char buf[sizeof(fmt) + 25];
+    int len = std::snprintf(buf, sizeof(buf), fmt, sf.value);
+    return os.write(buf, std::min(len, int(sizeof(buf)) - 1));
+}
+
+
 // sql_bbox
 
 struct sql_bbox : box2d<double>

--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -60,6 +60,7 @@ const std::string pgraster_datasource::SPATIAL_REF_SYS = "spatial_ref_system";
 using std::shared_ptr;
 using mapnik::attribute_descriptor;
 using mapnik::pgcommon::sql_bbox;
+using mapnik::pgcommon::sql_float;
 using mapnik::sql_utils::identifier;
 using mapnik::sql_utils::literal;
 using mapnik::value_integer;
@@ -611,9 +612,6 @@ std::string pgraster_datasource::populate_tokens(std::string const& sql,
     char const* start = sql.data();
     char const* end = start + sql.size();
 
-    populated_sql.precision(16);
-    populated_sql << std::showpoint;
-
     while (std::regex_search(start, end, m, re_tokens_))
     {
         populated_sql.write(start, m[0].first - start);
@@ -641,15 +639,15 @@ std::string pgraster_datasource::populate_tokens(std::string const& sql,
         }
         else if (boost::algorithm::equals(m1, "pixel_height"))
         {
-            populated_sql << pixel_height;
+            populated_sql << sql_float(pixel_height);
         }
         else if (boost::algorithm::equals(m1, "pixel_width"))
         {
-            populated_sql << pixel_width;
+            populated_sql << sql_float(pixel_width);
         }
         else if (boost::algorithm::equals(m1, "scale_denominator"))
         {
-            populated_sql << scale_denom;
+            populated_sql << sql_float(scale_denom);
         }
         else
         {
@@ -889,9 +887,9 @@ featureset_ptr pgraster_datasource::features_with_context(query const& q,process
         if (prescale_rasters_) {
           const double scale = std::min(px_gw, px_gh);
           s << ", least(1.0, abs(ST_ScaleX(" << identifier(col)
-            << "))::float8/" << scale
+            << "))::float8/" << sql_float(scale)
             << "), least(1.0, abs(ST_ScaleY(" << identifier(col)
-            << "))::float8/" << scale << "))";
+            << "))::float8/" << sql_float(scale) << "))";
           // TODO: if band_ is given, we'll interpret as indexed so
           //       the rescaling must NOT ruin it (use algorithm mode!)
         }

--- a/plugins/input/pgraster/pgraster_datasource.hpp
+++ b/plugins/input/pgraster/pgraster_datasource.hpp
@@ -90,7 +90,6 @@ public:
     layer_descriptor get_descriptor() const;
 
 private:
-    std::string sql_bbox(box2d<double> const& env) const;
     std::string populate_tokens(std::string const& sql, double scale_denom,
                                 box2d<double> const& env,
                                 double pixel_width, double pixel_height,

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -56,6 +56,7 @@ const std::string postgis_datasource::SPATIAL_REF_SYS = "spatial_ref_system";
 using std::shared_ptr;
 using mapnik::attribute_descriptor;
 using mapnik::pgcommon::sql_bbox;
+using mapnik::pgcommon::sql_float;
 using mapnik::sql_utils::identifier;
 using mapnik::sql_utils::literal;
 
@@ -521,9 +522,6 @@ std::string postgis_datasource::populate_tokens(
     char const* start = sql.data();
     char const* end = start + sql.size();
 
-    populated_sql.precision(16);
-    populated_sql << std::showpoint;
-
     while (std::regex_search(start, end, m, re_tokens_))
     {
         populated_sql.write(start, m[0].first - start);
@@ -551,15 +549,15 @@ std::string postgis_datasource::populate_tokens(
         }
         else if (boost::algorithm::equals(m1, "pixel_height"))
         {
-            populated_sql << pixel_height;
+            populated_sql << sql_float(pixel_height);
         }
         else if (boost::algorithm::equals(m1, "pixel_width"))
         {
-            populated_sql << pixel_width;
+            populated_sql << sql_float(pixel_width);
         }
         else if (boost::algorithm::equals(m1, "scale_denominator"))
         {
-            populated_sql << scale_denom;
+            populated_sql << sql_float(scale_denom);
         }
         else
         {
@@ -779,9 +777,9 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
             }
 
             // ! ST_RemoveRepeatedPoints()
-            s << "," << twkb_tolerance << ")";
+            s << "," << sql_float(twkb_tolerance) << ")";
             // ! ST_Simplify(), with parameter to keep collapsed geometries
-            s << "," << twkb_tolerance << ",true)";
+            s << "," << sql_float(twkb_tolerance) << ",true)";
             // ! ST_TWKB()
             s << "," << twkb_rounding << ") AS geom";
         }
@@ -808,7 +806,7 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
             if (simplify_geometries_ && simplify_snap_ratio_ > 0.0)
             {
                 const double tolerance = px_sz * simplify_snap_ratio_;
-                s << "," << tolerance << ")";
+                s << "," << sql_float(tolerance) << ")";
             }
 
             // ! ST_ClipByBox2D()
@@ -821,7 +819,7 @@ featureset_ptr postgis_datasource::features_with_context(query const& q,processo
             if (simplify_geometries_)
             {
                 const double tolerance = px_sz * simplify_dp_ratio_;
-                s << ", " << tolerance;
+                s << ", " << sql_float(tolerance);
                 // Add parameter to ST_Simplify to keep collapsed geometries
                 if (simplify_dp_preserve_)
                 {

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -78,7 +78,6 @@ public:
     layer_descriptor get_descriptor() const;
 
 private:
-    std::string sql_bbox(box2d<double> const& env) const;
     std::string populate_tokens(std::string const& sql,
                                 double scale_denom,
                                 box2d<double> const& env,

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -178,6 +178,18 @@ TEST_CASE("postgis") {
             auto ds = mapnik::datasource_cache::instance().create(params);
         }
 
+        SECTION("Postgis select from empty table")
+        {
+            mapnik::parameters params(base_params);
+            params["table"] = "test_empty_table";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+            mapnik::query qry(ds->envelope());
+            auto featureset = ds->features(qry);
+            auto feature = featureset->next();
+            CHECK(feature == nullptr);
+        }
+
         SECTION("Postgis dataset geometry type")
         {
             mapnik::parameters params(base_params);

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -316,9 +316,9 @@ TEST_CASE("postgis") {
             auto feature = featureset->next();
             CHECKED_IF(feature != nullptr)
             {
-                CHECK(feature->get("t_pixel_width").to_string() == "numeric");
-                CHECK(feature->get("t_pixel_height").to_string() == "numeric");
-                CHECK(feature->get("t_scale_denom").to_string() == "numeric");
+                CHECK(feature->get("t_pixel_width").to_string() == "double precision");
+                CHECK(feature->get("t_pixel_height").to_string() == "double precision");
+                CHECK(feature->get("t_scale_denom").to_string() == "double precision");
             }
         }
 


### PR DESCRIPTION
Fixes #4079 
Refs #2361 

Pass floating-point numbers in SQL queries with explicit type cast and in hexfloat format (exact value). Postgres parses floats with `stdtod`, which understands hexfloat since C99.

On plugin side, I intended to use stream format `std::hexfloat`, but to my surprise libstdc++ 4.9 (which clang builds on travis still use) does not implement it (was added in libstdc++ 5.1). In the end, using C99 `snprintf` to produce what's going to be parsed by C99 `strtod` seems like a much better idea.


#### TODO
- [ ] CHANGELOG
- [ ] Before merging this PR, merge branch https://github.com/mapnik/test-data/tree/postgis-empty-table into test-data master
