### PR TITLE
scons: prevent duplication of linker flags

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1423,14 +1423,16 @@ if not preconfigured:
     env.Append(LINKFLAGS = DEFAULT_CXX14_LINKFLAGS)
 
     custom_ldflags = env.ParseFlags(env['CUSTOM_LDFLAGS'])
-    # ParseFlags puts everything it does not recognize into CCFLAGS,
-    # but let's assume the user knows better, put those in LINKFLAGS
-    env.Append(LINKFLAGS = custom_ldflags.pop('CCFLAGS'))
     env.Append(LINKFLAGS = custom_ldflags.pop('LINKFLAGS'),
                LIBS = custom_ldflags.pop('LIBS'))
     env.AppendUnique(FRAMEWORKS = custom_ldflags.pop('FRAMEWORKS'),
                      LIBPATH = custom_ldflags.pop('LIBPATH'),
                      RPATH = custom_ldflags.pop('RPATH'))
+    # ParseFlags puts everything it does not recognize into CCFLAGS,
+    # but let's assume the user knows better: add those to LINKFLAGS.
+    # In order to prevent duplication of flags which ParseFlags puts
+    # into both CCFLAGS and LINKFLAGS, call AppendUnique.
+    env.AppendUnique(LINKFLAGS = custom_ldflags.pop('CCFLAGS'))
 
     invalid_ldflags = {k:v for k,v in custom_ldflags.items() if v}
     if invalid_ldflags:


### PR DESCRIPTION
Refs #4120 

There's a minor issue with flags that `env.ParseFlags` appends to both `CCFLAGS` and `LINKFLAGS`. Simply concatenating those lists then duplicates such flags (e.g. `-arch`).
https://github.com/mapnik/mapnik/blob/5732df452cda20b42c26f1946e3b770b142f403e/scons/scons-local-3.0.1/SCons/Environment.py#L722-L725

