### PR TITLE
[GHA] use current user if PR or local repo (readonly) and vcpkg debug…

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/mapnik/vcpkg-cache.git
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-cache.git
   UPDATE: 1
   preset: macos-ci
   mono: mono
@@ -51,6 +51,7 @@ jobs:
         run: ./vcpkg/bootstrap-vcpkg.sh
 
       - name: "Setup NuGet Credentials"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
@@ -62,10 +63,30 @@ jobs:
           -password "${{ secrets.NUGET_REGISTRY_PAT }}"
 
       - name: "Setup NuGet apikey"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
           setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: "Setup NuGet Credentials READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ github.actor }}"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Setup NuGet apikey READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${{ inputs.NUGET_REGISTRY }}"
 
       - name: Configure CMake
         run: cmake -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset=${{ env.preset }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
-  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/mapnik/vcpkg-cache.git
+  VCPKG_NUGET_REPOSITORY: https://github.com/mapnik/vcpkg-cache.git
   UPDATE: 1
   preset: linux-ci
   mono: mono
@@ -67,6 +67,7 @@ jobs:
         run: ./vcpkg/bootstrap-vcpkg.sh
 
       - name: "Setup NuGet Credentials"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
@@ -78,10 +79,30 @@ jobs:
           -password "${{ secrets.NUGET_REGISTRY_PAT }}"
 
       - name: "Setup NuGet apikey"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           ${{ env.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
           setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: "Setup NuGet Credentials READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ github.actor }}"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Setup NuGet apikey READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${{ inputs.NUGET_REGISTRY }}"
 
       - name: Configure CMake
         run: cmake -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset=${{ env.preset }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,6 +53,7 @@ jobs:
         run: ./vcpkg/bootstrap-vcpkg.bat
 
       - name: "Setup NuGet Credentials"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           `./vcpkg/vcpkg fetch nuget | tail -n 1`
@@ -64,10 +65,30 @@ jobs:
           -password "${{ secrets.NUGET_REGISTRY_PAT }}"
 
       - name: "Setup NuGet apikey"
+        if: ${{ !(github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik') }}
         shell: "bash"
         run: >
           `./vcpkg/vcpkg fetch nuget | tail -n 1`
           setapikey "${{ secrets.NUGET_REGISTRY_PAT }}" -Source "${{ inputs.NUGET_REGISTRY }}"
+
+      - name: "Setup NuGet Credentials READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ inputs.NUGET_REGISTRY }}"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "${{ github.actor }}"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Setup NuGet apikey READONLY"
+        if: ${{ github.event_name == 'pull_request' || github.repository != 'mapnik/mapnik' }}
+        shell: "bash"
+        run: >
+          `./vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.GITHUB_TOKEN }}" -Source "${{ inputs.NUGET_REGISTRY }}"
 
       - name: Configure CMake
         run: cmake -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DUSE_MEMORY_MAPPED_FILE=${{ inputs.USE_MEMORY_MAPPED_FILE }} --preset ${{env.preset}}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -191,7 +191,8 @@
             ],
             "cacheVariables": {
                 "INSTALL_DEPENDENCIES": "ON",
-                "ADDITIONAL_LIBARIES_PATHS": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/bin"
+                "ADDITIONAL_LIBARIES_PATHS": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/bin",
+                "VCPKG_INSTALL_OPTIONS": "--debug"
             },
             "environment": {
                 "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/share/proj4"
@@ -206,7 +207,8 @@
                 "ci-options"
             ],
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "--coverage"
+                "CMAKE_CXX_FLAGS": "--coverage",
+                "VCPKG_INSTALL_OPTIONS": "--debug"
             },
             "environment": {
                 "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-linux/share/proj4"
@@ -222,7 +224,8 @@
                 "ci-options"
             ],
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-fprofile-arcs -ftest-coverage"
+                "CMAKE_CXX_FLAGS": "-fprofile-arcs -ftest-coverage",
+                "VCPKG_INSTALL_OPTIONS": "--debug"
             },
             "environment": {
                 "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-osx/share/proj4"


### PR DESCRIPTION
This fixes some things with GHA. 

1. typo in ubuntu and macos vcpkg cache repo
2. use current user to fetch nuget packages from the vcpkg cache repo when it is a PR or the repo is not mapnik/mapnik
3. activate vpckg debug mode in case there are now some other issues I'm not aware of

