### PR TITLE
Fix windows build error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -101,7 +101,7 @@ jobs:
         continue-on-error: true
         working-directory: build/${{ env.preset }}/out
         env:
-          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj/data
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj
         run: ./mapnik-test-visual -j $(sysctl -n hw.logicalcpu) --output-dir ./visual-test-result
 
       - name: Pack visual test results
@@ -111,7 +111,7 @@ jobs:
       - name: Run Benchmark
         working-directory: build/${{ env.preset }}/out
         env:
-          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj/data
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-osx/share/proj
         run: ./run_benchmarks
 
       - name: Coverage

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -117,7 +117,7 @@ jobs:
         continue-on-error: true
         working-directory: build/${{ env.preset }}/out
         env:
-          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj/data
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj
         run: ./mapnik-test-visual -j $(nproc) --output-dir ./visual-test-result
 
       - name: Pack visual test results
@@ -127,7 +127,7 @@ jobs:
       - name: Run Benchmarks
         working-directory: build/${{ env.preset }}/out
         env:
-          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj/data
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-linux/share/proj
         run: ./run_benchmarks
 
       - name: Coverage

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: true
         working-directory: build/${{ env.preset }}/out
         env:
-          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-windows/share/proj/data
+          PROJ_LIB: ${{ github.workspace }}/build/${{ env.preset }}/vcpkg_installed/x64-windows/share/proj
         run: OpenCppCoverage --modules *libmapnik* --modules mapnik*.exe  --modules *.input --sources ${{ github.workspace }} --export_type binary --input_coverage=${{ github.workspace }}/ctest.cov --cover_children -- .\mapnik-test-visual.exe -j (Get-CimInstance -ClassName Win32_ComputerSystem).NumberOfLogicalProcessors --output-dir ./visual-test-result
 
       - name: Pack visual test results

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.cache
 *.gcov
 *.gcda
 *.gcno

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -195,7 +195,7 @@
                 "ADDITIONAL_LIBARIES_PATHS": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/bin"
             },
             "environment": {
-                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/share/proj/data"
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-windows/share/proj"
             }
         },
         {
@@ -210,7 +210,7 @@
                 "CMAKE_CXX_FLAGS": "--coverage"
             },
             "environment": {
-                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-linux/share/proj/data"
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-linux/share/proj"
             }
         },
         {
@@ -226,7 +226,7 @@
                 "CMAKE_CXX_FLAGS": "-fprofile-arcs -ftest-coverage"
             },
             "environment": {
-                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-osx/share/proj/data"
+                "PROJ_LIB": "${sourceDir}/build/${presetName}/vcpkg_installed/x64-osx/share/proj"
             }
         }
     ],

--- a/test/unit/vertex_adapter/simplify_converters_test.cpp
+++ b/test/unit/vertex_adapter/simplify_converters_test.cpp
@@ -37,7 +37,7 @@ void simplify(std::string const& wkt_in, double tolerance, std::string const& me
             output.emplace_back(x, y);
         }
         std::string wkt_out;
-        REQUIRE(mapnik::util::to_wkt(wkt_out, output));
+        REQUIRE(mapnik::util::to_wkt(wkt_out, mapnik::geometry::geometry<double>{output}));
         REQUIRE(wkt_out == expected);
     }
 }


### PR DESCRIPTION
Latest msvc compiler can't correctly use find the correct overloaded function: 

```
D:\a\mapnik\mapnik\test\unit\vertex_adapter\simplify_converters_test.cpp(40): error C2668: 'mapnik::util::to_wkt': ambiguous call to overloaded function
D:\a\mapnik\mapnik\include\mapnik/util/geometry_to_wkt.hpp(36): note: could be 'bool mapnik::util::to_wkt(std::string &,const mapnik::geometry::geometry<int[64](https://github.com/mapnik/mapnik/actions/runs/3526352727/jobs/5914192007#step:17:65)_t> &)'
D:\a\mapnik\mapnik\include\mapnik/util/geometry_to_wkt.hpp(34): note: or       'bool mapnik::util::to_wkt(std::string &,const mapnik::geometry::geometry<double> &)'
D:\a\mapnik\mapnik\test\unit\vertex_adapter\simplify_converters_test.cpp(40): note: while trying to match the argument list '(std::string, mapbox::geometry::line_string<T,std::vector>)'
        with
        [
            T=double
        ]
```