### PR TITLE
mapnik 3.1 Scons needs updating for Python 3.10

### DIFF
--- a/scons/scons-local-3.0.1/SCons/Action.py
+++ b/scons/scons-local-3.0.1/SCons/Action.py
@@ -107,6 +107,7 @@ import sys
 import subprocess
 import itertools
 import inspect
+from collections import OrderedDict
 
 import SCons.Debug
 from SCons.Debug import logInstanceCreation
@@ -1289,7 +1290,7 @@ class ListAction(ActionBase):
         return result
 
     def get_varlist(self, target, source, env, executor=None):
-        result = SCons.Util.OrderedDict()
+        result = OrderedDict()
         for act in self.list:
             for var in act.get_varlist(target, source, env, executor):
                 result[var] = True

--- a/scons/scons-local-3.0.1/SCons/Tool/javac.py
+++ b/scons/scons-local-3.0.1/SCons/Tool/javac.py
@@ -34,6 +34,7 @@ __revision__ = "src/engine/SCons/Tool/javac.py 74b2c53bc42290e911b334a6b44f187da
 
 import os
 import os.path
+from collections import OrderedDict
 
 import SCons.Action
 import SCons.Builder
@@ -70,7 +71,7 @@ def emit_java_classes(target, source, env):
         if isinstance(entry, SCons.Node.FS.File):
             slist.append(entry)
         elif isinstance(entry, SCons.Node.FS.Dir):
-            result = SCons.Util.OrderedDict()
+            result = OrderedDict()
             dirnode = entry.rdir()
             def find_java_files(arg, dirpath, filenames):
                 java_files = sorted([n for n in filenames

--- a/scons/scons-local-3.0.1/SCons/Util.py
+++ b/scons/scons-local-3.0.1/SCons/Util.py
@@ -37,21 +37,18 @@ import pprint
 PY3 = sys.version_info[0] == 3
 
 try:
+    from collections import UserDict, UserList, UserString
+except ImportError:
     from UserDict import UserDict
-except ImportError as e:
-    from collections import UserDict
-
-try:
     from UserList import UserList
-except ImportError as e:
-    from collections import UserList
-
-from collections import Iterable
+    from UserString import UserString
 
 try:
-    from UserString import UserString
-except ImportError as e:
-    from collections import UserString
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
+from collections import OrderedDict
 
 # Don't "from types import ..." these because we need to get at the
 # types module later to look for UnicodeType.
@@ -63,7 +60,7 @@ MethodType      = types.MethodType
 FunctionType    = types.FunctionType
 
 try:
-    unicode
+    _ = type(unicode)
 except NameError:
     UnicodeType = str
 else:
@@ -1033,60 +1030,6 @@ class CLVar(UserList):
         return (self, CLVar(other))
     def __str__(self):
         return ' '.join(self.data)
-
-# A dictionary that preserves the order in which items are added.
-# Submitted by David Benjamin to ActiveState's Python Cookbook web site:
-#     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/107747
-# Including fixes/enhancements from the follow-on discussions.
-class OrderedDict(UserDict):
-    def __init__(self, dict = None):
-        self._keys = []
-        UserDict.__init__(self, dict)
-
-    def __delitem__(self, key):
-        UserDict.__delitem__(self, key)
-        self._keys.remove(key)
-
-    def __setitem__(self, key, item):
-        UserDict.__setitem__(self, key, item)
-        if key not in self._keys: self._keys.append(key)
-
-    def clear(self):
-        UserDict.clear(self)
-        self._keys = []
-
-    def copy(self):
-        dict = OrderedDict()
-        dict.update(self)
-        return dict
-
-    def items(self):
-        return list(zip(self._keys, list(self.values())))
-
-    def keys(self):
-        return self._keys[:]
-
-    def popitem(self):
-        try:
-            key = self._keys[-1]
-        except IndexError:
-            raise KeyError('dictionary is empty')
-
-        val = self[key]
-        del self[key]
-
-        return (key, val)
-
-    def setdefault(self, key, failobj = None):
-        UserDict.setdefault(self, key, failobj)
-        if key not in self._keys: self._keys.append(key)
-
-    def update(self, dict):
-        for (key, val) in dict.items():
-            self.__setitem__(key, val)
-
-    def values(self):
-        return list(map(self.get, self._keys))
 
 class Selector(OrderedDict):
     """A callable ordered dictionary that maps file suffixes to


### PR DESCRIPTION
mapnik 3.1.0
Ubuntu 22.10 Alpha

I cherry-picked this commit from Scons 3.0.2 to fix the build with Python 3.10.

Python 3.10 removes the old Collections Importable (you need to use Collections.abc Importable instead).

https://github.com/SCons/scons/commit/3fa7141ec7b39