### PR TITLE
[CI] only run on master pushes and all PRs

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,11 +2,11 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - "master"
+  pull_request:
     branches-ignore:
       - "no-ci-*"
-  pull_request:
-    branches:
-      - "**"
 
 jobs:
   checkSource:


### PR DESCRIPTION
currently the CI is running on every push and each PR . 
As a result, for each commit in a mapnik/mapnik based branch, the CI is running twice. Now it is only running on master pushes and on PRs which aren't beginning with `no-ci-*`.  