### PR TITLE
Fixed to compile with Visual Studio 2017 Express

### DIFF
--- a/include/mapnik/function_call.hpp
+++ b/include/mapnik/function_call.hpp
@@ -116,13 +116,13 @@ struct length_impl
 // min
 inline value_type min_impl(value_type const& arg1, value_type const& arg2)
 {
-    return std::min(arg1.to_double(), arg2.to_double());
+    return (std::min)(arg1.to_double(), arg2.to_double());
 }
 
 // max
 inline value_type max_impl(value_type const& arg1, value_type const& arg2)
 {
-    return std::max(arg1.to_double(), arg2.to_double());
+    return (std::max)(arg1.to_double(), arg2.to_double());
 }
 
 // pow

--- a/include/mapnik/text/font_feature_settings.hpp
+++ b/include/mapnik/text/font_feature_settings.hpp
@@ -87,7 +87,7 @@ inline bool operator==(font_feature_settings const& lhs, font_feature_settings c
 }
 
 constexpr unsigned int font_feature_range_global_start = 0u;
-static const unsigned int font_feature_range_global_end = std::numeric_limits<unsigned int>::max();
+static const unsigned int font_feature_range_global_end = (std::numeric_limits<unsigned int>::max)();
 
 #pragma GCC diagnostic push
 #include <mapnik/warning_ignore.hpp>


### PR DESCRIPTION
Compiling in Windows with Visual Studio has a well known problem that they have MIN and MAX macros that conflict with other functions in the standard library like `std::numeric_limits<T>::max` and `std::numeric_limits<T>::min`. The standard portable solution is to wrap the function call in parentheses `(std::numeric_limits<T>::max)`.