### PR TITLE
SVG: Fix reflection points for smooth curves after arcs

### DIFF
--- a/include/mapnik/svg/svg_path_adapter.hpp
+++ b/include/mapnik/svg/svg_path_adapter.hpp
@@ -382,10 +382,12 @@ void path_adapter<VC>::arc_to(double rx,
         {
             join_path(a);
         }
-        else
-        {
-            line_to(x, y);
-        }
+
+        // We are adding an explicit line_to, even if we've already add the
+        // bezier arc to the current path. This is to prevent subsequent smooth
+        // bezier curves from accidentally assuming that the previous command
+        // was a bezier curve as well when calculating reflection points.
+        line_to(x, y);
     }
     else
     {


### PR DESCRIPTION
I found that the patch in #4113, which attempts to fix the shorthand “smooth curve” commands, has a defect when interacting with “elliptical arc” commands. Internally, Agg/Mapnik converts arcs to curves. This means that the detection logic in the “smooth curve” command, which looks at the previous points for calculating the reflection point, mistakenly assumes that the previous commands were curve commands, even though they were in reality arc commands.

An example where this occurs is the following SVG path:

```
M 11.676 30.682 a 4.5 4.5 0 0 1 -6.364 -6.364 s 1.149 0.133 3.69 2.674 s 2.674 3.69 2.674 3.69 z
```
