### PR TITLE
proj_transform test: Add bbox snapped test values for PROJ >= 6

### DIFF
--- a/test/unit/projection/proj_transform.cpp
+++ b/test/unit/projection/proj_transform.cpp
@@ -172,8 +172,13 @@ SECTION("Test proj antimeridian bbox")
     //        274000 7173000 # top-most
     //  END
     //
+#if PJ_VERSION >= 600
+    const mapnik::box2d<double> normal(148.7639922894, -60.1221489798,
+                                       159.9548476477, -24.9771194497);
+#else
     const mapnik::box2d<double> normal(148.7667597489, -60.1222810241,
                                        159.9548489296, -24.9771195155);
+#endif
 
     {
         // checks for not being snapped (ie. not antimeridian)


### PR DESCRIPTION
Values checked on PROJ 6.3.1 on Ubuntu 20.04 and PROJ 7.0.1 on Gentoo.

---

Looks like a fix for: https://github.com/mapnik/mapnik/issues/4117#issuecomment-577127176
