### PR TITLE
Add flag for reading ids from geojson source

### DIFF
--- a/include/mapnik/feature.hpp
+++ b/include/mapnik/feature.hpp
@@ -101,15 +101,17 @@ public:
     using cont_type = std::vector<value_type>;
     using iterator = feature_kv_iterator;
 
-    feature_impl(context_ptr const& ctx, mapnik::value_integer _id)
+    feature_impl(context_ptr const& ctx, mapnik::value_integer _id, bool _use_id_from_source = false)
         : id_(_id),
         ctx_(ctx),
         data_(ctx_->mapping_.size()),
         geom_(geometry::geometry_empty()),
-        raster_() {}
+        raster_(),
+        use_id_from_source_(_use_id_from_source) {}
 
     inline mapnik::value_integer id() const { return id_;}
     inline void set_id(mapnik::value_integer _id) { id_ = _id;}
+    inline bool use_id_from_source() { return use_id_from_source_; }
     template <typename T>
     inline void put(context_type::key_type const& key, T const& val)
     {
@@ -267,6 +269,7 @@ private:
     cont_type data_;
     geometry::geometry<double> geom_;
     raster_ptr raster_;
+    bool use_id_from_source_;
 };
 
 

--- a/include/mapnik/feature_factory.hpp
+++ b/include/mapnik/feature_factory.hpp
@@ -34,11 +34,11 @@ namespace mapnik
 {
 struct feature_factory
 {
-    static std::shared_ptr<feature_impl> create (context_ptr const& ctx, mapnik::value_integer fid)
+    static std::shared_ptr<feature_impl> create (context_ptr const& ctx, mapnik::value_integer fid, bool use_id_from_source = false)
     {
         //return boost::allocate_shared<feature_impl>(boost::pool_allocator<feature_impl>(),fid);
         //return boost::allocate_shared<feature_impl>(boost::fast_pool_allocator<feature_impl>(),fid);
-        return std::make_shared<feature_impl>(ctx,fid);
+        return std::make_shared<feature_impl>(ctx,fid,use_id_from_source);
     }
 };
 }

--- a/include/mapnik/json/feature_grammar_x3.hpp
+++ b/include/mapnik/json/feature_grammar_x3.hpp
@@ -35,12 +35,15 @@ namespace mapnik { namespace json { namespace grammar {
 
 namespace x3 = boost::spirit::x3;
 using feature_grammar_type = x3::rule<class feature_rule_tag>;
+using feature_with_id_grammar_type = x3::rule<class feature_with_id_rule_tag>;
 using geometry_grammar_type = x3::rule<struct geomerty_rule_tag, mapnik::geometry::geometry<double> >;
 
 feature_grammar_type const feature_rule = "Feature Rule";
+feature_with_id_grammar_type const feature_with_id_rule = "Feature With Id Rule";
 geometry_grammar_type const geometry_rule = "Geometry Rule";
 
 BOOST_SPIRIT_DECLARE(feature_grammar_type);
+BOOST_SPIRIT_DECLARE(feature_with_id_grammar_type);
 BOOST_SPIRIT_DECLARE(geometry_grammar_type);
 
 }}}

--- a/plugins/input/geobuf/geobuf.hpp
+++ b/plugins/input/geobuf/geobuf.hpp
@@ -218,7 +218,7 @@ private:
     template <typename T>
     void read_feature (T & reader)
     {
-        auto feature = feature_factory::create(ctx_,1);
+        auto feature = feature_factory::create(ctx_,1,true);
         while (reader.next())
         {
             switch (reader.tag())

--- a/plugins/input/geojson/geojson_datasource.hpp
+++ b/plugins/input/geojson/geojson_datasource.hpp
@@ -104,6 +104,7 @@ private:
     std::unique_ptr<spatial_index_type> tree_;
     bool cache_features_ = true;
     bool has_disk_index_ = false;
+    bool use_id_from_source_ = false;
     const std::size_t num_features_to_query_;
 };
 

--- a/src/json/feature_grammar_x3.cpp
+++ b/src/json/feature_grammar_x3.cpp
@@ -26,12 +26,15 @@
 namespace mapnik { namespace json { namespace grammar {
 
 BOOST_SPIRIT_INSTANTIATE(feature_grammar_type, iterator_type, feature_context_type);
+BOOST_SPIRIT_INSTANTIATE(feature_with_id_grammar_type, iterator_type, feature_context_type);
 BOOST_SPIRIT_INSTANTIATE(geometry_grammar_type, iterator_type, phrase_parse_context_type);
 
 #if BOOST_VERSION >= 107000
 BOOST_SPIRIT_INSTANTIATE(feature_grammar_type, iterator_type, feature_context_const_type);
+BOOST_SPIRIT_INSTANTIATE(feature_with_id_grammar_type, iterator_type, feature_context_const_type);
 #else
 BOOST_SPIRIT_INSTANTIATE_UNUSED(feature_grammar_type, iterator_type, feature_context_const_type);
+BOOST_SPIRIT_INSTANTIATE_UNUSED(feature_with_id_grammar_type, iterator_type, feature_context_const_type);
 #endif
 
 }}}

--- a/src/json/parse_feature.cpp
+++ b/src/json/parse_feature.cpp
@@ -35,12 +35,27 @@ void parse_feature(Iterator start, Iterator end, feature_impl& feature, mapnik::
     auto grammar = x3::with<mapnik::json::grammar::transcoder_tag>(tr)
         [x3::with<mapnik::json::grammar::feature_tag>(feature)
          [ mapnik::json::grammar::feature_rule ]];
+    auto grammar_with_id = x3::with<mapnik::json::grammar::transcoder_tag>(tr)
+        [x3::with<mapnik::json::grammar::feature_tag>(feature)
+         [ mapnik::json::grammar::feature_with_id_rule ]];
 #else
     auto grammar = x3::with<mapnik::json::grammar::transcoder_tag>(std::ref(tr))
         [x3::with<mapnik::json::grammar::feature_tag>(std::ref(feature))
          [ mapnik::json::grammar::feature_rule ]];
+    auto grammar_with_id = x3::with<mapnik::json::grammar::transcoder_tag>(std::ref(tr))
+        [x3::with<mapnik::json::grammar::feature_tag>(std::ref(feature))
+         [ mapnik::json::grammar::feature_with_id_rule ]];
 #endif
-    if (!x3::phrase_parse(start, end, grammar, space_type()))
+    bool parse_success = true;
+    if (feature.use_id_from_source())
+    {
+        parse_success = x3::phrase_parse(start, end, grammar_with_id, space_type());
+    }
+    else
+    {
+        parse_success = x3::phrase_parse(start, end, grammar, space_type());
+    }
+    if (!parse_success)
     {
         throw std::runtime_error("Can't parser GeoJSON Feature");
     }

--- a/test/unit/datasource/geojson.cpp
+++ b/test/unit/datasource/geojson.cpp
@@ -956,5 +956,54 @@ TEST_CASE("geojson") {
                 }
             }
         }
+
+        SECTION("GeoJSON reads id from source file when 'use_id_from_source=true'")
+        {
+            // Create datasource
+            mapnik::parameters params;
+            params["type"] = "geojson";
+            std::string base("./test/data/json/");
+            std::string file("feature-with-id.json");
+            params["base"] = base;
+            params["file"] = file;
+            params["use_id_from_source"] = true;
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(bool(ds));
+            CHECK(ds->get_geometry_type() == mapnik::datasource_geometry_t::Point);
+            auto features = all_features(ds);
+            auto feature = features->next();
+            REQUIRE(feature != nullptr);
+            CHECK(feature->id() == 12345);
+        }
+
+        SECTION("GeoJSON throws on invalid Feature.id when 'use_id_from_source=true'")
+        {
+            // Create datasource
+            mapnik::parameters params;
+            params["type"] = "geojson";
+            std::string base("./test/data/json/");
+            std::string file("feature-with-invalid-id.json");
+            params["base"] = base;
+            params["file"] = file;
+            params["use_id_from_source"] = true;
+            REQUIRE_THROWS(mapnik::datasource_cache::instance().create(params));
+        }
+
+        SECTION("GeoJSON ignores invalid Feature.id when 'use_id_from_source=false' or not set")
+        {
+            // Create datasource
+            mapnik::parameters params;
+            params["type"] = "geojson";
+            std::string base("./test/data/json/");
+            std::string file("feature-with-invalid-id.json");
+            params["base"] = base;
+            params["file"] = file;
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            CHECK(ds->get_geometry_type() == mapnik::datasource_geometry_t::Point);
+            auto features = all_features(ds);
+            auto feature = features->next();
+            REQUIRE(feature != nullptr);
+            CHECK(feature->id() == 1);
+        }
     }
 }


### PR DESCRIPTION
GeoJSON: Expose `use_id_from_source` datasource parameter to load features with their original ids from the source. Should address #4227 

Things to note here:
* Added a separate Spirit X3 rule for features that have an ID. This means by default parsing without any flags set will continue to ignore `Feature.id`. But once the flag is set, it will throw an error for invalid ids (e.g. string, null, etc...)
* Used `feature.use_id_from_source()` to check which grammar to use. I figured it can also be used by other plugins if they want to make it as an option.
* All instances where this flag is required is set to false by default. It should not change behavior for downstream packages. 
* Since this is opt-in, I don't think it breaks the original design decision to ensure `Feature.id`s as unique internally.

Depends on this PR: https://github.com/mapnik/test-data/pull/23