### PR TITLE
Update SConstruct to fix osx build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -691,7 +691,7 @@ def parse_config(context, config, checks='--libs --cflags'):
                 # and thus breaks knowledge below that gdal worked
                 # TODO - upgrade our scons logic to support Framework linking
                 if env['PLATFORM'] == 'Darwin':
-                    if value and '-framework GDAL' in value:
+                    if value and b'-framework GDAL' in value:
                         env['LIBS'].append('gdal')
                         if os.path.exists('/Library/Frameworks/GDAL.framework/unix/lib'):
                             env['LIBPATH'].insert(0,'/Library/Frameworks/GDAL.framework/unix/lib')


### PR DESCRIPTION
Fixed framework presence check to avoid TypeError:
TypeError: a bytes-like object is required, not 'str':