### PR TITLE
[CMake] make mapnik::core a public dependency of mapnik::mapnik

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -31,7 +31,7 @@ function(mapnik_create_benchmark)
     set(TARGET_NAME "mapnik-benchmark-${BENCHNAME}")
     add_executable(${TARGET_NAME} ${ARGV0})
     target_include_directories(${TARGET_NAME} PRIVATE include)
-    target_link_libraries(${TARGET_NAME} PRIVATE mapnik::core mapnik::agg mapnik::mapnik)
+    target_link_libraries(${TARGET_NAME} PRIVATE mapnik::agg mapnik::mapnik)
 
     mapnik_copy_dependencies(TARGETS ${TARGET_NAME})
 endfunction()

--- a/demo/c++/CMakeLists.txt
+++ b/demo/c++/CMakeLists.txt
@@ -2,7 +2,7 @@ project(mapnik-demo)
 
 add_executable(mapnik-demo rundemo.cpp)
 
-target_link_libraries(mapnik-demo PRIVATE mapnik::core mapnik::agg mapnik::mapnik)
+target_link_libraries(mapnik-demo PRIVATE mapnik::agg mapnik::mapnik)
 
 mapnik_install(TARGET mapnik-demo)
 mapnik_copy_plugins(TARGET mapnik-demo DESTINATION plugins/input PLUGINS input-shape)

--- a/demo/viewer/CMakeLists.txt
+++ b/demo/viewer/CMakeLists.txt
@@ -46,7 +46,6 @@ set_target_properties(mapnik-viewer PROPERTIES
 
 target_link_libraries(mapnik-viewer PRIVATE 
     Qt${QT_VERSION_MAJOR}::Widgets
-    mapnik::core
     mapnik::agg
     mapnik::mapnik
 )

--- a/deps/agg/CMakeLists.txt
+++ b/deps/agg/CMakeLists.txt
@@ -16,4 +16,4 @@ install(TARGETS agg
     RUNTIME DESTINATION bin
     PUBLIC_HEADER DESTINATION include
 )
-# todo install headers
+# agg headers would be installed in the top level CMakeLists.txt

--- a/docs/cmake-usage.md
+++ b/docs/cmake-usage.md
@@ -25,8 +25,13 @@ To use Mapnik in your project add the following lines to your CMakeLists.tzt.
 ```
 find_package(mapnik CONFIG REQUIRED)
 [...]
-target_link_libraries(mytarget ... mapnik::core mapnik::mapnik)
+target_link_libraries(mytarget ... mapnik::mapnik)
 ```
+All targets: 
+* `mapnik::core`: All compile definitions and headers.
+* `mapnik::mapnik`: libmapnik. Has a public dependency on mapnik::core
+* `mapnik::json`: json support for libmapnik.
+* `mapnik::wkt`: wkt support for libmapnik.
 
 All mapnik executables and targets are exported within `mapnikTargets.cmake`. 
 

--- a/plugins/input/csv/CMakeLists.txt
+++ b/plugins/input/csv/CMakeLists.txt
@@ -9,8 +9,7 @@ add_library(input-csv MODULE
 )
 add_library(mapnik::plugin::input::csv ALIAS input-csv)
 
-target_link_libraries(input-csv PRIVATE 
-    mapnik::core 
+target_link_libraries(input-csv PRIVATE
     mapnik::mapnik 
     mapnik::wkt 
     mapnik::json

--- a/plugins/input/gdal/CMakeLists.txt
+++ b/plugins/input/gdal/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library(mapnik::plugin::input::gdal ALIAS input-gdal)
 
 target_include_directories(input-gdal PRIVATE ${GDAL_INCLUDE_DIRS})
 target_link_libraries(input-gdal PRIVATE 
-    mapnik::core 
     mapnik::mapnik
     ${GDAL_LIBRARIES}
 )

--- a/plugins/input/geobuf/CMakeLists.txt
+++ b/plugins/input/geobuf/CMakeLists.txt
@@ -6,10 +6,8 @@ add_library(input-geobuf MODULE
 )
 add_library(mapnik::plugin::input::geobuf ALIAS input-geobuf)
 
-target_link_libraries(input-geobuf PRIVATE  
-    mapnik::core 
-    mapnik::mapnik
-)
+target_link_libraries(input-geobuf PRIVATE mapnik::mapnik)
+
 set_target_properties(input-geobuf PROPERTIES PREFIX "")
 set_target_properties(input-geobuf PROPERTIES OUTPUT_NAME "geobuf")
 set_target_properties(input-geobuf PROPERTIES SUFFIX ".input")

--- a/plugins/input/geojson/CMakeLists.txt
+++ b/plugins/input/geojson/CMakeLists.txt
@@ -8,8 +8,7 @@ add_library(input-geojson MODULE
 )
 add_library(mapnik::plugin::input::geojson ALIAS input-geojson)
 
-target_link_libraries(input-geojson PRIVATE 
-    mapnik::core 
+target_link_libraries(input-geojson PRIVATE
     mapnik::mapnik
     mapnik::json
 )

--- a/plugins/input/ogr/CMakeLists.txt
+++ b/plugins/input/ogr/CMakeLists.txt
@@ -11,8 +11,7 @@ add_library(input-ogr MODULE
 add_library(mapnik::plugin::input::ogr ALIAS input-ogr)
 
 target_include_directories(input-ogr PRIVATE ${GDAL_INCLUDE_DIRS})
-target_link_libraries(input-ogr PRIVATE 
-    mapnik::core 
+target_link_libraries(input-ogr PRIVATE
     mapnik::mapnik
     ${GDAL_LIBRARIES}
 )

--- a/plugins/input/pgraster/CMakeLists.txt
+++ b/plugins/input/pgraster/CMakeLists.txt
@@ -10,8 +10,7 @@ add_library(input-pgraster MODULE
 add_library(mapnik::plugin::input::pgraster ALIAS input-pgraster)
 
 
-target_link_libraries(input-pgraster PRIVATE 
-    mapnik::core 
+target_link_libraries(input-pgraster PRIVATE
     mapnik::mapnik  
     PostgreSQL::PostgreSQL
 )

--- a/plugins/input/postgis/CMakeLists.txt
+++ b/plugins/input/postgis/CMakeLists.txt
@@ -8,8 +8,7 @@ add_library(input-postgis MODULE
 )
 add_library(mapnik::plugin::input::postgis ALIAS input-postgis)
 
-target_link_libraries(input-postgis PRIVATE 
-    mapnik::core 
+target_link_libraries(input-postgis PRIVATE
     mapnik::mapnik  
     PostgreSQL::PostgreSQL
 )

--- a/plugins/input/raster/CMakeLists.txt
+++ b/plugins/input/raster/CMakeLists.txt
@@ -7,10 +7,7 @@ add_library(input-raster MODULE
 )
 add_library(mapnik::plugin::input::raster ALIAS input-raster)
 
-target_link_libraries(input-raster PRIVATE 
-    mapnik::core 
-    mapnik::mapnik
-)
+target_link_libraries(input-raster PRIVATE mapnik::mapnik)
 
 set_target_properties(input-raster PROPERTIES PREFIX "")
 set_target_properties(input-raster PROPERTIES OUTPUT_NAME "raster")

--- a/plugins/input/shape/CMakeLists.txt
+++ b/plugins/input/shape/CMakeLists.txt
@@ -10,10 +10,7 @@ add_library(input-shape MODULE
 )
 add_library(mapnik::plugin::input::shape ALIAS input-shape)
 
-target_link_libraries(input-shape PRIVATE 
-    mapnik::core 
-    mapnik::mapnik
-)
+target_link_libraries(input-shape PRIVATE mapnik::mapnik)
 
 set_target_properties(input-shape PROPERTIES PREFIX "")
 set_target_properties(input-shape PROPERTIES OUTPUT_NAME "shape")

--- a/plugins/input/sqlite/CMakeLists.txt
+++ b/plugins/input/sqlite/CMakeLists.txt
@@ -8,8 +8,7 @@ add_library(input-sqlite MODULE
 )
 add_library(mapnik::plugin::input::sqlite ALIAS input-sqlite)
 
-target_link_libraries(input-sqlite PRIVATE 
-    mapnik::core 
+target_link_libraries(input-sqlite PRIVATE
     mapnik::mapnik 
     SQLite::SQLite3
 )

--- a/plugins/input/topojson/CMakeLists.txt
+++ b/plugins/input/topojson/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(input-topojson MODULE
 )
 add_library(mapnik::plugin::input::topojson ALIAS input-topojson)
 
-target_link_libraries(input-topojson PRIVATE 
-    mapnik::core 
+target_link_libraries(input-topojson PRIVATE
     mapnik::mapnik
     mapnik::json
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -286,10 +286,8 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 target_compile_definitions(mapnik PRIVATE ${COMPILE_DEFS})
-target_link_libraries(mapnik PRIVATE 
-    mapnik::core
-    mapnik::agg
-)
+target_link_libraries(mapnik PUBLIC mapnik::core)
+target_link_libraries(mapnik PRIVATE mapnik::agg)
 
 set_target_properties(mapnik PROPERTIES 
     DEBUG_POSTFIX "${MAPNIK_DEBUG_POSTFIX}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,7 +109,6 @@ add_executable(mapnik-test-unit
 )
 target_link_libraries(mapnik-test-unit PUBLIC
     Catch 
-    mapnik::core
     mapnik::agg
     mapnik::mapnik
     mapnik::json
@@ -120,7 +119,6 @@ target_link_libraries(mapnik-test-unit PUBLIC
 add_executable(agg_rasterizer_integer_overflow_test standalone/agg_rasterizer_integer_overflow_test.cpp)
 target_link_libraries(agg_rasterizer_integer_overflow_test PUBLIC
     Catch 
-    mapnik::core 
     mapnik::mapnik 
     mapnik::agg
     mapnik::json
@@ -129,7 +127,6 @@ target_link_libraries(agg_rasterizer_integer_overflow_test PUBLIC
 add_executable(datasource_registration_test standalone/datasource_registration_test.cpp)
 target_link_libraries(datasource_registration_test PUBLIC
     Catch 
-    mapnik::core 
     mapnik::mapnik 
     mapnik::agg
 )
@@ -137,7 +134,6 @@ target_link_libraries(datasource_registration_test PUBLIC
 add_executable(font_registration_test standalone/font_registration_test.cpp)
 target_link_libraries(font_registration_test PUBLIC
     Catch 
-    mapnik::core 
     mapnik::mapnik 
     mapnik::agg
     mapnik::json
@@ -147,7 +143,6 @@ target_link_libraries(font_registration_test PUBLIC
 add_executable(map_xml_test standalone/map_xml_test.cpp)
 target_link_libraries(map_xml_test PUBLIC
     Catch 
-    mapnik::core 
     mapnik::mapnik 
     mapnik::agg
     mapnik::json
@@ -164,7 +159,6 @@ target_link_libraries(
     Catch
     Boost::program_options
     Boost::filesystem
-    mapnik::core
     mapnik::mapnik
     mapnik::agg
 )

--- a/utils/geometry_to_wkb/CMakeLists.txt
+++ b/utils/geometry_to_wkb/CMakeLists.txt
@@ -2,9 +2,6 @@ project(geometry_to_wkb)
 
 add_executable(geometry_to_wkb main.cpp)
 
-target_link_libraries(geometry_to_wkb PRIVATE 
-    mapnik::core 
-    mapnik::mapnik
-)
+target_link_libraries(geometry_to_wkb PRIVATE mapnik::mapnik)
 
 mapnik_install(TARGET geometry_to_wkb)

--- a/utils/mapnik-index/CMakeLists.txt
+++ b/utils/mapnik-index/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(mapnik-index
     ../../plugins/input/csv/csv_utils.cpp # this project depends on this file
 )
 target_link_libraries(mapnik-index PRIVATE
-    mapnik::core
     mapnik::mapnik
     mapnik::json
     mapnik::wkt

--- a/utils/mapnik-render/CMakeLists.txt
+++ b/utils/mapnik-render/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 add_executable(mapnik-render mapnik-render.cpp)
 
 target_link_libraries(mapnik-render PRIVATE 
-    mapnik::core 
     mapnik::mapnik
     Boost::program_options
 )

--- a/utils/ogrindex/CMakeLists.txt
+++ b/utils/ogrindex/CMakeLists.txt
@@ -2,6 +2,6 @@ project(ogrindex)
 
 add_executable(ogrindex ogrindex.cpp)
 
-target_link_libraries(ogrindex PRIVATE mapnik::core mapnik::mapnik)
+target_link_libraries(ogrindex PRIVATE mapnik::mapnik)
 
 mapnik_install(TARGET ogrindex)

--- a/utils/pgsql2sqlite/CMakeLists.txt
+++ b/utils/pgsql2sqlite/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(pgsql2sqlite PRIVATE
     SQLite::SQLite3
     PostgreSQL::PostgreSQL
     Boost::program_options
-    mapnik::core
     mapnik::mapnik
 )
 

--- a/utils/shapeindex/CMakeLists.txt
+++ b/utils/shapeindex/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(shapeindex
 target_include_directories(shapeindex PRIVATE ../../plugins/input/shape)
 target_link_libraries(shapeindex PRIVATE
     Boost::program_options
-    mapnik::core 
     mapnik::mapnik
 )
 

--- a/utils/svg2png/CMakeLists.txt
+++ b/utils/svg2png/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(svg2png
 
 target_link_libraries(svg2png PRIVATE 
     Boost::program_options      
-    mapnik::core 
     mapnik::mapnik
     mapnik::agg
 )


### PR DESCRIPTION
This PR adds mostly a convenience to the target `mapnik::mapnik` so that it has a public dependency on `mapnik::core`. All targets which have a dependency of `mapnik::mapnik` (which is the most common use case) won't need to add `mapnik::core`.

PR tested and ready to merge.