### PR TITLE
fix pg_config error for darwin os

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -615,7 +615,7 @@ def parse_config(context, config, checks='--libs --cflags'):
                 # and thus breaks knowledge below that gdal worked
                 # TODO - upgrade our scons logic to support Framework linking
                 if env['PLATFORM'] == 'Darwin':
-                    value = call(cmd,silent=True)
+                    value = call(cmd,silent=True).decode("utf-8")
                     if value and '-framework GDAL' in value:
                         env['LIBS'].append('gdal')
                         if os.path.exists('/Library/Frameworks/GDAL.framework/unix/lib'):


### PR DESCRIPTION
Issue: https://github.com/mapnik/mapnik/issues/4170

Fixes the following error when trying to run `./configure` on mac OSX 10.15.6:
``` bash
Checking for requested plugins dependencies...
Checking for pg_config... yes
Checking for pg_config... yes
TypeError: a bytes-like object is required, not 'str':
  File "/Users/msitu/src/improc/icin/geotizzler/mapnik/SConstruct", line 1652:
    if conf.parse_config('GDAL_CONFIG',checks='--libs'):
  File "/Users/msitu/src/improc/icin/geotizzler/mapnik/scons/scons-local-3.0.1/SCons/SConf.py", line 659:
    ret = self.test(context, *args, **kw)
  File "/Users/msitu/src/improc/icin/geotizzler/mapnik/SConstruct", line 619:
    if value and '-framework GDAL' in value:
Checking for gdal-config --libs... %   
```