### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,76 @@
+name: Build and Test
+
+on:
+  push:
+    branches-ignore:
+      - "no-ci-*"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  windows:
+    name: Windows memory mapped
+    uses: mapnik/mapnik/.github/workflows/windows.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'ON'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}
+  
+  windows-mmf-off:
+    name: Windows file based
+    uses: mapnik/mapnik/.github/workflows/windows.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'OFF'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}
+
+  ubuntu:
+    name: Linux memory mapped
+    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'ON'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}
+
+  ubuntu-mmf-off:
+    name: Linux file based
+    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'OFF'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}
+
+  macos:
+    name: MacOS memory mapped
+    uses: mapnik/mapnik/.github/workflows/macos.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'ON'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}
+
+  macos-mmf-off:
+    name: MacOS file based
+    uses: mapnik/mapnik/.github/workflows/macos.yml@gh_ci
+    with:
+      VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
+      NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
+      NUGET_USERNAME: mapnik
+      USE_MEMORY_MAPPED_FILE: 'OFF'
+    secrets:
+      NUGET_REGISTRY_PAT: ${{ secrets.VCPKG_NUGET_CI }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   windows:
     name: Windows memory mapped
-    uses: mapnik/mapnik/.github/workflows/windows.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/windows.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
@@ -22,7 +22,7 @@ jobs:
   
   windows-mmf-off:
     name: Windows file based
-    uses: mapnik/mapnik/.github/workflows/windows.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/windows.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
@@ -33,7 +33,7 @@ jobs:
 
   ubuntu:
     name: Linux memory mapped
-    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
@@ -44,7 +44,7 @@ jobs:
 
   ubuntu-mmf-off:
     name: Linux file based
-    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/ubuntu.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
@@ -55,7 +55,7 @@ jobs:
 
   macos:
     name: MacOS memory mapped
-    uses: mapnik/mapnik/.github/workflows/macos.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/macos.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json
@@ -66,7 +66,7 @@ jobs:
 
   macos-mmf-off:
     name: MacOS file based
-    uses: mapnik/mapnik/.github/workflows/macos.yml@gh_ci
+    uses: mapnik/mapnik/.github/workflows/macos.yml@master
     with:
       VCPKG_SHA: 2e34a79a814551424d9b1a981b3b110e0a8fbdfd
       NUGET_REGISTRY: https://nuget.pkg.github.com/mapnik/index.json

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/mapnik/vcpkg-cache.git
   UPDATE: 1
   preset: macos-ci
   mono: mono

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,125 @@
+name: MacOS
+
+on:
+  workflow_call:
+    inputs:
+      VCPKG_SHA:
+        required: true
+        type: string
+      NUGET_REGISTRY:
+        required: true
+        type: string
+      NUGET_USERNAME:
+        required: true
+        type: string
+      USE_MEMORY_MAPPED_FILE:
+        required: true
+        type: string
+    secrets:
+      NUGET_REGISTRY_PAT:
+        required: true
+
+env:
+  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  UPDATE: 1
+  preset: macos-ci
+  mono: mono
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Install required system packages
+        run: |
+          brew install automake ninja lcov
+
+      - name: checkout mapnik
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: checkout vcpkg
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vcpkg"
+          ref: ${{ inputs.VCPKG_SHA }}
+          path: vcpkg
+
+      - name: "Setup vcpkg"
+        shell: bash
+        run: ./vcpkg/bootstrap-vcpkg.sh
+
+      - name: "Setup NuGet Credentials"
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ inputs.NUGET_USERNAME }}"
+          -password "${{ secrets.NUGET_REGISTRY_PAT }}"
+
+      - name: "Setup NuGet apikey"
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset=${{ env.preset }}
+
+      - name: Build
+        run: cmake --build --preset ${{ env.preset }}
+
+      - name: Test
+        run: ctest --preset ${{ env.preset }}
+
+      - name: Test visuals
+        continue-on-error: true
+        working-directory: build/${{ env.preset }}/out
+        env:
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj4
+        run: ./mapnik-test-visual -j $(sysctl -n hw.logicalcpu) --output-dir ./visual-test-result
+
+      - name: Pack visual test results
+        working-directory: build/${{ env.preset }}/out
+        run: tar cfvz visual-test-results.tar.gz ./visual-test-result
+
+      - name: Run Benchmark
+        working-directory: build/${{ env.preset }}/out
+        env:
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj4
+        run: ./run_benchmarks
+
+      - name: Coverage
+        working-directory: build/${{ env.preset }}
+        run: |
+          lcov --directory . --capture --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/vcpkg_installed/*'  '/.cache/*' '*/test/*'  --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: build/${{ env.preset }}/coverage.info
+
+      - name: Package
+        if: failure()
+        run: cmake --build --preset ${{ env.preset }} --target package
+
+      - name: Upload mapnik build artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ env.preset }}-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/${{ env.preset }}/mapnik-*.tar.gz
+          retention-days: 2
+
+      - name: Upload visual test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.preset }}-visual-tests-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/${{ env.preset }}/out/visual-test-results.tar.gz
+          retention-days: 2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,141 @@
+name: Ubuntu
+
+on:
+  workflow_call:
+    inputs:
+      VCPKG_SHA:
+        required: true
+        type: string
+      NUGET_REGISTRY:
+        required: true
+        type: string
+      NUGET_USERNAME:
+        required: true
+        type: string
+      USE_MEMORY_MAPPED_FILE:
+        required: true
+        type: string
+    secrets:
+      NUGET_REGISTRY_PAT:
+        required: true
+
+env:
+  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  UPDATE: 1
+  preset: linux-ci
+  mono: mono
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgis/postgis
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: mapnik-tmp-postgis-test-db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Install required system packages
+        shell: "bash"
+        run: |
+          sudo apt-get install -y gperf libxxf86vm-dev ninja-build postgresql-client lcov
+
+      - name: checkout mapnik
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: checkout vcpkg
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vcpkg"
+          ref: ${{ inputs.VCPKG_SHA }}
+          path: vcpkg
+
+      - name: "Setup vcpkg"
+        shell: bash
+        run: ./vcpkg/bootstrap-vcpkg.sh
+
+      - name: "Setup NuGet Credentials"
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ inputs.NUGET_USERNAME }}"
+          -password "${{ secrets.NUGET_REGISTRY_PAT }}"
+
+      - name: "Setup NuGet apikey"
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset=${{ env.preset }}
+
+      - name: Build
+        run: cmake --build --preset ${{ env.preset }}
+
+      - name: Test
+        run: ctest --preset ${{ env.preset }}
+
+      - name: Test visuals
+        continue-on-error: true
+        working-directory: build/${{ env.preset }}/out
+        env:
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj4
+        run: ./mapnik-test-visual -j $(nproc) --output-dir ./visual-test-result
+
+      - name: Pack visual test results
+        working-directory: build/${{ env.preset }}/out
+        run: tar cfvz visual-test-results.tar.gz ./visual-test-result
+
+      - name: Run Benchmarks
+        working-directory: build/${{ env.preset }}/out
+        env:
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj4
+        run: ./run_benchmarks
+
+      - name: Coverage
+        working-directory: build/${{ env.preset }}
+        run: |
+          lcov --directory . --capture --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/vcpkg_installed/*'  '/.cache/*' '*/test/*'  --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: build/${{ env.preset }}/coverage.info
+
+      - name: Package
+        if: failure()
+        run: cmake --build --preset ${{ env.preset }} --target package
+
+      - name: Upload mapnik build artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ env.preset }}-artifact-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/${{ env.preset }}/mapnik-*.tar.gz
+          retention-days: 2
+
+      - name: Upload visual test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.preset }}-visual-tests-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/${{ env.preset }}/out/visual-test-results.tar.gz
+          retention-days: 2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/mapnik/vcpkg-cache.git
   UPDATE: 1
   preset: linux-ci
   mono: mono

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,114 @@
+name: Windows
+
+on:
+  workflow_call:
+    inputs:
+      VCPKG_SHA:
+        required: true
+        type: string
+      NUGET_REGISTRY:
+        required: true
+        type: string
+      NUGET_USERNAME:
+        required: true
+        type: string
+      USE_MEMORY_MAPPED_FILE:
+        required: true
+        type: string
+    secrets:
+      NUGET_REGISTRY_PAT:
+        required: true
+
+env:
+  VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  UPDATE: 1
+  preset: windows-ci
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Install required system packages
+        run: |
+          choco install ninja OpenCppCoverage
+          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: checkout mapnik
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: checkout vcpkg
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vcpkg"
+          ref: ${{ inputs.VCPKG_SHA }}
+          path: vcpkg
+
+      - name: "Setup vcpkg"
+        run: ./vcpkg/bootstrap-vcpkg.bat
+
+      - name: "Setup NuGet Credentials"
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ inputs.NUGET_USERNAME }}"
+          -password "${{ secrets.NUGET_REGISTRY_PAT }}"
+
+      - name: "Setup NuGet apikey"
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset ${{env.preset}}
+
+      - name: Build
+        run: cmake --build --preset ${{env.preset}}
+
+      - name: Test
+        run: OpenCppCoverage --modules *libmapnik* --modules mapnik*.exe  --modules *.input --sources ${{ github.workspace }} --export_type binary --cover_children -- ctest --preset ${{env.preset}}
+
+      - name: Test visuals
+        shell: pwsh
+        continue-on-error: true
+        working-directory: build/${{ env.preset }}/out
+        env:
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-windows/share/proj4
+        run: OpenCppCoverage --modules *libmapnik* --modules mapnik*.exe  --modules *.input --sources ${{ github.workspace }} --export_type binary --input_coverage=${{ github.workspace }}/ctest.cov --cover_children -- .\mapnik-test-visual.exe -j (Get-CimInstance -ClassName Win32_ComputerSystem).NumberOfLogicalProcessors --output-dir ./visual-test-result
+
+      - name: Pack visual test results
+        working-directory: build/${{ env.preset }}/out
+        run: tar cfvz visual-test-results.tar.gz ./visual-test-result
+        
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: build/${{ env.preset }}/out/mapnik-test-visual.cov
+
+      - name: Package
+        if: failure()
+        run: cmake --build --preset ${{env.preset}} --target package
+
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ env.preset }}-artifact-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/*-ci/mapnik-*.tar.gz
+          retention-days: 2
+
+      - name: Upload visual test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.preset }}-visual-tests-mmio-${{ inputs.USE_MEMORY_MAPPED_FILE }}
+          path: build/${{ env.preset }}/out/visual-test-results.tar.gz
+          retention-days: 2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-nuget.git
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-cache.git
   UPDATE: 1
   preset: windows-ci
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -173,6 +173,60 @@
                 "windows-default",
                 "release-build"
             ]
+        },
+        {
+            "name": "ci-options",
+            "hidden": true,
+            "cacheVariables": {
+                "BUILD_TESTING": "ON",
+                "BUILD_DEMO_VIEWER": "OFF"
+            }
+        },
+        {
+            "name": "windows-ci",
+            "description": "used by the ci pipeline",
+            "inherits": [
+                "windows-release",
+                "ci-options"
+            ],
+            "cacheVariables": {
+                "INSTALL_DEPENDENCIES": "ON",
+                "ADDITIONAL_LIBARIES_PATHS": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/bin"
+            },
+            "environment": {
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/share/proj4"
+            }
+        },
+        {
+            "name": "linux-ci",
+            "description": "used by the ci pipeline",
+            "inherits": [
+                "release-with-debug-build",
+                "use-gcc",
+                "ci-options"
+            ],
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "--coverage"
+            },
+            "environment": {
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-linux/share/proj4"
+            }
+        },
+        {
+            "name": "macos-ci",
+            "description": "used by the ci pipeline",
+            "inherits": [
+                "use-ninja",
+                "release-with-debug-build",
+                "default-build-dir",
+                "ci-options"
+            ],
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fprofile-arcs -ftest-coverage"
+            },
+            "environment": {
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-osx/share/proj4"
+            }
         }
     ],
     "buildPresets": [
@@ -199,6 +253,18 @@
         {
             "name": "linux-gcc-release",
             "configurePreset": "linux-gcc-release"
+        },
+        {
+            "name": "windows-ci",
+            "configurePreset": "windows-ci"
+        },
+        {
+            "name": "linux-ci",
+            "configurePreset": "linux-ci"
+        },
+        {
+            "name": "macos-ci",
+            "configurePreset": "macos-ci"
         }
     ],
     "testPresets": [
@@ -212,6 +278,27 @@
                 "noTestsAction": "error",
                 "stopOnFailure": false
             }
+        },
+        {
+            "name": "windows-ci",
+            "configurePreset": "windows-ci",
+            "inherits": [
+                "test-default"
+            ]
+        },
+        {
+            "name": "linux-ci",
+            "configurePreset": "linux-ci",
+            "inherits": [
+                "test-default"
+            ]
+        },
+        {
+            "name": "macos-ci",
+            "configurePreset": "macos-ci",
+            "inherits": [
+                "test-default"
+            ]
         }
     ]
 }


### PR DESCRIPTION
There are some needed steps. For the whole dependency management I'm using vcpkg. So most of the dependencies are very up to date. But this needs some setup steps. vcpkg is using binary caching via nuget to not build all dependencies each run. If you ever should use vcpkg in another repo, this might confilct. The trick is to add one central repo (e.g. named `vcpkg-cache`) where all binaries gets uploaded. (I've an empty repo https://github.com/mathisloge/vcpkg-nuget where all my binaries are landing. But for this PR we need to add a repo to mapnik e.g. mapnik/vcpkg-cache. Additionally you will need to add a github personal access token with these scopes to each repo using the binary cache
![image](https://user-images.githubusercontent.com/13556116/138736690-f6f62e50-c963-4f48-99b4-0068b0b9bb87.png)


Afterwards you will need to add this newly created PAT to this repository so that the workflow can upload the binaries to mapnik/vcpkg-cache

Latest run from the #4262 branch (where the usernames are not changed) 
https://github.com/mathisloge/mapnik/actions/runs/1760952679

CodeCov:
https://app.codecov.io/gh/mathisloge/mapnik/branch/gh_ci/commits?page=1