### PR TITLE
Allow builds on OpenBSD

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1444,7 +1444,7 @@ if not preconfigured:
     ### platform specific bits
 
     thread_suffix = 'mt'
-    if env['PLATFORM'] == 'FreeBSD':
+    if env['PLATFORM'] == 'FreeBSD' or env['PLATFORM'] == 'OpenBSD':
         thread_suffix = ''
         env.Append(LIBS = 'pthread')
 

--- a/src/build.py
+++ b/src/build.py
@@ -38,6 +38,11 @@ def call(cmd, silent=True):
 
 def ldconfig(*args,**kwargs):
     call('ldconfig')
+    if env['PLATFORM'] == 'OpenBSD':
+        # For OBSD call ldconfig as done by rc -- refer to rc.conf(8)
+        call('ldconfig /usr/X11R6/lib /usr/local/lib')
+    else:
+        call('ldconfig')
 
 if env['LINKING'] == 'static':
     lib_env.Append(CXXFLAGS="-fPIC")
@@ -117,7 +122,7 @@ if env['RUNTIME_LINK'] != 'static':
 
 lib_env['LIBS'].append('z')
 
-if env['PLATFORM'] == 'FreeBSD':
+if env['PLATFORM'] == 'FreeBSD' or env['PLATFORM'] == 'OpenBSD':
     lib_env['LIBS'].append('pthread')
 
 if env['PLATFORM'] == 'Darwin':
@@ -139,7 +144,7 @@ else: # unix, non-macos
         else:
             mapnik_lib_link_flag += ' -Wl,-h,%s' %  mapnik_libname
     else: # Linux and others
-        if env['PLATFORM'] != 'FreeBSD':
+        if env['PLATFORM'] != 'FreeBSD' or env['PLATFORM'] != 'OpenBSD':
             lib_env['LIBS'].append('dl')
         mapnik_lib_link_flag += ' -Wl,-rpath-link,.'
         if env['ENABLE_SONAME']:


### PR DESCRIPTION
After making these changes, I was then able to build mapnik on OpenBSD.


Just in case anyone feels crazy and wants to try on OpenBSD for themselves ;-), this was the configure line that worked for me:

./configure ICU_LIBS=/usr/local/lib ICU_INCLUDES=/usr/local/include HB_LIBS=/usr/local/lib HB_INCLUDES=/usr/local/include PROJ_LIBS=/usr/local/lib PROJ_INCLUDES=/usr/local/include FREETYPE_LIBS=/usr/X11R6/lib FREETYPE_INCLUDES=/usr/X11R6/include/freetype2 CUSTOM_CFLAGS=-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 -I/usr/X11R6/include/freetype2 CUSTOM_CXXFLAGS=-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1 -I/usr/X11R6/include/freetype2

