### PR TITLE
use shared::ptr<T>::use_count instead of unique()

### DIFF
--- a/include/mapnik/pool.hpp
+++ b/include/mapnik/pool.hpp
@@ -75,7 +75,7 @@ public:
         typename ContType::iterator itr=pool_.begin();
         while ( itr!=pool_.end())
         {
-            if (!itr->unique())
+            if (itr->use_count() > 1)
             {
                 ++itr;
             }


### PR DESCRIPTION
This should be safe to use, since there aren't any weak_ptr's using the shared_ptr. Furthermore any async operations should be finished or guarded for multithreaded execution.


fixes the comment of https://github.com/mapnik/mapnik/issues/4229#issuecomment-964497471