### PR TITLE
Fix bounding box in svg patterns

### DIFF
--- a/src/marker_cache.cpp
+++ b/src/marker_cache.cpp
@@ -187,9 +187,7 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                 }
             }
             //svg.arrange_orientations();
-            double lox,loy,hix,hiy;
-            svg.bounding_rect(&lox, &loy, &hix, &hiy);
-            marker_path->set_bounding_box(lox,loy,hix,hiy);
+            marker_path->set_bounding_box(0,0,svg.width(),svg.height());
             marker_path->set_dimensions(svg.width(),svg.height());
             if (update_cache)
             {
@@ -227,9 +225,7 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                     }
                 }
                 //svg.arrange_orientations();
-                double lox,loy,hix,hiy;
-                svg.bounding_rect(&lox, &loy, &hix, &hiy);
-                marker_path->set_bounding_box(lox,loy,hix,hiy);
+                marker_path->set_bounding_box(0,0,svg.width(),svg.height());
                 marker_path->set_dimensions(svg.width(),svg.height());
                 if (update_cache)
                 {

--- a/src/marker_cache.cpp
+++ b/src/marker_cache.cpp
@@ -187,9 +187,8 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                 }
             }
             //svg.arrange_orientations();
-            double width, height;
-            width = svg.width();
-            height = svg.height();
+            const double width = svg.width();
+            const double height = svg.height();
             marker_path->set_dimensions(width,height);
             if (width != 0 && height != 0) {
                 marker_path->set_bounding_box(0,0,width,height);
@@ -237,9 +236,8 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                     }
                 }
                 //svg.arrange_orientations();
-                double width, height;
-                width = svg.width();
-                height = svg.height();
+                const double width = svg.width();
+                const double height = svg.height();
                 marker_path->set_dimensions(width,height);
                 if (width != 0 && height != 0) {
                     marker_path->set_bounding_box(0,0,width,height);

--- a/src/marker_cache.cpp
+++ b/src/marker_cache.cpp
@@ -187,8 +187,20 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                 }
             }
             //svg.arrange_orientations();
-            marker_path->set_bounding_box(0,0,svg.width(),svg.height());
-            marker_path->set_dimensions(svg.width(),svg.height());
+            double width, height;
+            width = svg.width();
+            height = svg.height();
+            marker_path->set_dimensions(width,height);
+            if (width != 0 && height != 0) {
+                marker_path->set_bounding_box(0,0,width,height);
+            } else {
+                // falback in case the SVG has a zero width, height, or has
+                // those as percentages: determine the smallest rectangle
+                // in which all objects fit.
+                double lox,loy,hix,hiy;
+                svg.bounding_rect(&lox, &loy, &hix, &hiy);
+                marker_path->set_bounding_box(lox,loy,hix,hiy);
+            }
             if (update_cache)
             {
                 auto emplace_result = marker_cache_.emplace(uri,std::make_shared<mapnik::marker const>(mapnik::marker_svg(marker_path)));
@@ -225,8 +237,20 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                     }
                 }
                 //svg.arrange_orientations();
-                marker_path->set_bounding_box(0,0,svg.width(),svg.height());
-                marker_path->set_dimensions(svg.width(),svg.height());
+                double width, height;
+                width = svg.width();
+                height = svg.height();
+                marker_path->set_dimensions(width,height);
+                if (width != 0 && height != 0) {
+                    marker_path->set_bounding_box(0,0,width,height);
+                } else {
+                    // falback in case the SVG has a zero width, height, or has
+                    // those as percentages: determine the smallest rectangle
+                    // in which all objects fit.
+                    double lox,loy,hix,hiy;
+                    svg.bounding_rect(&lox, &loy, &hix, &hiy);
+                    marker_path->set_bounding_box(lox,loy,hix,hiy);
+                }
                 if (update_cache)
                 {
                     auto emplace_result = marker_cache_.emplace(uri,std::make_shared<mapnik::marker const>(mapnik::marker_svg(marker_path)));

--- a/test/unit/svg/svg_parser_test.cpp
+++ b/test/unit/svg/svg_parser_test.cpp
@@ -847,4 +847,15 @@ TEST_CASE("SVG parser") {
         CHECK(bbox.width() == Approx(100));
         CHECK(bbox.height() == Approx(100));
     }
+
+    SECTION("SVG contents outside <viewBox>")
+    {
+        std::string svg_name("./test/data/svg/shape_outside_viewbox.svg");
+        std::shared_ptr<mapnik::marker const> marker = mapnik::marker_cache::instance().find(svg_name, false);
+        REQUIRE(marker);
+        REQUIRE(marker->is<mapnik::marker_svg>());
+        mapnik::marker_svg const& svg = mapnik::util::get<mapnik::marker_svg>(*marker);
+        auto bbox = svg.bounding_box();
+        REQUIRE(bbox == mapnik::box2d<double>(0, 0, 10, 10));
+    }
 }

--- a/utils/svg2png/svg2png.cpp
+++ b/utils/svg2png/svg2png.cpp
@@ -74,8 +74,10 @@ struct main_marker_visitor
         agg::scanline_u8 sl;
 
         double opacity = 1;
-        double w, h;
+        double w, h, x, y;
         std::tie(w, h) = marker.dimensions();
+        x = 0;
+        y = 0;
         if (w == 0 || h == 0)
         {
             if (verbose_)
@@ -83,6 +85,8 @@ struct main_marker_visitor
                 std::clog << "Invalid SVG dimensions: " << w << "," << h << " using svgBBOX()" << std::endl;
             }
             auto b = marker.bounding_box();
+            x = b.minx();
+            y = b.miny();
             w = b.width();
             h = b.height();
         }
@@ -104,7 +108,7 @@ struct main_marker_visitor
 
         mapnik::box2d<double> bbox = {0, 0, svg_width, svg_height};
         // center the svg marker on '0,0'
-        agg::trans_affine mtx = agg::trans_affine_translation(-0.5 * w, -0.5 * h);
+        agg::trans_affine mtx = agg::trans_affine_translation(-0.5 * w - x, -0.5 * h - y);
         // Scale the image
         mtx.scale(scale_factor_);
         // render the marker at the center of the marker box


### PR DESCRIPTION
In SVG patterns, Mapnik currently ignores the viewBox of the svg, and determines the bounding box by rendering all elements inside the pattern and looking at the extends. Those are then scaled and centered to the pattern tile size.

Looking through the issues and PRs this has caused quite some difficulties for https://github.com/gravitystorm/openstreetmap-carto (see https://github.com/gravitystorm/openstreetmap-carto/issues/2750), and is blocking the conversion to vector patterns and vector tile output (https://github.com/gravitystorm/openstreetmap-carto/issues/2045). Quite a few PRs in https://github.com/gravitystorm/openstreetmap-carto couldn't get merged or were backed out because of this issue (https://github.com/gravitystorm/openstreetmap-carto/pull/2759, https://github.com/gravitystorm/openstreetmap-carto/pull/2727). Some patterns were clipped and/or given a dummy geometry as a workaround (https://github.com/gravitystorm/openstreetmap-carto/pull/2748, https://github.com/gravitystorm/openstreetmap-carto/pull/2714, https://github.com/gravitystorm/openstreetmap-carto/pull/2747, https://github.com/gravitystorm/openstreetmap-carto/pull/2683, https://github.com/gravitystorm/openstreetmap-carto/pull/4059).

As I understand it, the only change necessary is to stop determining the bounding box by looking at the extend of the elements inside the svg, and just use the reported with and height. I must admit my testing was limited, but can confirm it fixes the problem for all patterns I locally have. It also doesn't break scaling when the svg contains a `viewBox` with different dimensions from its width or height.