### PR TITLE
fixes proj_transform_cache incomplete type

### DIFF
--- a/include/mapnik/map.hpp
+++ b/include/mapnik/map.hpp
@@ -103,7 +103,7 @@ private:
     boost::optional<std::string> font_directory_;
     freetype_engine::font_file_mapping_type font_file_mapping_;
     freetype_engine::font_memory_cache_type font_memory_cache_;
-    std::unique_ptr<proj_transform_cache> proj_cache_ = {};
+    std::unique_ptr<proj_transform_cache> proj_cache_;
 public:
     using const_style_iterator = std::map<std::string,feature_type_style>::const_iterator;
     using style_iterator = std::map<std::string,feature_type_style>::iterator;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -76,7 +76,8 @@ Map::Map()
     extra_params_(),
     font_directory_(),
     font_file_mapping_(),
-    font_memory_cache_() {}
+    font_memory_cache_(),
+    proj_cache_(std::make_unique<proj_transform_cache>()) {}
 
 Map::Map(int width,int height, std::string const& srs)
     : width_(width),
@@ -90,7 +91,8 @@ Map::Map(int width,int height, std::string const& srs)
       extra_params_(),
       font_directory_(),
       font_file_mapping_(),
-      font_memory_cache_() {}
+      font_memory_cache_(),
+      proj_cache_(std::make_unique<proj_transform_cache>()) {}
 
 Map::Map(Map const& rhs)
     : width_(rhs.width_),
@@ -112,7 +114,8 @@ Map::Map(Map const& rhs)
       font_directory_(rhs.font_directory_),
       font_file_mapping_(rhs.font_file_mapping_),
       // on copy discard memory caches
-      font_memory_cache_()
+      font_memory_cache_(),
+      proj_cache_(std::make_unique<proj_transform_cache>())
 {
     init_proj_transforms();
 }


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/mapnik/mapnik/pull/4191#issuecomment-811946506

The following error was reported:
```
In file included from /usr/include/c++/7/memory:80:0,
                 from /mnt/vcpkg-ci/buildtrees/mapnik/src/c7cd6ca2e3-41c4b42cba.clean/include/mapnik/text/font_library.hpp:31,
                 from /mnt/vcpkg-ci/buildtrees/mapnik/src/c7cd6ca2e3-41c4b42cba.clean/include/mapnik/font_engine_freetype.hpp:31,
                 from /mnt/vcpkg-ci/buildtrees/mapnik/src/c7cd6ca2e3-41c4b42cba.clean/include/mapnik/renderer_common.hpp:27,
                 from /mnt/vcpkg-ci/buildtrees/mapnik/src/c7cd6ca2e3-41c4b42cba.clean/src/renderer_common.cpp:23:
/usr/include/c++/7/bits/unique_ptr.h: In instantiation of ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = mapnik::proj_transform_cache]’:
/usr/include/c++/7/bits/unique_ptr.h:263:17:   required from ‘std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = mapnik::proj_transform_cache; _Dp = std::default_delete<mapnik::proj_transform_cache>]’
/mnt/vcpkg-ci/buildtrees/mapnik/src/c7cd6ca2e3-41c4b42cba.clean/include/mapnik/map.hpp:106:58:   required from here
/usr/include/c++/7/bits/unique_ptr.h:76:22: error: invalid application of ‘sizeof’ to incomplete type ‘mapnik::proj_transform_cache’
  static_assert(sizeof(_Tp)>0,
```