### PR TITLE
[CMake] fix `mapnik_find_plugin_dir`

### DIFF
--- a/cmake/mapnikConfig.cmake.in
+++ b/cmake/mapnikConfig.cmake.in
@@ -28,11 +28,11 @@ endforeach()
 
 function(mapnik_find_plugin_dir PLUGIN_DIR)
     string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_l)
-    set(_plugin_dir "${MAPNIK_PLUGINS_DIR_${_build_config}}")
+    set(_plugin_dir "${MAPNIK_PLUGINS_DIR_${_build_type_l}}")
     # only release has more then one configuration
     if(NOT _plugin_dir) 
         set(_all_rel_cfgs RELEASE RELWITHDEBINFO MINSIZEREL)
-        list(FIND _all_rel_cfgs ${_build_config} _is_rel_cfg)
+        list(FIND _all_rel_cfgs ${_build_type_l} _is_rel_cfg)
         # check if the current configuration is a known release configuration
         if(${_is_rel_cfg} GREATER_EQUAL 0)
             foreach(_rel_cfg IN LISTS _all_rel_cfgs)


### PR DESCRIPTION
Sorry @artemp 
found a bug in the cmake export logic. My test project had the used variable `_build_config` defined, which normally does not exists. This fixes the bug. 