### PR TITLE
Refactor/enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For a complete change history, see the git log.
 - Slightly improved `sql_utils::table_from_sql` ([2587bb3](https://github.com/mapnik/mapnik/commit/2587bb3a1d8db397acfa8dcc2d332da3a8a9399f))
 - Added wrappers for proper quoting in SQL query construction: `sql_utils::identifier`, `sql_utils::literal` ([7b21713](https://github.com/mapnik/mapnik/commit/7b217133e2749b82c2638551045c4edbece15086))
 - Added two-argument `sql_utils::unquote`, `sql_utils::unquote_copy` that also collapse inner quotes ([a4e8ea2](https://github.com/mapnik/mapnik/commit/a4e8ea21be297d89bbf36ba594d6c661a7a9ac81))
+- Reworked mapnik::enumeration<...> ([#4372](https://github.com/mapnik/mapnik/pull/4372))
 
 #### Plugins
 

--- a/benchmark/src/test_png_encoding2.cpp
+++ b/benchmark/src/test_png_encoding2.cpp
@@ -1,5 +1,6 @@
 #include "bench_framework.hpp"
 #include "compare_images.hpp"
+#include <memory>
 
 class test : public benchmark::test_case
 {

--- a/demo/c++/rundemo.cpp
+++ b/demo/c++/rundemo.cpp
@@ -131,8 +131,8 @@ int main(int, char**)
                 line_symbolizer line_sym;
                 put(line_sym, keys::stroke, color(171, 158, 137));
                 put(line_sym, keys::stroke_width, 2.0);
-                put(line_sym, keys::stroke_linecap, ROUND_CAP);
-                put(line_sym, keys::stroke_linejoin, ROUND_JOIN);
+                put(line_sym, keys::stroke_linecap, line_cap_enum::ROUND_CAP);
+                put(line_sym, keys::stroke_linejoin, line_join_enum::ROUND_JOIN);
                 r.append(std::move(line_sym));
             }
             roads34_style.add_rule(std::move(r));
@@ -148,8 +148,8 @@ int main(int, char**)
                 line_symbolizer line_sym;
                 put(line_sym, keys::stroke, color(171, 158, 137));
                 put(line_sym, keys::stroke_width, 4.0);
-                put(line_sym, keys::stroke_linecap, ROUND_CAP);
-                put(line_sym, keys::stroke_linejoin, ROUND_JOIN);
+                put(line_sym, keys::stroke_linecap, line_cap_enum::ROUND_CAP);
+                put(line_sym, keys::stroke_linejoin, line_join_enum::ROUND_JOIN);
                 r.append(std::move(line_sym));
             }
             roads2_style_1.add_rule(std::move(r));
@@ -164,8 +164,8 @@ int main(int, char**)
                 line_symbolizer line_sym;
                 put(line_sym, keys::stroke, color(255, 250, 115));
                 put(line_sym, keys::stroke_width, 2.0);
-                put(line_sym, keys::stroke_linecap, ROUND_CAP);
-                put(line_sym, keys::stroke_linejoin, ROUND_JOIN);
+                put(line_sym, keys::stroke_linecap, line_cap_enum::ROUND_CAP);
+                put(line_sym, keys::stroke_linejoin, line_join_enum::ROUND_JOIN);
                 r.append(std::move(line_sym));
             }
             roads2_style_2.add_rule(std::move(r));
@@ -181,8 +181,8 @@ int main(int, char**)
                 line_symbolizer line_sym;
                 put(line_sym, keys::stroke, color(188, 149, 28));
                 put(line_sym, keys::stroke_width, 7.0);
-                put(line_sym, keys::stroke_linecap, ROUND_CAP);
-                put(line_sym, keys::stroke_linejoin, ROUND_JOIN);
+                put(line_sym, keys::stroke_linecap, line_cap_enum::ROUND_CAP);
+                put(line_sym, keys::stroke_linejoin, line_join_enum::ROUND_JOIN);
                 r.append(std::move(line_sym));
             }
             roads1_style_1.add_rule(std::move(r));
@@ -197,8 +197,8 @@ int main(int, char**)
                 line_symbolizer line_sym;
                 put(line_sym, keys::stroke, color(242, 191, 36));
                 put(line_sym, keys::stroke_width, 5.0);
-                put(line_sym, keys::stroke_linecap, ROUND_CAP);
-                put(line_sym, keys::stroke_linejoin, ROUND_JOIN);
+                put(line_sym, keys::stroke_linecap, line_cap_enum::ROUND_CAP);
+                put(line_sym, keys::stroke_linejoin, line_join_enum::ROUND_JOIN);
                 r.append(std::move(line_sym));
             }
             roads1_style_2.add_rule(std::move(r));

--- a/include/mapnik/adaptive_smooth.hpp
+++ b/include/mapnik/adaptive_smooth.hpp
@@ -4,6 +4,8 @@
 #include <mapnik/util/math.hpp>
 
 #include <mapnik/warning.hpp>
+#include <mapnik/symbolizer_enumerations.hpp>
+#include <mapnik/util/variant.hpp>
 MAPNIK_DISABLE_WARNING_PUSH
 #include <mapnik/warning_ignore_agg.hpp>
 #include "agg_conv_smooth_poly1.h"
@@ -80,9 +82,9 @@ class smooth_converter
     {
         switch (algo)
         {
-            case SMOOTH_ALGORITHM_ADAPTIVE:
+            case smooth_algorithm_enum::SMOOTH_ALGORITHM_ADAPTIVE:
                 return adaptive_impl_type(geom);
-            case SMOOTH_ALGORITHM_BASIC:
+            case smooth_algorithm_enum::SMOOTH_ALGORITHM_BASIC:
             default:
                 break;
         }
@@ -92,7 +94,7 @@ class smooth_converter
   public:
     smooth_converter(Geometry& geom)
         : geom_(geom)
-        , impl_(std::move(init_impl(SMOOTH_ALGORITHM_BASIC, geom)))
+        , impl_(std::move(init_impl(smooth_algorithm_enum::SMOOTH_ALGORITHM_BASIC, geom)))
     {}
 
     void algorithm(smooth_algorithm_enum algo) { impl_ = init_impl(algo, geom_); }

--- a/include/mapnik/agg_helpers.hpp
+++ b/include/mapnik/agg_helpers.hpp
@@ -39,19 +39,19 @@ void set_gamma_method(T& ras_ptr, double gamma, gamma_method_enum method)
 {
     switch (method)
     {
-        case GAMMA_POWER:
+        case gamma_method_enum::GAMMA_POWER:
             ras_ptr->gamma(agg::gamma_power(gamma));
             break;
-        case GAMMA_LINEAR:
+        case gamma_method_enum::GAMMA_LINEAR:
             ras_ptr->gamma(agg::gamma_linear(0.0, gamma));
             break;
-        case GAMMA_NONE:
+        case gamma_method_enum::GAMMA_NONE:
             ras_ptr->gamma(agg::gamma_none());
             break;
-        case GAMMA_THRESHOLD:
+        case gamma_method_enum::GAMMA_THRESHOLD:
             ras_ptr->gamma(agg::gamma_threshold(gamma));
             break;
-        case GAMMA_MULTIPLY:
+        case gamma_method_enum::GAMMA_MULTIPLY:
             ras_ptr->gamma(agg::gamma_multiply(gamma));
             break;
         default:

--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -592,7 +592,7 @@ void feature_style_processor<Processor>::render_style(Processor& p,
                         util::apply_visitor(symbolizer_dispatch<Processor>(p, *feature, prj_trans), sym);
                     }
                 }
-                if (style->get_filter_mode() == FILTER_FIRST)
+                if (style->get_filter_mode() == filter_mode_enum::FILTER_FIRST)
                 {
                     // Stop iterating over rules and proceed with next feature.
                     do_also = false;

--- a/include/mapnik/feature_type_style.hpp
+++ b/include/mapnik/feature_type_style.hpp
@@ -43,7 +43,7 @@ namespace mapnik {
 
 class rule;
 
-enum filter_mode_enum { FILTER_ALL, FILTER_FIRST, filter_mode_enum_MAX };
+enum class filter_mode_enum { FILTER_ALL, FILTER_FIRST, filter_mode_enum_MAX };
 
 DEFINE_ENUM(filter_mode_e, filter_mode_enum);
 

--- a/include/mapnik/markers_placement.hpp
+++ b/include/mapnik/markers_placement.hpp
@@ -46,26 +46,26 @@ class markers_placement_finder : util::noncopyable
         switch (marker_placement_enum(placement_type))
         {
             default:
-            case MARKER_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_POINT_PLACEMENT:
                 construct(&point_, locator, detector, params);
                 break;
-            case MARKER_ANGLED_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_ANGLED_POINT_PLACEMENT:
                 construct(&point_, locator, detector, params);
                 point_.use_angle(true);
                 break;
-            case MARKER_INTERIOR_PLACEMENT:
+            case marker_placement_enum::MARKER_INTERIOR_PLACEMENT:
                 construct(&interior_, locator, detector, params);
                 break;
-            case MARKER_LINE_PLACEMENT:
+            case marker_placement_enum::MARKER_LINE_PLACEMENT:
                 construct(&line_, locator, detector, params);
                 break;
-            case MARKER_VERTEX_FIRST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_FIRST_PLACEMENT:
                 construct(&vertex_first_, locator, detector, params);
                 break;
-            case MARKER_VERTEX_LAST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_LAST_PLACEMENT:
                 construct(&vertex_last_, locator, detector, params);
                 break;
-            case MARKER_POLYLABEL_PLACEMENT:
+            case marker_placement_enum::MARKER_POLYLABEL_PLACEMENT:
                 construct(&polylabel_, locator, detector, params);
                 break;
         }
@@ -73,26 +73,26 @@ class markers_placement_finder : util::noncopyable
 
     ~markers_placement_finder()
     {
-        switch (marker_placement_enum(placement_type_))
+        switch (marker_placement_enum{placement_type_})
         {
             default:
-            case MARKER_POINT_PLACEMENT:
-            case MARKER_ANGLED_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_ANGLED_POINT_PLACEMENT:
                 destroy(&point_);
                 break;
-            case MARKER_INTERIOR_PLACEMENT:
+            case marker_placement_enum::MARKER_INTERIOR_PLACEMENT:
                 destroy(&interior_);
                 break;
-            case MARKER_LINE_PLACEMENT:
+            case marker_placement_enum::MARKER_LINE_PLACEMENT:
                 destroy(&line_);
                 break;
-            case MARKER_VERTEX_FIRST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_FIRST_PLACEMENT:
                 destroy(&vertex_first_);
                 break;
-            case MARKER_VERTEX_LAST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_LAST_PLACEMENT:
                 destroy(&vertex_last_);
                 break;
-            case MARKER_POLYLABEL_PLACEMENT:
+            case marker_placement_enum::MARKER_POLYLABEL_PLACEMENT:
                 destroy(&polylabel_);
                 break;
         }
@@ -101,21 +101,21 @@ class markers_placement_finder : util::noncopyable
     // Get next point where the marker should be placed. Returns true if a place is found, false if none is found.
     bool get_point(double& x, double& y, double& angle, bool ignore_placement)
     {
-        switch (marker_placement_enum(placement_type_))
+        switch (marker_placement_enum{placement_type_})
         {
             default:
-            case MARKER_POINT_PLACEMENT:
-            case MARKER_ANGLED_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_POINT_PLACEMENT:
+            case marker_placement_enum::MARKER_ANGLED_POINT_PLACEMENT:
                 return point_.get_point(x, y, angle, ignore_placement);
-            case MARKER_INTERIOR_PLACEMENT:
+            case marker_placement_enum::MARKER_INTERIOR_PLACEMENT:
                 return interior_.get_point(x, y, angle, ignore_placement);
-            case MARKER_LINE_PLACEMENT:
+            case marker_placement_enum::MARKER_LINE_PLACEMENT:
                 return line_.get_point(x, y, angle, ignore_placement);
-            case MARKER_VERTEX_FIRST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_FIRST_PLACEMENT:
                 return vertex_first_.get_point(x, y, angle, ignore_placement);
-            case MARKER_VERTEX_LAST_PLACEMENT:
+            case marker_placement_enum::MARKER_VERTEX_LAST_PLACEMENT:
                 return vertex_last_.get_point(x, y, angle, ignore_placement);
-            case MARKER_POLYLABEL_PLACEMENT:
+            case marker_placement_enum::MARKER_POLYLABEL_PLACEMENT:
                 return polylabel_.get_point(x, y, angle, ignore_placement);
         }
     }

--- a/include/mapnik/markers_placements/basic.hpp
+++ b/include/mapnik/markers_placements/basic.hpp
@@ -32,7 +32,6 @@
 #include <mapnik/warning.hpp>
 MAPNIK_DISABLE_WARNING_PUSH
 #include <mapnik/warning_ignore_agg.hpp>
-#include "agg_basics.h"
 #include "agg_trans_affine.h"
 MAPNIK_DISABLE_WARNING_POP
 
@@ -72,32 +71,32 @@ class markers_basic_placement : util::noncopyable
     {
         switch (params_.direction)
         {
-            case DIRECTION_UP:
+            case direction_enum::DIRECTION_UP:
                 angle = 0;
                 return true;
-            case DIRECTION_DOWN:
+            case direction_enum::DIRECTION_DOWN:
                 angle = util::pi;
                 return true;
-            case DIRECTION_AUTO:
+            case direction_enum::DIRECTION_AUTO:
                 angle = util::normalize_angle(angle);
                 if (std::abs(angle) > util::pi / 2)
                     angle += util::pi;
                 return true;
-            case DIRECTION_AUTO_DOWN:
+            case direction_enum::DIRECTION_AUTO_DOWN:
                 angle = util::normalize_angle(angle);
                 if (std::abs(angle) < util::pi / 2)
                     angle += util::pi;
                 return true;
-            case DIRECTION_LEFT:
+            case direction_enum::DIRECTION_LEFT:
                 angle += util::pi;
                 return true;
-            case DIRECTION_LEFT_ONLY:
+            case direction_enum::DIRECTION_LEFT_ONLY:
                 angle = util::normalize_angle(angle + util::pi);
                 return std::fabs(angle) < util::pi / 2;
-            case DIRECTION_RIGHT_ONLY:
+            case direction_enum::DIRECTION_RIGHT_ONLY:
                 angle = util::normalize_angle(angle);
                 return std::fabs(angle) < util::pi / 2;
-            case DIRECTION_RIGHT:
+            case direction_enum::DIRECTION_RIGHT:
             default:
                 return true;
         }

--- a/include/mapnik/raster_colorizer.hpp
+++ b/include/mapnik/raster_colorizer.hpp
@@ -57,7 +57,7 @@ class feature_impl;
 class raster;
 
 //! \brief Enumerates the modes of interpolation
-enum colorizer_mode_enum : std::uint8_t {
+enum class colorizer_mode_enum : std::uint8_t {
     COLORIZER_INHERIT = 0,     //!< The stop inherits the mode from the colorizer
     COLORIZER_LINEAR = 1,      //!< Linear interpolation between colors, each channel separately
     COLORIZER_DISCRETE = 2,    //!< Single color for stop
@@ -80,7 +80,7 @@ class MAPNIK_DECL colorizer_stop
     //! \param[in] mode The stop mode
     //! \param[in] _color The stop color
     colorizer_stop(float value = 0,
-                   colorizer_mode mode = COLORIZER_INHERIT,
+                   colorizer_mode mode = colorizer_mode_enum::COLORIZER_INHERIT,
                    color const& _color = color(0, 0, 0, 0),
                    std::string const& label = "");
 
@@ -146,7 +146,8 @@ class MAPNIK_DECL raster_colorizer
 {
   public:
     //! \brief Constructor
-    raster_colorizer(colorizer_mode mode = COLORIZER_LINEAR, color const& _color = color(0, 0, 0, 0));
+    raster_colorizer(colorizer_mode mode = colorizer_mode_enum::COLORIZER_LINEAR,
+                     color const& _color = color(0, 0, 0, 0));
 
     //! \brief Destructor
     ~raster_colorizer();
@@ -158,7 +159,8 @@ class MAPNIK_DECL raster_colorizer
 
     void set_default_mode(colorizer_mode mode)
     {
-        default_mode_ = (mode == COLORIZER_INHERIT) ? COLORIZER_LINEAR : static_cast<colorizer_mode_enum>(mode);
+        default_mode_ =
+          (mode == colorizer_mode_enum::COLORIZER_INHERIT) ? colorizer_mode_enum::COLORIZER_LINEAR : mode.value_;
     }
 
     void set_default_mode_enum(colorizer_mode_enum mode) { set_default_mode(mode); }

--- a/include/mapnik/renderer_common/process_point_symbolizer.hpp
+++ b/include/mapnik/renderer_common/process_point_symbolizer.hpp
@@ -52,28 +52,28 @@ void render_point_symbolizer(point_symbolizer const& sym,
 
     if (!mark->is<mapnik::marker_null>())
     {
-        value_double opacity = get<value_double, keys::opacity>(sym, feature, common.vars_);
-        value_bool allow_overlap = get<value_bool, keys::allow_overlap>(sym, feature, common.vars_);
-        value_bool ignore_placement = get<value_bool, keys::ignore_placement>(sym, feature, common.vars_);
-        point_placement_enum placement =
+        const value_double opacity = get<value_double, keys::opacity>(sym, feature, common.vars_);
+        const value_bool allow_overlap = get<value_bool, keys::allow_overlap>(sym, feature, common.vars_);
+        const value_bool ignore_placement = get<value_bool, keys::ignore_placement>(sym, feature, common.vars_);
+        const point_placement_enum placement =
           get<point_placement_enum, keys::point_placement_type>(sym, feature, common.vars_);
 
-        box2d<double> const& bbox = mark->bounding_box();
-        coord2d center = bbox.center();
+        const box2d<double>& bbox = mark->bounding_box();
+        const coord2d center = bbox.center();
 
         agg::trans_affine tr;
-        auto image_transform = get_optional<transform_type>(sym, keys::image_transform);
+        const auto image_transform = get_optional<transform_type>(sym, keys::image_transform);
         if (image_transform)
             evaluate_transform(tr, feature, common.vars_, *image_transform, common.scale_factor_);
 
-        agg::trans_affine_translation recenter(-center.x, -center.y);
-        agg::trans_affine recenter_tr = recenter * tr;
+        const agg::trans_affine_translation recenter(-center.x, -center.y);
+        const agg::trans_affine recenter_tr = recenter * tr;
         box2d<double> label_ext = bbox * recenter_tr * agg::trans_affine_scaling(common.scale_factor_);
 
-        mapnik::geometry::geometry<double> const& geometry = feature.get_geometry();
+        const mapnik::geometry::geometry<double>& geometry = feature.get_geometry();
         mapnik::geometry::point<double> pt;
         geometry::geometry_types type = geometry::geometry_type(geometry);
-        if (placement == CENTROID_POINT_PLACEMENT || type == geometry::geometry_types::Point ||
+        if (placement == point_placement_enum::CENTROID_POINT_PLACEMENT || type == geometry::geometry_types::Point ||
             type == geometry::geometry_types::MultiPoint)
         {
             if (!geometry::centroid(geometry, pt))

--- a/include/mapnik/symbolizer.hpp
+++ b/include/mapnik/symbolizer.hpp
@@ -147,14 +147,14 @@ struct enum_traits<simplify_algorithm_e>
     static result_type from_string(std::string const& str) { return simplify_algorithm_from_string(str); }
 };
 
-#define ENUM_FROM_STRING(e)                                                                                            \
+#define ENUM_FROM_STRING(alias, e)                                                                                     \
     template<>                                                                                                         \
     struct enum_traits<e>                                                                                              \
     {                                                                                                                  \
         using result_type = boost::optional<e>;                                                                        \
         static result_type from_string(std::string const& str)                                                         \
         {                                                                                                              \
-            enumeration<e, e##_MAX> enum_;                                                                             \
+            enumeration<e, alias##_to_string, alias##_from_string, alias##_lookup> enum_;                              \
             try                                                                                                        \
             {                                                                                                          \
                 enum_.from_string(str);                                                                                \
@@ -166,26 +166,25 @@ struct enum_traits<simplify_algorithm_e>
             }                                                                                                          \
         }                                                                                                              \
     };
-
-ENUM_FROM_STRING(line_cap_enum)
-ENUM_FROM_STRING(line_join_enum)
-ENUM_FROM_STRING(point_placement_enum)
-ENUM_FROM_STRING(line_rasterizer_enum)
-ENUM_FROM_STRING(marker_placement_enum)
-ENUM_FROM_STRING(marker_multi_policy_enum)
-ENUM_FROM_STRING(debug_symbolizer_mode_enum)
-ENUM_FROM_STRING(pattern_alignment_enum)
-ENUM_FROM_STRING(halo_rasterizer_enum)
-ENUM_FROM_STRING(label_placement_enum)
-ENUM_FROM_STRING(vertical_alignment_enum)
-ENUM_FROM_STRING(horizontal_alignment_enum)
-ENUM_FROM_STRING(justify_alignment_enum)
-ENUM_FROM_STRING(text_transform_enum)
-ENUM_FROM_STRING(text_upright_enum)
-ENUM_FROM_STRING(direction_enum)
-ENUM_FROM_STRING(gamma_method_enum)
-ENUM_FROM_STRING(line_pattern_enum)
-ENUM_FROM_STRING(smooth_algorithm_enum)
+ENUM_FROM_STRING(line_cap_e, line_cap_enum)
+ENUM_FROM_STRING(line_join_e, line_join_enum)
+ENUM_FROM_STRING(point_placement_e, point_placement_enum)
+ENUM_FROM_STRING(line_rasterizer_e, line_rasterizer_enum)
+ENUM_FROM_STRING(marker_placement_e, marker_placement_enum)
+ENUM_FROM_STRING(marker_multi_policy_e, marker_multi_policy_enum)
+ENUM_FROM_STRING(debug_symbolizer_mode_e, debug_symbolizer_mode_enum)
+ENUM_FROM_STRING(pattern_alignment_e, pattern_alignment_enum)
+ENUM_FROM_STRING(halo_rasterizer_e, halo_rasterizer_enum)
+ENUM_FROM_STRING(label_placement_e, label_placement_enum)
+ENUM_FROM_STRING(vertical_alignment_e, vertical_alignment_enum)
+ENUM_FROM_STRING(horizontal_alignment_e, horizontal_alignment_enum)
+ENUM_FROM_STRING(justify_alignment_e, justify_alignment_enum)
+ENUM_FROM_STRING(text_transform_e, text_transform_enum)
+ENUM_FROM_STRING(text_upright_e, text_upright_enum)
+ENUM_FROM_STRING(direction_e, direction_enum)
+ENUM_FROM_STRING(gamma_method_e, gamma_method_enum)
+ENUM_FROM_STRING(line_pattern_e, line_pattern_enum)
+ENUM_FROM_STRING(smooth_algorithm_e, smooth_algorithm_enum)
 
 // enum
 template<typename T, bool is_enum = true>

--- a/include/mapnik/symbolizer_base.hpp
+++ b/include/mapnik/symbolizer_base.hpp
@@ -69,7 +69,7 @@ struct enumeration_wrapper
     enumeration_wrapper() = delete;
     template<typename T>
     explicit enumeration_wrapper(T value_)
-        : value(value_)
+        : value(static_cast<int>(value_))
     {}
 
     inline bool operator==(enumeration_wrapper const& rhs) const { return value == rhs.value; }

--- a/include/mapnik/symbolizer_default_values.hpp
+++ b/include/mapnik/symbolizer_default_values.hpp
@@ -50,7 +50,7 @@ struct symbolizer_default<value_double, keys::gamma>
 template<>
 struct symbolizer_default<gamma_method_enum, keys::gamma_method>
 {
-    static gamma_method_enum value() { return GAMMA_POWER; }
+    static gamma_method_enum value() { return gamma_method_enum::GAMMA_POWER; }
 };
 
 // opacity
@@ -64,7 +64,7 @@ struct symbolizer_default<value_double, keys::opacity>
 template<>
 struct symbolizer_default<pattern_alignment_enum, keys::alignment>
 {
-    static pattern_alignment_enum value() { return GLOBAL_ALIGNMENT; }
+    static pattern_alignment_enum value() { return pattern_alignment_enum::GLOBAL_ALIGNMENT; }
 };
 
 // offset
@@ -127,14 +127,14 @@ struct symbolizer_default<value_double, keys::stroke_opacity>
 template<>
 struct symbolizer_default<line_join_enum, keys::stroke_linejoin>
 {
-    static line_join_enum value() { return MITER_JOIN; }
+    static line_join_enum value() { return line_join_enum::MITER_JOIN; }
 };
 
 // stroke-linecap
 template<>
 struct symbolizer_default<line_cap_enum, keys::stroke_linecap>
 {
-    static line_cap_enum value() { return BUTT_CAP; }
+    static line_cap_enum value() { return line_cap_enum::BUTT_CAP; }
 };
 
 // stroke-gamma
@@ -148,7 +148,7 @@ struct symbolizer_default<value_double, keys::stroke_gamma>
 template<>
 struct symbolizer_default<gamma_method_enum, keys::stroke_gamma_method>
 {
-    static gamma_method_enum value() { return GAMMA_POWER; }
+    static gamma_method_enum value() { return gamma_method_enum::GAMMA_POWER; }
 };
 
 // stroke-dashoffset
@@ -173,7 +173,7 @@ struct symbolizer_default<value_double, keys::stroke_miterlimit>
 template<>
 struct symbolizer_default<line_rasterizer_enum, keys::line_rasterizer>
 {
-    static line_rasterizer_enum value() { return RASTERIZER_FULL; }
+    static line_rasterizer_enum value() { return line_rasterizer_enum::RASTERIZER_FULL; }
 };
 
 // transform
@@ -315,7 +315,7 @@ struct symbolizer_default<value_double, keys::simplify_tolerance>
 template<>
 struct symbolizer_default<halo_rasterizer_enum, keys::halo_rasterizer>
 {
-    static halo_rasterizer_enum value() { return HALO_RASTERIZER_FULL; }
+    static halo_rasterizer_enum value() { return halo_rasterizer_enum::HALO_RASTERIZER_FULL; }
 };
 
 // text-placements
@@ -324,28 +324,28 @@ struct symbolizer_default<halo_rasterizer_enum, keys::halo_rasterizer>
 template<>
 struct symbolizer_default<point_placement_enum, keys::point_placement_type>
 {
-    static point_placement_enum value() { return CENTROID_POINT_PLACEMENT; }
+    static point_placement_enum value() { return point_placement_enum::CENTROID_POINT_PLACEMENT; }
 };
 
 // marker placement
 template<>
 struct symbolizer_default<marker_placement_enum, keys::markers_placement_type>
 {
-    static marker_placement_enum value() { return MARKER_POINT_PLACEMENT; }
+    static marker_placement_enum value() { return marker_placement_enum::MARKER_POINT_PLACEMENT; }
 };
 
 // multi-policy
 template<>
 struct symbolizer_default<marker_multi_policy_enum, keys::markers_multipolicy>
 {
-    static marker_multi_policy_enum value() { return MARKER_EACH_MULTI; }
+    static marker_multi_policy_enum value() { return marker_multi_policy_enum::MARKER_EACH_MULTI; }
 };
 
 // direction
 template<>
 struct symbolizer_default<direction_enum, keys::direction>
 {
-    static direction_enum value() { return DIRECTION_RIGHT; }
+    static direction_enum value() { return direction_enum::DIRECTION_RIGHT; }
 };
 
 // placement
@@ -380,7 +380,7 @@ struct symbolizer_default<value_bool, keys::avoid_edges>
 template<>
 struct symbolizer_default<line_pattern_enum, keys::line_pattern>
 {
-    static line_pattern_enum value() { return LINE_PATTERN_WARP; }
+    static line_pattern_enum value() { return line_pattern_enum::LINE_PATTERN_WARP; }
 };
 
 // extend
@@ -393,7 +393,7 @@ struct symbolizer_default<value_double, keys::extend>
 template<>
 struct symbolizer_default<smooth_algorithm_enum, keys::smooth_algorithm>
 {
-    static smooth_algorithm_enum value() { return SMOOTH_ALGORITHM_BASIC; }
+    static smooth_algorithm_enum value() { return smooth_algorithm_enum::SMOOTH_ALGORITHM_BASIC; }
 };
 
 } // namespace mapnik

--- a/include/mapnik/symbolizer_enumerations.hpp
+++ b/include/mapnik/symbolizer_enumerations.hpp
@@ -27,50 +27,43 @@
 
 namespace mapnik {
 
-enum line_cap_enum : std::uint8_t { BUTT_CAP, SQUARE_CAP, ROUND_CAP, line_cap_enum_MAX };
-
+enum class line_cap_enum : std::uint8_t { BUTT_CAP, SQUARE_CAP, ROUND_CAP, line_cap_enum_MAX };
 DEFINE_ENUM(line_cap_e, line_cap_enum);
 
-enum line_join_enum : std::uint8_t { MITER_JOIN, MITER_REVERT_JOIN, ROUND_JOIN, BEVEL_JOIN, line_join_enum_MAX };
-
+enum class line_join_enum : std::uint8_t { MITER_JOIN, MITER_REVERT_JOIN, ROUND_JOIN, BEVEL_JOIN, line_join_enum_MAX };
 DEFINE_ENUM(line_join_e, line_join_enum);
 
-enum line_rasterizer_enum : std::uint8_t {
+enum class line_rasterizer_enum : std::uint8_t {
     RASTERIZER_FULL, // agg::renderer_scanline_aa_solid
     RASTERIZER_FAST, // agg::rasterizer_outline_aa, twice as fast but only good for thin lines
     line_rasterizer_enum_MAX
 };
-
 DEFINE_ENUM(line_rasterizer_e, line_rasterizer_enum);
 
-enum halo_rasterizer_enum : std::uint8_t { HALO_RASTERIZER_FULL, HALO_RASTERIZER_FAST, halo_rasterizer_enum_MAX };
-
+enum class halo_rasterizer_enum : std::uint8_t { HALO_RASTERIZER_FULL, HALO_RASTERIZER_FAST, halo_rasterizer_enum_MAX };
 DEFINE_ENUM(halo_rasterizer_e, halo_rasterizer_enum);
 
-enum point_placement_enum : std::uint8_t {
+enum class point_placement_enum : std::uint8_t {
     CENTROID_POINT_PLACEMENT,
     INTERIOR_POINT_PLACEMENT,
     point_placement_enum_MAX
 };
-
 DEFINE_ENUM(point_placement_e, point_placement_enum);
 
-enum pattern_alignment_enum : std::uint8_t { LOCAL_ALIGNMENT, GLOBAL_ALIGNMENT, pattern_alignment_enum_MAX };
-
+enum class pattern_alignment_enum : std::uint8_t { LOCAL_ALIGNMENT, GLOBAL_ALIGNMENT, pattern_alignment_enum_MAX };
 DEFINE_ENUM(pattern_alignment_e, pattern_alignment_enum);
 
-enum debug_symbolizer_mode_enum : std::uint8_t {
+enum class debug_symbolizer_mode_enum : std::uint8_t {
     DEBUG_SYM_MODE_COLLISION,
     DEBUG_SYM_MODE_VERTEX,
     DEBUG_SYM_MODE_RINGS,
     debug_symbolizer_mode_enum_MAX
 };
-
 DEFINE_ENUM(debug_symbolizer_mode_e, debug_symbolizer_mode_enum);
 
 // markers
 // TODO - consider merging with text_symbolizer label_placement_e
-enum marker_placement_enum : std::uint8_t {
+enum class marker_placement_enum : std::uint8_t {
     MARKER_POINT_PLACEMENT,
     MARKER_INTERIOR_PLACEMENT,
     MARKER_LINE_PLACEMENT,
@@ -80,19 +73,17 @@ enum marker_placement_enum : std::uint8_t {
     MARKER_POLYLABEL_PLACEMENT,
     marker_placement_enum_MAX
 };
-
 DEFINE_ENUM(marker_placement_e, marker_placement_enum);
 
-enum marker_multi_policy_enum : std::uint8_t {
+enum class marker_multi_policy_enum : std::uint8_t {
     MARKER_EACH_MULTI,    // each component in a multi gets its marker
     MARKER_WHOLE_MULTI,   // consider all components of a multi as a whole
     MARKER_LARGEST_MULTI, // only the largest component of a multi gets a marker
     marker_multi_policy_enum_MAX
 };
-
 DEFINE_ENUM(marker_multi_policy_e, marker_multi_policy_enum);
 
-enum text_transform_enum : std::uint8_t {
+enum class text_transform_enum : std::uint8_t {
     NONE = 0,
     UPPERCASE,
     LOWERCASE,
@@ -100,10 +91,9 @@ enum text_transform_enum : std::uint8_t {
     REVERSE,
     text_transform_enum_MAX
 };
-
 DEFINE_ENUM(text_transform_e, text_transform_enum);
 
-enum label_placement_enum : std::uint8_t {
+enum class label_placement_enum : std::uint8_t {
     POINT_PLACEMENT,
     LINE_PLACEMENT,
     VERTEX_PLACEMENT,
@@ -113,14 +103,18 @@ enum label_placement_enum : std::uint8_t {
     ALTERNATING_GRID_PLACEMENT,
     label_placement_enum_MAX
 };
-
 DEFINE_ENUM(label_placement_e, label_placement_enum);
 
-enum vertical_alignment_enum : std::uint8_t { V_TOP = 0, V_MIDDLE, V_BOTTOM, V_AUTO, vertical_alignment_enum_MAX };
-
+enum class vertical_alignment_enum : std::uint8_t {
+    V_TOP = 0,
+    V_MIDDLE,
+    V_BOTTOM,
+    V_AUTO,
+    vertical_alignment_enum_MAX
+};
 DEFINE_ENUM(vertical_alignment_e, vertical_alignment_enum);
 
-enum horizontal_alignment_enum : std::uint8_t {
+enum class horizontal_alignment_enum : std::uint8_t {
     H_LEFT = 0,
     H_MIDDLE,
     H_RIGHT,
@@ -128,14 +122,12 @@ enum horizontal_alignment_enum : std::uint8_t {
     H_ADJUST,
     horizontal_alignment_enum_MAX
 };
-
 DEFINE_ENUM(horizontal_alignment_e, horizontal_alignment_enum);
 
-enum justify_alignment_enum : std::uint8_t { J_LEFT = 0, J_MIDDLE, J_RIGHT, J_AUTO, justify_alignment_enum_MAX };
-
+enum class justify_alignment_enum : std::uint8_t { J_LEFT = 0, J_MIDDLE, J_RIGHT, J_AUTO, justify_alignment_enum_MAX };
 DEFINE_ENUM(justify_alignment_e, justify_alignment_enum);
 
-enum text_upright_enum : std::uint8_t {
+enum class text_upright_enum : std::uint8_t {
     UPRIGHT_AUTO,
     UPRIGHT_AUTO_DOWN,
     UPRIGHT_LEFT,
@@ -144,10 +136,9 @@ enum text_upright_enum : std::uint8_t {
     UPRIGHT_RIGHT_ONLY,
     text_upright_enum_MAX
 };
-
 DEFINE_ENUM(text_upright_e, text_upright_enum);
 
-enum direction_enum : std::uint8_t {
+enum class direction_enum : std::uint8_t {
     DIRECTION_LEFT,
     DIRECTION_RIGHT,
     DIRECTION_LEFT_ONLY,
@@ -158,10 +149,9 @@ enum direction_enum : std::uint8_t {
     DIRECTION_DOWN,
     direction_enum_MAX
 };
-
 DEFINE_ENUM(direction_e, direction_enum);
 
-enum gamma_method_enum : std::uint8_t {
+enum class gamma_method_enum : std::uint8_t {
     GAMMA_POWER,     // agg::gamma_power
     GAMMA_LINEAR,    // agg::gamma_linear
     GAMMA_NONE,      // agg::gamma_none
@@ -169,19 +159,16 @@ enum gamma_method_enum : std::uint8_t {
     GAMMA_MULTIPLY,  // agg::gamma_multiply
     gamma_method_enum_MAX
 };
-
 DEFINE_ENUM(gamma_method_e, gamma_method_enum);
 
-enum line_pattern_enum : std::uint8_t { LINE_PATTERN_WARP, LINE_PATTERN_REPEAT, line_pattern_enum_MAX };
-
+enum class line_pattern_enum : std::uint8_t { LINE_PATTERN_WARP, LINE_PATTERN_REPEAT, line_pattern_enum_MAX };
 DEFINE_ENUM(line_pattern_e, line_pattern_enum);
 
-enum smooth_algorithm_enum : std::uint8_t {
+enum class smooth_algorithm_enum : std::uint8_t {
     SMOOTH_ALGORITHM_BASIC = 0,
     SMOOTH_ALGORITHM_ADAPTIVE,
     smooth_algorithm_enum_MAX
 };
-
 DEFINE_ENUM(smooth_algorithm_e, smooth_algorithm_enum);
 
 } // namespace mapnik

--- a/include/mapnik/text/placement_finder_impl.hpp
+++ b/include/mapnik/text/placement_finder_impl.hpp
@@ -65,12 +65,14 @@ bool placement_finder::find_line_placements(T& path, bool points)
         // horizontal_alignment_e halign = layouts_.back()->horizontal_alignment();
 
         // halign == H_LEFT -> don't move
-        if (horizontal_alignment_ == H_MIDDLE || horizontal_alignment_ == H_AUTO || horizontal_alignment_ == H_ADJUST)
+        if (horizontal_alignment_ == horizontal_alignment_enum::H_MIDDLE ||
+            horizontal_alignment_ == horizontal_alignment_enum::H_AUTO ||
+            horizontal_alignment_ == horizontal_alignment_enum::H_ADJUST)
         {
             if (!pp.forward(spacing / 2.0))
                 continue;
         }
-        else if (horizontal_alignment_ == H_RIGHT)
+        else if (horizontal_alignment_ == horizontal_alignment_enum::H_RIGHT)
         {
             if (!pp.forward(pp.length()))
                 continue;

--- a/include/mapnik/text/properties_util.hpp
+++ b/include/mapnik/text/properties_util.hpp
@@ -46,7 +46,7 @@ struct is_mapnik_enumeration
 };
 
 template<typename T>
-struct is_mapnik_enumeration<T, typename std::enable_if<std::is_enum<typename T::native_type>::value>::type>
+struct is_mapnik_enumeration<T, typename std::enable_if_t<std::is_enum<typename T::native_type>::value>>
 {
     static constexpr bool value = true;
 };
@@ -117,7 +117,7 @@ struct set_property_from_xml_impl<T0, true>
             {
                 target_enum_type e;
                 e.from_string(*enum_str);
-                val = enumeration_wrapper(e);
+                val = enumeration_wrapper(e.value_);
             }
         }
         catch (...)

--- a/include/mapnik/text/text_properties.hpp
+++ b/include/mapnik/text/text_properties.hpp
@@ -159,7 +159,7 @@ struct MAPNIK_DECL text_layout_properties
 
 struct text_properties_expressions
 {
-    symbolizer_base::value_type label_placement = enumeration_wrapper(POINT_PLACEMENT);
+    symbolizer_base::value_type label_placement = enumeration_wrapper(label_placement_enum::POINT_PLACEMENT);
     symbolizer_base::value_type label_spacing = 0.0;
     symbolizer_base::value_type label_position_tolerance = 0.0;
     symbolizer_base::value_type avoid_edges = false;
@@ -171,7 +171,7 @@ struct text_properties_expressions
     symbolizer_base::value_type max_char_angle_delta = 22.5;
     symbolizer_base::value_type allow_overlap = false;
     symbolizer_base::value_type largest_bbox_only = true;
-    symbolizer_base::value_type upright = enumeration_wrapper(UPRIGHT_AUTO);
+    symbolizer_base::value_type upright = enumeration_wrapper(text_upright_enum::UPRIGHT_AUTO);
     symbolizer_base::value_type grid_cell_width = 0.0;
     symbolizer_base::value_type grid_cell_height = 0.0;
 };

--- a/include/mapnik/vertex_converters.hpp
+++ b/include/mapnik/vertex_converters.hpp
@@ -46,7 +46,6 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include "agg_trans_affine.h"
 #include "agg_conv_clip_polygon.h"
 #include "agg_conv_clip_polyline.h"
-#include "agg_conv_smooth_poly1.h"
 #include "agg_conv_stroke.h"
 #include "agg_conv_dash.h"
 #include "agg_conv_transform.h"
@@ -156,30 +155,29 @@ struct converter_traits<T, mapnik::dash_tag>
 template<typename Symbolizer, typename PathType, typename Feature>
 void set_join_caps(Symbolizer const& sym, PathType& stroke, Feature const& feature, attributes const& vars)
 {
-    line_join_enum join = get<line_join_enum, keys::stroke_linejoin>(sym, feature, vars);
+    const line_join_enum join = get<line_join_enum, keys::stroke_linejoin>(sym, feature, vars);
     switch (join)
     {
-        case MITER_JOIN:
+        case line_join_enum::MITER_JOIN:
             stroke.generator().line_join(agg::miter_join);
             break;
-        case MITER_REVERT_JOIN:
+        case line_join_enum::MITER_REVERT_JOIN:
             stroke.generator().line_join(agg::miter_join);
             break;
-        case ROUND_JOIN:
+        case line_join_enum::ROUND_JOIN:
             stroke.generator().line_join(agg::round_join);
             break;
         default:
             stroke.generator().line_join(agg::bevel_join);
     }
 
-    line_cap_enum cap = get<line_cap_enum, keys::stroke_linecap>(sym, feature, vars);
-
+    const line_cap_enum cap = get<line_cap_enum, keys::stroke_linecap>(sym, feature, vars);
     switch (cap)
     {
-        case BUTT_CAP:
+        case line_cap_enum::BUTT_CAP:
             stroke.generator().line_cap(agg::butt_cap);
             break;
-        case SQUARE_CAP:
+        case line_cap_enum::SQUARE_CAP:
             stroke.generator().line_cap(agg::square_cap);
             break;
         default:

--- a/include/mapnik/well_known_srs.hpp
+++ b/include/mapnik/well_known_srs.hpp
@@ -39,8 +39,7 @@ MAPNIK_DISABLE_WARNING_POP
 
 namespace mapnik {
 
-enum well_known_srs_enum : std::uint8_t { WGS_84, WEB_MERC, well_known_srs_enum_MAX };
-
+enum class well_known_srs_enum : std::uint8_t { WGS_84, WEB_MERC, well_known_srs_enum_MAX };
 DEFINE_ENUM(well_known_srs_e, well_known_srs_enum);
 
 constexpr double EARTH_RADIUS = 6378137.0;

--- a/include/mapnik/xml_attribute_cast.hpp
+++ b/include/mapnik/xml_attribute_cast.hpp
@@ -161,17 +161,20 @@ struct do_xml_attribute_cast<double>
     }
 };
 
-// specialization for mapnik::enumeration<T,int>
-template<typename T, int MAX>
-struct do_xml_attribute_cast<mapnik::enumeration<T, MAX>>
+// specialization for mapnik::enumeration<...>
+template<typename ENUM,
+         char const* (*F_TO_STRING)(ENUM),
+         ENUM (*F_FROM_STRING)(const char*),
+         std::map<ENUM, std::string> (*F_LOOKUP)()>
+struct do_xml_attribute_cast<mapnik::enumeration<ENUM, F_TO_STRING, F_FROM_STRING, F_LOOKUP>>
 {
-    static inline boost::optional<mapnik::enumeration<T, MAX>> xml_attribute_cast_impl(xml_tree const& /*tree*/,
-                                                                                       std::string const& source)
+    using Enum = mapnik::enumeration<ENUM, F_TO_STRING, F_FROM_STRING, F_LOOKUP>;
+    static inline boost::optional<Enum> xml_attribute_cast_impl(xml_tree const& /*tree*/, std::string const& source)
     {
-        using result_type = typename boost::optional<mapnik::enumeration<T, MAX>>;
+        using result_type = typename boost::optional<Enum>;
         try
         {
-            mapnik::enumeration<T, MAX> e;
+            Enum e;
             e.from_string(source);
             return result_type(e);
         }

--- a/src/agg/agg_renderer.cpp
+++ b/src/agg/agg_renderer.cpp
@@ -51,7 +51,6 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include "agg_color_rgba.h"
 #include "agg_scanline_u.h"
 #include "agg_image_filters.h"
-#include "agg_trans_bilinear.h"
 #include "agg_span_allocator.h"
 #include "agg_image_accessors.h"
 #include "agg_span_image_filter_rgba.h"
@@ -74,8 +73,8 @@ agg_renderer<T0, T1>::agg_renderer(Map const& m, T0& pixmap, double scale_factor
     , buffers_()
     , internal_buffers_(m.width(), m.height())
     , inflated_buffer_()
-    , ras_ptr(new rasterizer)
-    , gamma_method_(GAMMA_POWER)
+    , ras_ptr(std::make_unique<rasterizer>())
+    , gamma_method_(gamma_method_enum::GAMMA_POWER)
     , gamma_(1.0)
     , common_(m, attributes(), offset_x, offset_y, m.width(), m.height(), scale_factor)
 {
@@ -94,8 +93,8 @@ agg_renderer<T0, T1>::agg_renderer(Map const& m,
     , buffers_()
     , internal_buffers_(req.width(), req.height())
     , inflated_buffer_()
-    , ras_ptr(new rasterizer)
-    , gamma_method_(GAMMA_POWER)
+    , ras_ptr(std::make_unique<rasterizer>())
+    , gamma_method_(gamma_method_enum::GAMMA_POWER)
     , gamma_(1.0)
     , common_(m, req, vars, offset_x, offset_y, req.width(), req.height(), scale_factor)
 {
@@ -113,8 +112,8 @@ agg_renderer<T0, T1>::agg_renderer(Map const& m,
     , buffers_()
     , internal_buffers_(m.width(), m.height())
     , inflated_buffer_()
-    , ras_ptr(new rasterizer)
-    , gamma_method_(GAMMA_POWER)
+    , ras_ptr(std::make_unique<rasterizer>())
+    , gamma_method_(gamma_method_enum::GAMMA_POWER)
     , gamma_(1.0)
     , common_(m, attributes(), offset_x, offset_y, m.width(), m.height(), scale_factor, detector)
 {
@@ -405,10 +404,10 @@ struct agg_render_marker_visitor
         using renderer_type = agg::renderer_scanline_aa_solid<renderer_base>;
 
         ras_ptr_->reset();
-        if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
+        if (gamma_method_ != gamma_method_enum::GAMMA_POWER || gamma_ != 1.0)
         {
             ras_ptr_->gamma(agg::gamma_power());
-            gamma_method_ = GAMMA_POWER;
+            gamma_method_ = gamma_method_enum::GAMMA_POWER;
             gamma_ = 1.0;
         }
         agg::scanline_u8 sl;
@@ -451,10 +450,10 @@ struct agg_render_marker_visitor
         using renderer_base = agg::renderer_base<pixfmt_comp_type>;
 
         ras_ptr_->reset();
-        if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
+        if (gamma_method_ != gamma_method_enum::GAMMA_POWER || gamma_ != 1.0)
         {
             ras_ptr_->gamma(agg::gamma_power());
-            gamma_method_ = GAMMA_POWER;
+            gamma_method_ = gamma_method_enum::GAMMA_POWER;
             gamma_ = 1.0;
         }
         agg::scanline_u8 sl;

--- a/src/agg/process_debug_symbolizer.cpp
+++ b/src/agg/process_debug_symbolizer.cpp
@@ -221,30 +221,34 @@ void agg_renderer<T0, T1>::process(debug_symbolizer const& sym,
                                    proj_transform const& prj_trans)
 {
     debug_symbolizer_mode_enum mode =
-      get<debug_symbolizer_mode_enum>(sym, keys::mode, feature, common_.vars_, DEBUG_SYM_MODE_COLLISION);
+      get<debug_symbolizer_mode_enum>(sym,
+                                      keys::mode,
+                                      feature,
+                                      common_.vars_,
+                                      debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION);
 
     ras_ptr->reset();
-    if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
+    if (gamma_method_ != gamma_method_enum::GAMMA_POWER || gamma_ != 1.0)
     {
         ras_ptr->gamma(agg::gamma_power());
-        gamma_method_ = GAMMA_POWER;
+        gamma_method_ = gamma_method_enum::GAMMA_POWER;
         gamma_ = 1.0;
     }
 
-    if (mode == DEBUG_SYM_MODE_RINGS)
+    if (mode == debug_symbolizer_mode_enum::DEBUG_SYM_MODE_RINGS)
     {
         RingRenderer<buffer_type> renderer(*ras_ptr, buffers_.top().get(), common_.t_, prj_trans);
         render_ring_visitor<buffer_type> apply(renderer);
         mapnik::util::apply_visitor(apply, feature.get_geometry());
     }
-    else if (mode == DEBUG_SYM_MODE_COLLISION)
+    else if (mode == debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION)
     {
         for (auto const& n : *common_.detector_)
         {
             draw_rect(buffers_.top().get(), n.get().box);
         }
     }
-    else if (mode == DEBUG_SYM_MODE_VERTEX)
+    else if (mode == debug_symbolizer_mode_enum::DEBUG_SYM_MODE_VERTEX)
     {
         using apply_vertex_mode = apply_vertex_mode<buffer_type>;
         apply_vertex_mode apply(buffers_.top().get(), common_.t_, prj_trans);

--- a/src/agg/process_dot_symbolizer.cpp
+++ b/src/agg/process_dot_symbolizer.cpp
@@ -102,8 +102,8 @@ void agg_renderer<T0, T1>::process(dot_symbolizer const& sym,
 {
     double width = 0.0;
     double height = 0.0;
-    bool has_width = has_key(sym, keys::width);
-    bool has_height = has_key(sym, keys::height);
+    const bool has_width = has_key(sym, keys::width);
+    const bool has_height = has_key(sym, keys::height);
     if (has_width && has_height)
     {
         width = get<double>(sym, keys::width, feature, common_.vars_, 0.0);
@@ -117,15 +117,15 @@ void agg_renderer<T0, T1>::process(dot_symbolizer const& sym,
     {
         width = height = get<double>(sym, keys::height, feature, common_.vars_, 0.0);
     }
-    double rx = width / 2.0 * common_.scale_factor_;
-    double ry = height / 2.0 * common_.scale_factor_;
-    double opacity = get<double>(sym, keys::opacity, feature, common_.vars_, 1.0);
-    color const& fill = get<mapnik::color>(sym, keys::fill, feature, common_.vars_, mapnik::color(128, 128, 128));
+    const double rx = width / 2.0 * common_.scale_factor_;
+    const double ry = height / 2.0 * common_.scale_factor_;
+    const double opacity = get<double>(sym, keys::opacity, feature, common_.vars_, 1.0);
+    const color& fill = get<mapnik::color>(sym, keys::fill, feature, common_.vars_, mapnik::color(128, 128, 128));
     ras_ptr->reset();
-    if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
+    if (gamma_method_ != gamma_method_enum::GAMMA_POWER || gamma_ != 1.0)
     {
         ras_ptr->gamma(agg::gamma_power());
-        gamma_method_ = GAMMA_POWER;
+        gamma_method_ = gamma_method_enum::GAMMA_POWER;
         gamma_ = 1.0;
     }
     buffer_type& current_buffer = buffers_.top().get();

--- a/src/agg/process_group_symbolizer.cpp
+++ b/src/agg/process_group_symbolizer.cpp
@@ -68,7 +68,12 @@ struct thunk_renderer<image_rgba8> : render_thunk_list_dispatch
         , ras_ptr_(ras_ptr)
         , buf_(buf)
         , common_(common)
-        , tex_(buf, HALO_RASTERIZER_FULL, src_over, src_over, common.scale_factor_, common.font_manager_.get_stroker())
+        , tex_(buf,
+               halo_rasterizer_enum::HALO_RASTERIZER_FULL,
+               src_over,
+               src_over,
+               common.scale_factor_,
+               common.font_manager_.get_stroker())
     {}
 
     virtual void operator()(vector_marker_render_thunk const& thunk)

--- a/src/agg/process_line_pattern_symbolizer.cpp
+++ b/src/agg/process_line_pattern_symbolizer.cpp
@@ -45,15 +45,9 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include "agg_pixfmt_rgba.h"
 #include "agg_color_rgba.h"
 #include "agg_rendering_buffer.h"
-#include "agg_rasterizer_outline.h"
 #include "agg_rasterizer_outline_aa.h"
-#include "agg_scanline_u.h"
-#include "agg_renderer_scanline.h"
 #include "agg_pattern_filters_rgba.h"
-#include "agg_span_allocator.h"
-#include "agg_span_pattern_rgba.h"
 #include "agg_renderer_outline_image.h"
-#include "agg_image_accessors.h"
 MAPNIK_DISABLE_WARNING_POP
 
 namespace mapnik {
@@ -216,17 +210,17 @@ struct agg_renderer_process_visitor_l
         line_pattern_enum pattern = get<line_pattern_enum, keys::line_pattern>(sym_, feature_, common_.vars_);
         switch (pattern)
         {
-            case LINE_PATTERN_WARP: {
+            case line_pattern_enum::LINE_PATTERN_WARP: {
                 warp_pattern pattern(pattern_image, common_, sym_, feature_, prj_trans_);
                 render(pattern);
                 break;
             }
-            case LINE_PATTERN_REPEAT: {
+            case line_pattern_enum::LINE_PATTERN_REPEAT: {
                 repeat_pattern pattern(pattern_image, common_, sym_, feature_, prj_trans_);
                 render(pattern);
                 break;
             }
-            case line_pattern_enum_MAX:
+            case line_pattern_enum::line_pattern_enum_MAX:
             default:
                 MAPNIK_LOG_ERROR(process_line_pattern_symbolizer) << "Incorrect line-pattern value.";
         }
@@ -265,10 +259,10 @@ void agg_renderer<T0, T1>::process(line_pattern_symbolizer const& sym,
     if (filename.empty())
         return;
     ras_ptr->reset();
-    if (gamma_method_ != GAMMA_POWER || gamma_ != 1.0)
+    if (gamma_method_ != gamma_method_enum::GAMMA_POWER || gamma_ != 1.0)
     {
         ras_ptr->gamma(agg::gamma_power());
-        gamma_method_ = GAMMA_POWER;
+        gamma_method_ = gamma_method_enum::GAMMA_POWER;
         gamma_ = 1.0;
     }
 

--- a/src/agg/process_line_symbolizer.cpp
+++ b/src/agg/process_line_symbolizer.cpp
@@ -43,9 +43,6 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include "agg_rasterizer_scanline_aa.h"
 #include "agg_scanline_u.h"
 #include "agg_renderer_scanline.h"
-#include "agg_scanline_p.h"
-#include "agg_conv_stroke.h"
-#include "agg_conv_dash.h"
 #include "agg_renderer_outline_aa.h"
 #include "agg_rasterizer_outline_aa.h"
 MAPNIK_DISABLE_WARNING_POP
@@ -59,30 +56,29 @@ namespace mapnik {
 template<typename Symbolizer, typename Rasterizer, typename Feature>
 void set_join_caps_aa(Symbolizer const& sym, Rasterizer& ras, Feature& feature, attributes const& vars)
 {
-    line_join_enum join = get<line_join_enum, keys::stroke_linejoin>(sym, feature, vars);
+    const line_join_enum join = get<line_join_enum, keys::stroke_linejoin>(sym, feature, vars);
     switch (join)
     {
-        case MITER_JOIN:
+        case line_join_enum::MITER_JOIN:
             ras.line_join(agg::outline_miter_accurate_join);
             break;
-        case MITER_REVERT_JOIN:
+        case line_join_enum::MITER_REVERT_JOIN:
             ras.line_join(agg::outline_no_join);
             break;
-        case ROUND_JOIN:
+        case line_join_enum::ROUND_JOIN:
             ras.line_join(agg::outline_round_join);
             break;
         default:
             ras.line_join(agg::outline_no_join);
     }
 
-    line_cap_enum cap = get<line_cap_enum, keys::stroke_linecap>(sym, feature, vars);
-
+    const line_cap_enum cap = get<line_cap_enum, keys::stroke_linecap>(sym, feature, vars);
     switch (cap)
     {
-        case BUTT_CAP:
+        case line_cap_enum::BUTT_CAP:
             ras.round_cap(false);
             break;
-        case SQUARE_CAP:
+        case line_cap_enum::SQUARE_CAP:
             ras.round_cap(false);
             break;
         default:
@@ -97,10 +93,10 @@ void agg_renderer<T0, T1>::process(line_symbolizer const& sym,
 
 {
     color const& col = get<color, keys::stroke>(sym, feature, common_.vars_);
-    unsigned r = col.red();
-    unsigned g = col.green();
-    unsigned b = col.blue();
-    unsigned a = col.alpha();
+    const unsigned r = col.red();
+    const unsigned g = col.green();
+    const unsigned b = col.blue();
+    const unsigned a = col.alpha();
 
     double gamma = get<value_double, keys::stroke_gamma>(sym, feature, common_.vars_);
     gamma_method_enum gamma_method = get<gamma_method_enum, keys::stroke_gamma_method>(sym, feature, common_.vars_);
@@ -136,13 +132,14 @@ void agg_renderer<T0, T1>::process(line_symbolizer const& sym,
 
     box2d<double> clip_box = clipping_extent(common_);
 
-    value_bool clip = get<value_bool, keys::clip>(sym, feature, common_.vars_);
-    value_double width = get<value_double, keys::stroke_width>(sym, feature, common_.vars_);
-    value_double opacity = get<value_double, keys::stroke_opacity>(sym, feature, common_.vars_);
-    value_double offset = get<value_double, keys::offset>(sym, feature, common_.vars_);
-    value_double simplify_tolerance = get<value_double, keys::simplify_tolerance>(sym, feature, common_.vars_);
-    value_double smooth = get<value_double, keys::smooth>(sym, feature, common_.vars_);
-    line_rasterizer_enum rasterizer_e = get<line_rasterizer_enum, keys::line_rasterizer>(sym, feature, common_.vars_);
+    const value_bool clip = get<value_bool, keys::clip>(sym, feature, common_.vars_);
+    const value_double width = get<value_double, keys::stroke_width>(sym, feature, common_.vars_);
+    const value_double opacity = get<value_double, keys::stroke_opacity>(sym, feature, common_.vars_);
+    const value_double offset = get<value_double, keys::offset>(sym, feature, common_.vars_);
+    const value_double simplify_tolerance = get<value_double, keys::simplify_tolerance>(sym, feature, common_.vars_);
+    const value_double smooth = get<value_double, keys::smooth>(sym, feature, common_.vars_);
+    const line_rasterizer_enum rasterizer_e =
+      get<line_rasterizer_enum, keys::line_rasterizer>(sym, feature, common_.vars_);
     if (clip)
     {
         double pad_per_pixel = static_cast<double>(common_.query_extent_.width() / common_.width_);
@@ -153,7 +150,7 @@ void agg_renderer<T0, T1>::process(line_symbolizer const& sym,
         clip_box.pad(padding);
     }
 
-    if (rasterizer_e == RASTERIZER_FAST)
+    if (rasterizer_e == line_rasterizer_enum::RASTERIZER_FAST)
     {
         using renderer_type = agg::renderer_outline_aa<renderer_base>;
         using rasterizer_type = agg::rasterizer_outline_aa<renderer_type>;

--- a/src/agg/process_polygon_symbolizer.cpp
+++ b/src/agg/process_polygon_symbolizer.cpp
@@ -55,9 +55,9 @@ void agg_renderer<T0, T1>::process(polygon_symbolizer const& sym,
       vertex_converter<clip_poly_tag, transform_tag, affine_transform_tag, simplify_tag, smooth_tag>;
 
     ras_ptr->reset();
-    double gamma = get<value_double>(sym, keys::gamma, feature, common_.vars_, 1.0);
+    const double gamma = get<value_double>(sym, keys::gamma, feature, common_.vars_, 1.0);
     gamma_method_enum gamma_method =
-      get<gamma_method_enum>(sym, keys::gamma_method, feature, common_.vars_, GAMMA_POWER);
+      get<gamma_method_enum>(sym, keys::gamma_method, feature, common_.vars_, gamma_method_enum::GAMMA_POWER);
     if (gamma != gamma_ || gamma_method != gamma_method_)
     {
         set_gamma_method(ras_ptr, gamma, gamma_method);

--- a/src/agg/process_shield_symbolizer.cpp
+++ b/src/agg/process_shield_symbolizer.cpp
@@ -37,28 +37,32 @@ void agg_renderer<T0, T1>::process(shield_symbolizer const& sym,
                                    mapnik::feature_impl& feature,
                                    proj_transform const& prj_trans)
 {
-    box2d<double> clip_box = clipping_extent(common_);
+    const box2d<double> clip_box = clipping_extent(common_);
     agg::trans_affine tr;
-    auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
+    const auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
     if (transform)
         evaluate_transform(tr, feature, common_.vars_, *transform, common_.scale_factor_);
-    text_symbolizer_helper helper(sym,
-                                  feature,
-                                  common_.vars_,
-                                  prj_trans,
-                                  common_.width_,
-                                  common_.height_,
-                                  common_.scale_factor_,
-                                  common_.t_,
-                                  common_.font_manager_,
-                                  *common_.detector_,
-                                  clip_box,
-                                  tr);
+    const text_symbolizer_helper helper(sym,
+                                        feature,
+                                        common_.vars_,
+                                        prj_trans,
+                                        common_.width_,
+                                        common_.height_,
+                                        common_.scale_factor_,
+                                        common_.t_,
+                                        common_.font_manager_,
+                                        *common_.detector_,
+                                        clip_box,
+                                        tr);
 
-    halo_rasterizer_enum halo_rasterizer =
-      get<halo_rasterizer_enum>(sym, keys::halo_rasterizer, feature, common_.vars_, HALO_RASTERIZER_FULL);
-    composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
-    composite_mode_e halo_comp_op = get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
+    const halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym,
+                                                                           keys::halo_rasterizer,
+                                                                           feature,
+                                                                           common_.vars_,
+                                                                           halo_rasterizer_enum::HALO_RASTERIZER_FULL);
+    const composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
+    const composite_mode_e halo_comp_op =
+      get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
     agg_text_renderer<T0> ren(buffers_.top().get(),
                               halo_rasterizer,
                               comp_op,
@@ -66,12 +70,12 @@ void agg_renderer<T0, T1>::process(shield_symbolizer const& sym,
                               common_.scale_factor_,
                               common_.font_manager_.get_stroker());
 
-    double opacity = get<double>(sym, keys::opacity, feature, common_.vars_, 1.0);
+    const double opacity = get<double>(sym, keys::opacity, feature, common_.vars_, 1.0);
 
     placements_list const& placements = helper.get();
     for (auto const& glyphs : placements)
     {
-        marker_info_ptr mark = glyphs->get_marker();
+        const marker_info_ptr mark = glyphs->get_marker();
         if (mark)
         {
             render_marker(glyphs->marker_pos(), *mark->marker_, mark->transform_, opacity, comp_op);

--- a/src/agg/process_text_symbolizer.cpp
+++ b/src/agg/process_text_symbolizer.cpp
@@ -37,28 +37,32 @@ void agg_renderer<T0, T1>::process(text_symbolizer const& sym,
                                    mapnik::feature_impl& feature,
                                    proj_transform const& prj_trans)
 {
-    box2d<double> clip_box = clipping_extent(common_);
+    const box2d<double> clip_box = clipping_extent(common_);
     agg::trans_affine tr;
-    auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
+    const auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
     if (transform)
         evaluate_transform(tr, feature, common_.vars_, *transform, common_.scale_factor_);
-    text_symbolizer_helper helper(sym,
-                                  feature,
-                                  common_.vars_,
-                                  prj_trans,
-                                  common_.width_,
-                                  common_.height_,
-                                  common_.scale_factor_,
-                                  common_.t_,
-                                  common_.font_manager_,
-                                  *common_.detector_,
-                                  clip_box,
-                                  tr);
+    const text_symbolizer_helper helper(sym,
+                                        feature,
+                                        common_.vars_,
+                                        prj_trans,
+                                        common_.width_,
+                                        common_.height_,
+                                        common_.scale_factor_,
+                                        common_.t_,
+                                        common_.font_manager_,
+                                        *common_.detector_,
+                                        clip_box,
+                                        tr);
 
-    halo_rasterizer_enum halo_rasterizer =
-      get<halo_rasterizer_enum>(sym, keys::halo_rasterizer, feature, common_.vars_, HALO_RASTERIZER_FULL);
-    composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
-    composite_mode_e halo_comp_op = get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
+    const halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym,
+                                                                           keys::halo_rasterizer,
+                                                                           feature,
+                                                                           common_.vars_,
+                                                                           halo_rasterizer_enum::HALO_RASTERIZER_FULL);
+    const composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature, common_.vars_, src_over);
+    const composite_mode_e halo_comp_op =
+      get<composite_mode_e>(sym, keys::halo_comp_op, feature, common_.vars_, src_over);
     agg_text_renderer<T0> ren(buffers_.top().get(),
                               halo_rasterizer,
                               comp_op,
@@ -66,7 +70,7 @@ void agg_renderer<T0, T1>::process(text_symbolizer const& sym,
                               common_.scale_factor_,
                               common_.font_manager_.get_stroker());
 
-    auto halo_transform = get_optional<transform_type>(sym, keys::halo_transform);
+    const auto halo_transform = get_optional<transform_type>(sym, keys::halo_transform);
     if (halo_transform)
     {
         agg::trans_affine halo_affine_transform;

--- a/src/cairo/cairo_context.cpp
+++ b/src/cairo/cairo_context.cpp
@@ -192,11 +192,11 @@ void cairo_context::set_operator(composite_mode_e comp_op)
 
 void cairo_context::set_line_join(line_join_e join)
 {
-    if (join == MITER_JOIN)
+    if (join == line_join_enum::MITER_JOIN)
         cairo_set_line_join(cairo_.get(), CAIRO_LINE_JOIN_MITER);
-    else if (join == MITER_REVERT_JOIN)
+    else if (join == line_join_enum::MITER_REVERT_JOIN)
         cairo_set_line_join(cairo_.get(), CAIRO_LINE_JOIN_MITER);
-    else if (join == ROUND_JOIN)
+    else if (join == line_join_enum::ROUND_JOIN)
         cairo_set_line_join(cairo_.get(), CAIRO_LINE_JOIN_ROUND);
     else
         cairo_set_line_join(cairo_.get(), CAIRO_LINE_JOIN_BEVEL);
@@ -205,9 +205,9 @@ void cairo_context::set_line_join(line_join_e join)
 
 void cairo_context::set_line_cap(line_cap_e cap)
 {
-    if (cap == BUTT_CAP)
+    if (cap == line_cap_enum::BUTT_CAP)
         cairo_set_line_cap(cairo_.get(), CAIRO_LINE_CAP_BUTT);
-    else if (cap == SQUARE_CAP)
+    else if (cap == line_cap_enum::SQUARE_CAP)
         cairo_set_line_cap(cairo_.get(), CAIRO_LINE_CAP_SQUARE);
     else
         cairo_set_line_cap(cairo_.get(), CAIRO_LINE_CAP_ROUND);
@@ -480,7 +480,7 @@ void cairo_context::add_text(glyph_positions const& pos,
         pixel_position new_pos = glyph_pos.pos + glyph.offset.rotate(glyph_pos.rot);
         glyph_path(glyph.glyph_index, pixel_position(sx + new_pos.x, sy - new_pos.y));
         set_line_width(2.0 * halo_radius);
-        set_line_join(ROUND_JOIN);
+        set_line_join(line_join_enum::ROUND_JOIN);
         set_color(glyph.format->halo_fill, glyph.format->halo_opacity);
         stroke();
     }

--- a/src/cairo/process_debug_symbolizer.cpp
+++ b/src/cairo/process_debug_symbolizer.cpp
@@ -96,23 +96,27 @@ void cairo_renderer<T>::process(debug_symbolizer const& sym,
     cairo_save_restore guard(context_);
 
     debug_symbolizer_mode_enum mode =
-      get<debug_symbolizer_mode_enum>(sym, keys::mode, feature, common_.vars_, DEBUG_SYM_MODE_COLLISION);
+      get<debug_symbolizer_mode_enum>(sym,
+                                      keys::mode,
+                                      feature,
+                                      common_.vars_,
+                                      debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION);
 
     context_.set_operator(src_over);
     context_.set_color(mapnik::color(255, 0, 0), 1.0);
-    context_.set_line_join(MITER_JOIN);
-    context_.set_line_cap(BUTT_CAP);
+    context_.set_line_join(line_join_enum::MITER_JOIN);
+    context_.set_line_cap(line_cap_enum::BUTT_CAP);
     context_.set_miter_limit(4.0);
     context_.set_line_width(1.0);
 
-    if (mode == DEBUG_SYM_MODE_COLLISION)
+    if (mode == debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION)
     {
         for (auto& n : *common_.detector_)
         {
             render_debug_box(context_, n.get().box);
         }
     }
-    else if (mode == DEBUG_SYM_MODE_VERTEX)
+    else if (mode == debug_symbolizer_mode_enum::DEBUG_SYM_MODE_VERTEX)
     {
         using apply_vertex_mode = apply_vertex_mode<cairo_context>;
         apply_vertex_mode apply(context_, common_.t_, prj_trans);

--- a/src/cairo/process_line_pattern_symbolizer.cpp
+++ b/src/cairo/process_line_pattern_symbolizer.cpp
@@ -216,20 +216,20 @@ void cairo_renderer<T>::process(line_pattern_symbolizer const& sym,
         return;
     }
 
-    line_pattern_enum pattern = get<line_pattern_enum, keys::line_pattern>(sym, feature, common_.vars_);
+    const line_pattern_enum pattern = get<line_pattern_enum, keys::line_pattern>(sym, feature, common_.vars_);
     switch (pattern)
     {
-        case LINE_PATTERN_WARP: {
+        case line_pattern_enum::LINE_PATTERN_WARP: {
             warp_pattern pattern(*marker, common_, sym, feature, prj_trans);
             pattern.render(context_);
             break;
         }
-        case LINE_PATTERN_REPEAT: {
+        case line_pattern_enum::LINE_PATTERN_REPEAT: {
             repeat_pattern pattern(*marker, common_, sym, feature, prj_trans);
             pattern.render(context_);
             break;
         }
-        case line_pattern_enum_MAX:
+        case line_pattern_enum::line_pattern_enum_MAX:
         default:
             MAPNIK_LOG_ERROR(process_line_pattern_symbolizer) << "Incorrect line-pattern value.";
     }

--- a/src/feature_type_style.cpp
+++ b/src/feature_type_style.cpp
@@ -20,21 +20,27 @@
  *
  *****************************************************************************/
 
+#include <algorithm>
+#include <string>
+#include <unordered_map>
 #include <mapnik/feature_type_style.hpp>
 #include <mapnik/rule.hpp>
 #include <mapnik/enumeration.hpp>
 
-// boost
-
 namespace mapnik {
-
-static const char* filter_mode_strings[] = {"all", "first", ""};
-
-IMPLEMENT_ENUM(filter_mode_e, filter_mode_strings)
+namespace {
+using E = detail::EnumStringT<filter_mode_enum>;
+constexpr detail::EnumMapT<filter_mode_enum, 3> filter_mode_e_map{{
+  E{filter_mode_enum::FILTER_ALL, "all"},
+  E{filter_mode_enum::FILTER_FIRST, "first"},
+  E{filter_mode_enum::filter_mode_enum_MAX, ""},
+}};
+} // namespace
+IMPLEMENT_ENUM(filter_mode_e, filter_mode_enum);
 
 feature_type_style::feature_type_style()
     : rules_()
-    , filter_mode_(FILTER_ALL)
+    , filter_mode_(filter_mode_enum::FILTER_ALL)
     , filters_()
     , direct_filters_()
     , comp_op_()

--- a/src/grid/process_line_pattern_symbolizer.cpp
+++ b/src/grid/process_line_pattern_symbolizer.cpp
@@ -42,8 +42,6 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include "agg_rasterizer_scanline_aa.h"
 #include "agg_renderer_scanline.h"
 #include "agg_scanline_bin.h"
-#include "agg_conv_stroke.h"
-#include "agg_conv_dash.h"
 MAPNIK_DISABLE_WARNING_POP
 
 // stl
@@ -56,10 +54,10 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
                                mapnik::feature_impl& feature,
                                proj_transform const& prj_trans)
 {
-    std::string filename = get<std::string, keys::file>(sym, feature, common_.vars_);
+    const std::string filename = get<std::string, keys::file>(sym, feature, common_.vars_);
     if (filename.empty())
         return;
-    std::shared_ptr<mapnik::marker const> mark = marker_cache::instance().find(filename, true);
+    const auto mark = marker_cache::instance().find(filename, true);
     if (mark->is<mapnik::marker_null>())
         return;
 
@@ -70,10 +68,10 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
         return;
     }
 
-    value_bool clip = get<value_bool, keys::clip>(sym, feature, common_.vars_);
-    value_double offset = get<value_double, keys::offset>(sym, feature, common_.vars_);
-    value_double simplify_tolerance = get<value_double, keys::simplify_tolerance>(sym, feature, common_.vars_);
-    value_double smooth = get<value_double, keys::smooth>(sym, feature, common_.vars_);
+    const value_bool clip = get<value_bool, keys::clip>(sym, feature, common_.vars_);
+    const value_double offset = get<value_double, keys::offset>(sym, feature, common_.vars_);
+    const value_double simplify_tolerance = get<value_double, keys::simplify_tolerance>(sym, feature, common_.vars_);
+    const value_double smooth = get<value_double, keys::smooth>(sym, feature, common_.vars_);
 
     using pixfmt_type = typename grid_renderer_base_type::pixfmt_type;
     using color_type = typename grid_renderer_base_type::pixfmt_type::color_type;
@@ -90,12 +88,12 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     ras_ptr->reset();
 
     line_pattern_enum pattern = get<line_pattern_enum, keys::line_pattern>(sym, feature, common_.vars_);
-    std::size_t stroke_width = (pattern == LINE_PATTERN_WARP)
-                                 ? mark->width()
-                                 : get<value_double, keys::stroke_width>(sym, feature, common_.vars_);
+    const std::size_t stroke_width = (pattern == line_pattern_enum::LINE_PATTERN_WARP)
+                                       ? mark->width()
+                                       : get<value_double, keys::stroke_width>(sym, feature, common_.vars_);
 
     agg::trans_affine tr;
-    auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
+    const auto transform = get_optional<transform_type>(sym, keys::geometry_transform);
     if (transform)
     {
         evaluate_transform(tr, feature, common_.vars_, *transform, common_.scale_factor_);
@@ -104,10 +102,10 @@ void grid_renderer<T>::process(line_pattern_symbolizer const& sym,
     box2d<double> clipping_extent = common_.query_extent_;
     if (clip)
     {
-        double pad_per_pixel = static_cast<double>(common_.query_extent_.width() / common_.width_);
-        double pixels = std::ceil(
+        const double pad_per_pixel = static_cast<double>(common_.query_extent_.width() / common_.width_);
+        const double pixels = std::ceil(
           std::max(stroke_width / 2.0 + std::fabs(offset), (std::fabs(offset) * offset_converter_default_threshold)));
-        double padding = pad_per_pixel * pixels * common_.scale_factor_;
+        const double padding = pad_per_pixel * pixels * common_.scale_factor_;
 
         clipping_extent.pad(padding);
     }

--- a/src/load_map.cpp
+++ b/src/load_map.cpp
@@ -489,7 +489,7 @@ void map_parser::parse_style(Map& map, xml_node const& node)
         name = node.get_attr<std::string>("name");
         feature_type_style style;
 
-        filter_mode_e filter_mode = node.get_attr<filter_mode_e>("filter-mode", FILTER_ALL);
+        filter_mode_e filter_mode = node.get_attr<filter_mode_e>("filter-mode", filter_mode_enum::FILTER_ALL);
         style.set_filter_mode(filter_mode);
 
         // compositing
@@ -1586,9 +1586,10 @@ bool map_parser::parse_raster_colorizer(raster_colorizer_ptr const& rc, xml_node
     try
     {
         // mode
-        colorizer_mode default_mode = node.get_attr<colorizer_mode>("default-mode", COLORIZER_LINEAR);
+        colorizer_mode default_mode =
+          node.get_attr<colorizer_mode>("default-mode", colorizer_mode_enum::COLORIZER_LINEAR);
 
-        if (default_mode == COLORIZER_INHERIT)
+        if (default_mode == colorizer_mode_enum::COLORIZER_INHERIT)
         {
             throw config_error("RasterColorizer mode must not be INHERIT. ");
         }
@@ -1626,7 +1627,7 @@ bool map_parser::parse_raster_colorizer(raster_colorizer_ptr const& rc, xml_node
                 }
 
                 // mode default to INHERIT
-                colorizer_mode mode = n.get_attr<colorizer_mode>("mode", COLORIZER_INHERIT);
+                colorizer_mode mode = n.get_attr<colorizer_mode>("mode", colorizer_mode_enum::COLORIZER_INHERIT);
 
                 // value is required, and it must be bigger than the previous
                 optional<float> val = n.get_opt_attr<float>("value");

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -46,19 +46,22 @@
 #include <stdexcept>
 
 namespace mapnik {
-
-static const char* aspect_fix_mode_strings[] = {"GROW_BBOX",
-                                                "GROW_CANVAS",
-                                                "SHRINK_BBOX",
-                                                "SHRINK_CANVAS",
-                                                "ADJUST_BBOX_WIDTH",
-                                                "ADJUST_BBOX_HEIGHT",
-                                                "ADJUST_CANVAS_WIDTH",
-                                                "ADJUST_CANVAS_HEIGHT",
-                                                "RESPECT",
-                                                ""};
-
-IMPLEMENT_ENUM(aspect_fix_mode_e, aspect_fix_mode_strings)
+namespace {
+using E = detail::EnumStringT<Map::aspect_fix_mode>;
+constexpr detail::EnumMapT<Map::aspect_fix_mode, 10> aspect_fix_mode_e_map{{
+  E{Map::aspect_fix_mode::GROW_BBOX, "GROW_BBOX"},
+  E{Map::aspect_fix_mode::GROW_CANVAS, "GROW_CANVAS"},
+  E{Map::aspect_fix_mode::SHRINK_BBOX, "SHRINK_BBOX"},
+  E{Map::aspect_fix_mode::SHRINK_CANVAS, "SHRINK_CANVAS"},
+  E{Map::aspect_fix_mode::ADJUST_BBOX_WIDTH, "ADJUST_BBOX_WIDTH"},
+  E{Map::aspect_fix_mode::ADJUST_BBOX_HEIGHT, "ADJUST_BBOX_HEIGHT"},
+  E{Map::aspect_fix_mode::ADJUST_CANVAS_WIDTH, "ADJUST_CANVAS_WIDTH"},
+  E{Map::aspect_fix_mode::ADJUST_CANVAS_HEIGHT, "ADJUST_CANVAS_HEIGHT"},
+  E{Map::aspect_fix_mode::RESPECT, "RESPECT"},
+  E{Map::aspect_fix_mode::aspect_fix_mode_MAX, ""},
+}};
+} // namespace
+IMPLEMENT_ENUM(aspect_fix_mode_e, Map::aspect_fix_mode)
 
 Map::Map()
     : width_(400)

--- a/src/marker_helpers.cpp
+++ b/src/marker_helpers.cpp
@@ -240,7 +240,8 @@ void apply_markers_multi(feature_impl const& feature,
           get<marker_multi_policy_enum, keys::markers_multipolicy>(sym, feature, vars);
         marker_placement_enum placement = get<marker_placement_enum, keys::markers_placement_type>(sym, feature, vars);
 
-        if (placement == MARKER_POINT_PLACEMENT && multi_policy == MARKER_WHOLE_MULTI)
+        if (placement == marker_placement_enum::MARKER_POINT_PLACEMENT &&
+            multi_policy == marker_multi_policy_enum::MARKER_WHOLE_MULTI)
         {
             geometry::point<double> pt;
             // test if centroid is contained by bounding box
@@ -252,9 +253,10 @@ void apply_markers_multi(feature_impl const& feature,
                 converter.apply(va, proc);
             }
         }
-        else if ((placement == MARKER_POINT_PLACEMENT || placement == MARKER_INTERIOR_PLACEMENT ||
-                  placement == MARKER_POLYLABEL_PLACEMENT) &&
-                 multi_policy == MARKER_LARGEST_MULTI)
+        else if ((placement == marker_placement_enum::MARKER_POINT_PLACEMENT ||
+                  placement == marker_placement_enum::MARKER_INTERIOR_PLACEMENT ||
+                  placement == marker_placement_enum::MARKER_POLYLABEL_PLACEMENT) &&
+                 multi_policy == marker_multi_policy_enum::MARKER_LARGEST_MULTI)
         {
             // Only apply to path with largest envelope area
             // TODO: consider using true area for polygon types
@@ -287,7 +289,8 @@ void apply_markers_multi(feature_impl const& feature,
         }
         else
         {
-            if (multi_policy != MARKER_EACH_MULTI && placement != MARKER_POINT_PLACEMENT)
+            if (multi_policy != marker_multi_policy_enum::MARKER_EACH_MULTI &&
+                placement != marker_placement_enum::MARKER_POINT_PLACEMENT)
             {
                 MAPNIK_LOG_WARN(marker_symbolizer)
                   << "marker_multi_policy != 'each' has no effect with marker_placement != 'point'";

--- a/src/proj_transform.cpp
+++ b/src/proj_transform.cpp
@@ -109,12 +109,12 @@ proj_transform::proj_transform(projection const& source, projection const& dest)
         bool known_trans = false;
         if (src_k && dest_k)
         {
-            if (*src_k == WGS_84 && *dest_k == WEB_MERC)
+            if (*src_k == well_known_srs_enum::WGS_84 && *dest_k == well_known_srs_enum::WEB_MERC)
             {
                 wgs84_to_merc_ = true;
                 known_trans = true;
             }
-            else if (*src_k == WEB_MERC && *dest_k == WGS_84)
+            else if (*src_k == well_known_srs_enum::WEB_MERC && *dest_k == well_known_srs_enum::WGS_84)
             {
                 merc_to_wgs84_ = true;
                 known_trans = true;

--- a/src/raster_colorizer.cpp
+++ b/src/raster_colorizer.cpp
@@ -36,10 +36,17 @@
 namespace mapnik {
 
 //! \brief Strings for the colorizer_mode enumeration
-static const char* colorizer_mode_strings[] =
-  {"inherit", "linear", "discrete", "exact", "linear-rgba", "linear-bgra", ""};
-
-IMPLEMENT_ENUM(colorizer_mode, colorizer_mode_strings)
+using colorizer_mode_str = detail::EnumStringT<colorizer_mode_enum>;
+constexpr detail::EnumMapT<colorizer_mode_enum, 7> colorizer_mode_map{{
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_INHERIT, "inherit"},
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_LINEAR, "linear"},
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_DISCRETE, "discrete"},
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_EXACT, "exact"},
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_LINEAR_RGBA, "linear-rgba"},
+  colorizer_mode_str{colorizer_mode_enum::COLORIZER_LINEAR_BGRA, "linear-bgra"},
+  colorizer_mode_str{colorizer_mode_enum::colorizer_mode_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(colorizer_mode, colorizer_mode_enum)
 
 colorizer_stop::colorizer_stop(float val, colorizer_mode mode, color const& _color, std::string const& label)
     : value_(val)
@@ -177,7 +184,7 @@ unsigned raster_colorizer::get_color(float val) const
     else
     {
         stopMode = stops_[stopIdx].get_mode();
-        if (stopMode == COLORIZER_INHERIT)
+        if (stopMode == colorizer_mode_enum::COLORIZER_INHERIT)
         {
             stopMode = default_mode_;
         }
@@ -206,7 +213,7 @@ unsigned raster_colorizer::get_color(float val) const
 
     switch (stopMode)
     {
-        case COLORIZER_LINEAR: {
+        case colorizer_mode_enum::COLORIZER_LINEAR: {
             // deal with this separately so we don't have to worry about div0
             if (nextStopValue == stopValue)
             {
@@ -228,7 +235,7 @@ unsigned raster_colorizer::get_color(float val) const
             }
         }
         break;
-        case COLORIZER_LINEAR_RGBA: {
+        case colorizer_mode_enum::COLORIZER_LINEAR_RGBA: {
             if (nextStopValue == stopValue)
             {
                 return stopColor.rgba();
@@ -240,7 +247,7 @@ unsigned raster_colorizer::get_color(float val) const
             outputColor = color(colorStart + fraction * (colorEnd - colorStart));
         }
         break;
-        case COLORIZER_LINEAR_BGRA: {
+        case colorizer_mode_enum::COLORIZER_LINEAR_BGRA: {
             if (nextStopValue == stopValue)
             {
                 return stopColor.rgba();
@@ -255,10 +262,10 @@ unsigned raster_colorizer::get_color(float val) const
             std::swap(outputColor.red_, outputColor.blue_);
         }
         break;
-        case COLORIZER_DISCRETE:
+        case colorizer_mode_enum::COLORIZER_DISCRETE:
             outputColor = stopColor;
             break;
-        case COLORIZER_EXACT:
+        case colorizer_mode_enum::COLORIZER_EXACT:
         default:
             // approximately equal (within epsilon)
             if (std::fabs(val - stopValue) < epsilon_)

--- a/src/renderer_common/pattern_alignment.cpp
+++ b/src/renderer_common/pattern_alignment.cpp
@@ -73,7 +73,7 @@ coord<double, 2> pattern_offset(symbolizer_base const& sym,
     coord<double, 2> reference_position(0, 0);
     pattern_alignment_enum alignment_type = get<pattern_alignment_enum, keys::alignment>(sym, feature, common.vars_);
 
-    if (alignment_type == LOCAL_ALIGNMENT)
+    if (alignment_type == pattern_alignment_enum::LOCAL_ALIGNMENT)
     {
         apply_local_alignment apply(common.t_, prj_trans, reference_position.x, reference_position.y);
         util::apply_visitor(geometry::vertex_processor<apply_local_alignment>(apply), feature.get_geometry());

--- a/src/renderer_common/render_thunk_extractor.cpp
+++ b/src/renderer_common/render_thunk_extractor.cpp
@@ -137,8 +137,11 @@ void render_thunk_extractor::extract_text_thunk(text_render_thunk::helper_ptr&& 
 {
     double opacity = get<double>(sym, keys::opacity, feature_, common_.vars_, 1.0);
     composite_mode_e comp_op = get<composite_mode_e>(sym, keys::comp_op, feature_, common_.vars_, src_over);
-    halo_rasterizer_enum halo_rasterizer =
-      get<halo_rasterizer_enum>(sym, keys::halo_rasterizer, feature_, common_.vars_, HALO_RASTERIZER_FULL);
+    halo_rasterizer_enum halo_rasterizer = get<halo_rasterizer_enum>(sym,
+                                                                     keys::halo_rasterizer,
+                                                                     feature_,
+                                                                     common_.vars_,
+                                                                     halo_rasterizer_enum::HALO_RASTERIZER_FULL);
 
     text_render_thunk thunk(std::move(helper), opacity, comp_op, halo_rasterizer);
     thunks_.emplace_back(std::move(thunk));

--- a/src/svg/output/svg_output_attributes.cpp
+++ b/src/svg/output/svg_output_attributes.cpp
@@ -59,13 +59,13 @@ void path_output_attributes::set_stroke_linecap(line_cap_e stroke_linecap)
 {
     switch (stroke_linecap)
     {
-        case BUTT_CAP:
+        case line_cap_enum::BUTT_CAP:
             stroke_linecap_ = "butt";
             break;
-        case SQUARE_CAP:
+        case line_cap_enum::SQUARE_CAP:
             stroke_linecap_ = "square";
             break;
-        case ROUND_CAP:
+        case line_cap_enum::ROUND_CAP:
             stroke_linecap_ = "round";
             break;
         default:
@@ -77,16 +77,16 @@ void path_output_attributes::set_stroke_linejoin(line_join_e stroke_linejoin)
 {
     switch (stroke_linejoin)
     {
-        case MITER_JOIN:
+        case line_join_enum::MITER_JOIN:
             stroke_linejoin_ = "miter";
             break;
-        case MITER_REVERT_JOIN:
+        case line_join_enum::MITER_REVERT_JOIN:
             stroke_linejoin_ = "miter";
             break;
-        case ROUND_JOIN:
+        case line_join_enum::ROUND_JOIN:
             stroke_linejoin_ = "round";
             break;
-        case BEVEL_JOIN:
+        case line_join_enum::BEVEL_JOIN:
             stroke_linejoin_ = "bevel";
             break;
         default:

--- a/src/symbolizer_enumerations.cpp
+++ b/src/symbolizer_enumerations.cpp
@@ -23,98 +23,202 @@
 #include <mapnik/symbolizer_enumerations.hpp>
 
 namespace mapnik {
+
 // stroke
-static const char* line_cap_strings[] = {"butt", "square", "round", ""};
+using line_cap_e_str = detail::EnumStringT<line_cap_enum>;
+constexpr detail::EnumMapT<line_cap_enum, 4> line_cap_e_map{{
+  line_cap_e_str{line_cap_enum::BUTT_CAP, "butt"},
+  line_cap_e_str{line_cap_enum::SQUARE_CAP, "square"},
+  line_cap_e_str{line_cap_enum::ROUND_CAP, "round"},
+  line_cap_e_str{line_cap_enum::line_cap_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(line_cap_e, line_cap_enum)
 
-IMPLEMENT_ENUM(line_cap_e, line_cap_strings)
-
-static const char* line_join_strings[] = {"miter", "miter-revert", "round", "bevel", ""};
-
-IMPLEMENT_ENUM(line_join_e, line_join_strings)
+using line_join_e_str = detail::EnumStringT<line_join_enum>;
+constexpr detail::EnumMapT<line_join_enum, 5> line_join_e_map{{
+  line_join_e_str{line_join_enum::MITER_JOIN, "miter"},
+  line_join_e_str{line_join_enum::MITER_REVERT_JOIN, "miter-revert"},
+  line_join_e_str{line_join_enum::ROUND_JOIN, "round"},
+  line_join_e_str{line_join_enum::BEVEL_JOIN, "bevel"},
+  line_join_e_str{line_join_enum::line_join_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(line_join_e, line_join_enum)
 
 // point symbolizer
-static const char* point_placement_strings[] = {"centroid", "interior", ""};
-
-IMPLEMENT_ENUM(point_placement_e, point_placement_strings)
+using point_placement_e_str = detail::EnumStringT<point_placement_enum>;
+constexpr detail::EnumMapT<point_placement_enum, 3> point_placement_e_map{{
+  point_placement_e_str{point_placement_enum::CENTROID_POINT_PLACEMENT, "centroid"},
+  point_placement_e_str{point_placement_enum::INTERIOR_POINT_PLACEMENT, "interior"},
+  point_placement_e_str{point_placement_enum::point_placement_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(point_placement_e, point_placement_enum)
 
 // line symbolizer
-static const char* line_rasterizer_strings[] = {"full", "fast", ""};
-IMPLEMENT_ENUM(line_rasterizer_e, line_rasterizer_strings)
+using line_rasterizer_e_str = detail::EnumStringT<line_rasterizer_enum>;
+constexpr detail::EnumMapT<line_rasterizer_enum, 3> line_rasterizer_e_map{{
+  line_rasterizer_e_str{line_rasterizer_enum::RASTERIZER_FULL, "full"},
+  line_rasterizer_e_str{line_rasterizer_enum::RASTERIZER_FAST, "fast"},
+  line_rasterizer_e_str{line_rasterizer_enum::line_rasterizer_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(line_rasterizer_e, line_rasterizer_enum)
 
 // markers symbolizer
-static const char* marker_placement_strings[] =
-  {"point", "interior", "line", "vertex-first", "vertex-last", "angled-point", "polylabel", ""};
+using marker_placement_e_str = detail::EnumStringT<marker_placement_enum>;
+constexpr detail::EnumMapT<marker_placement_enum, 8> marker_placement_e_map{{
+  marker_placement_e_str{marker_placement_enum::MARKER_POINT_PLACEMENT, "point"},
+  marker_placement_e_str{marker_placement_enum::MARKER_INTERIOR_PLACEMENT, "interior"},
+  marker_placement_e_str{marker_placement_enum::MARKER_LINE_PLACEMENT, "line"},
+  marker_placement_e_str{marker_placement_enum::MARKER_VERTEX_FIRST_PLACEMENT, "vertex-first"},
+  marker_placement_e_str{marker_placement_enum::MARKER_VERTEX_LAST_PLACEMENT, "vertex-last"},
+  marker_placement_e_str{marker_placement_enum::MARKER_ANGLED_POINT_PLACEMENT, "angled-point"},
+  marker_placement_e_str{marker_placement_enum::MARKER_POLYLABEL_PLACEMENT, "polylabel"},
+  marker_placement_e_str{marker_placement_enum::marker_placement_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(marker_placement_e, marker_placement_enum)
 
-IMPLEMENT_ENUM(marker_placement_e, marker_placement_strings)
-
-static const char* marker_multi_policy_strings[] = {"each", "whole", "largest", ""};
-
-IMPLEMENT_ENUM(marker_multi_policy_e, marker_multi_policy_strings)
+using marker_multi_policy_e_str = detail::EnumStringT<marker_multi_policy_enum>;
+constexpr detail::EnumMapT<marker_multi_policy_enum, 4> marker_multi_policy_e_map{{
+  marker_multi_policy_e_str{marker_multi_policy_enum::MARKER_EACH_MULTI, "each"},
+  marker_multi_policy_e_str{marker_multi_policy_enum::MARKER_WHOLE_MULTI, "whole"},
+  marker_multi_policy_e_str{marker_multi_policy_enum::MARKER_LARGEST_MULTI, "largest"},
+  marker_multi_policy_e_str{marker_multi_policy_enum::marker_multi_policy_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(marker_multi_policy_e, marker_multi_policy_enum)
 
 // debug symbolizer
-static const char* debug_symbolizer_mode_strings[] = {"collision", "vertex", "rings", ""};
-
-IMPLEMENT_ENUM(debug_symbolizer_mode_e, debug_symbolizer_mode_strings)
+using debug_symbolizer_mode_e_str = detail::EnumStringT<debug_symbolizer_mode_enum>;
+constexpr detail::EnumMapT<debug_symbolizer_mode_enum, 4> debug_symbolizer_mode_e_map{{
+  debug_symbolizer_mode_e_str{debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION, "collision"},
+  debug_symbolizer_mode_e_str{debug_symbolizer_mode_enum::DEBUG_SYM_MODE_VERTEX, "vertex"},
+  debug_symbolizer_mode_e_str{debug_symbolizer_mode_enum::DEBUG_SYM_MODE_RINGS, "rings"},
+  debug_symbolizer_mode_e_str{debug_symbolizer_mode_enum::debug_symbolizer_mode_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(debug_symbolizer_mode_e, debug_symbolizer_mode_enum)
 
 // polygon pattern symbolizer
-static const char* pattern_alignment_strings[] = {"local",  // feature
-                                                  "global", // map
-                                                  ""};
-
-IMPLEMENT_ENUM(pattern_alignment_e, pattern_alignment_strings)
+using pattern_alignment_e_str = detail::EnumStringT<pattern_alignment_enum>;
+constexpr detail::EnumMapT<pattern_alignment_enum, 3> pattern_alignment_e_map{{
+  pattern_alignment_e_str{pattern_alignment_enum::LOCAL_ALIGNMENT, "local"},   // feature
+  pattern_alignment_e_str{pattern_alignment_enum::GLOBAL_ALIGNMENT, "global"}, // map
+  pattern_alignment_e_str{pattern_alignment_enum::pattern_alignment_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(pattern_alignment_e, pattern_alignment_enum)
 
 // text
-static const char* halo_rasterizer_strings[] = {"full", "fast", ""};
+using halo_rasterizer_e_str = detail::EnumStringT<halo_rasterizer_enum>;
+constexpr detail::EnumMapT<halo_rasterizer_enum, 3> halo_rasterizer_e_map{{
+  halo_rasterizer_e_str{halo_rasterizer_enum::HALO_RASTERIZER_FULL, "full"},
+  halo_rasterizer_e_str{halo_rasterizer_enum::HALO_RASTERIZER_FAST, "fast"},
+  halo_rasterizer_e_str{halo_rasterizer_enum::halo_rasterizer_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(halo_rasterizer_e, halo_rasterizer_enum)
 
-IMPLEMENT_ENUM(halo_rasterizer_e, halo_rasterizer_strings)
+using label_placement_e_str = detail::EnumStringT<label_placement_enum>;
+constexpr detail::EnumMapT<label_placement_enum, 8> label_placement_e_map{{
+  label_placement_e_str{label_placement_enum::POINT_PLACEMENT, "point"},
+  label_placement_e_str{label_placement_enum::LINE_PLACEMENT, "line"},
+  label_placement_e_str{label_placement_enum::VERTEX_PLACEMENT, "vertex"},
+  label_placement_e_str{label_placement_enum::INTERIOR_PLACEMENT, "interior"},
+  label_placement_e_str{label_placement_enum::POLYLABEL_PLACEMENT, "polylabel"},
+  label_placement_e_str{label_placement_enum::GRID_PLACEMENT, "grid"},
+  label_placement_e_str{label_placement_enum::ALTERNATING_GRID_PLACEMENT, "alternating-grid"},
+  label_placement_e_str{label_placement_enum::label_placement_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(label_placement_e, label_placement_enum)
 
-static const char* label_placement_strings[] =
-  {"point", "line", "vertex", "interior", "polylabel", "grid", "alternating-grid", ""};
+using vertical_alignment_e_str = detail::EnumStringT<vertical_alignment_enum>;
+constexpr detail::EnumMapT<vertical_alignment_enum, 5> vertical_alignment_e_map{{
+  vertical_alignment_e_str{vertical_alignment_enum::V_TOP, "top"},
+  vertical_alignment_e_str{vertical_alignment_enum::V_MIDDLE, "middle"},
+  vertical_alignment_e_str{vertical_alignment_enum::V_BOTTOM, "bottom"},
+  vertical_alignment_e_str{vertical_alignment_enum::V_AUTO, "auto"},
+  vertical_alignment_e_str{vertical_alignment_enum::vertical_alignment_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(vertical_alignment_e, vertical_alignment_enum)
 
-IMPLEMENT_ENUM(label_placement_e, label_placement_strings)
+using horizontal_alignment_e_str = detail::EnumStringT<horizontal_alignment_enum>;
+constexpr detail::EnumMapT<horizontal_alignment_enum, 6> horizontal_alignment_e_map{{
+  horizontal_alignment_e_str{horizontal_alignment_enum::H_LEFT, "left"},
+  horizontal_alignment_e_str{horizontal_alignment_enum::H_MIDDLE, "middle"},
+  horizontal_alignment_e_str{horizontal_alignment_enum::H_RIGHT, "right"},
+  horizontal_alignment_e_str{horizontal_alignment_enum::H_AUTO, "auto"},
+  horizontal_alignment_e_str{horizontal_alignment_enum::H_ADJUST, "adjust"},
+  horizontal_alignment_e_str{horizontal_alignment_enum::horizontal_alignment_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(horizontal_alignment_e, horizontal_alignment_enum)
 
-static const char* vertical_alignment_strings[] = {"top", "middle", "bottom", "auto", ""};
+using justify_alignment_e_str = detail::EnumStringT<justify_alignment_enum>;
+constexpr detail::EnumMapT<justify_alignment_enum, 5> justify_alignment_e_map{{
+  justify_alignment_e_str{justify_alignment_enum::J_LEFT, "left"},
+  justify_alignment_e_str{justify_alignment_enum::J_MIDDLE, "center"}, // not 'middle' in order to match CSS
+  justify_alignment_e_str{justify_alignment_enum::J_RIGHT, "right"},
+  justify_alignment_e_str{justify_alignment_enum::J_AUTO, "auto"},
+  justify_alignment_e_str{justify_alignment_enum::justify_alignment_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(justify_alignment_e, justify_alignment_enum)
 
-IMPLEMENT_ENUM(vertical_alignment_e, vertical_alignment_strings)
+using text_transform_e_str = detail::EnumStringT<text_transform_enum>;
+constexpr detail::EnumMapT<text_transform_enum, 6> text_transform_e_map{{
+  text_transform_e_str{text_transform_enum::NONE, "none"},
+  text_transform_e_str{text_transform_enum::UPPERCASE, "uppercase"},
+  text_transform_e_str{text_transform_enum::LOWERCASE, "lowercase"},
+  text_transform_e_str{text_transform_enum::CAPITALIZE, "capitalize"},
+  text_transform_e_str{text_transform_enum::REVERSE, "reverse"},
+  text_transform_e_str{text_transform_enum::text_transform_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(text_transform_e, text_transform_enum)
 
-static const char* horizontal_alignment_strings[] = {"left", "middle", "right", "auto", "adjust", ""};
+using text_upright_e_str = detail::EnumStringT<text_upright_enum>;
+constexpr detail::EnumMapT<text_upright_enum, 7> text_upright_e_map{{
+  text_upright_e_str{text_upright_enum::UPRIGHT_AUTO, "auto"},
+  text_upright_e_str{text_upright_enum::UPRIGHT_AUTO_DOWN, "auto-down"},
+  text_upright_e_str{text_upright_enum::UPRIGHT_LEFT, "left"},
+  text_upright_e_str{text_upright_enum::UPRIGHT_RIGHT, "right"},
+  text_upright_e_str{text_upright_enum::UPRIGHT_LEFT_ONLY, "left-only"},
+  text_upright_e_str{text_upright_enum::UPRIGHT_RIGHT_ONLY, "right-only"},
+  text_upright_e_str{text_upright_enum::text_upright_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(text_upright_e, text_upright_enum)
 
-IMPLEMENT_ENUM(horizontal_alignment_e, horizontal_alignment_strings)
+using direction_e_str = detail::EnumStringT<direction_enum>;
+constexpr detail::EnumMapT<direction_enum, 9> direction_e_map{{
+  direction_e_str{direction_enum::DIRECTION_LEFT, "left"},
+  direction_e_str{direction_enum::DIRECTION_RIGHT, "right"},
+  direction_e_str{direction_enum::DIRECTION_LEFT_ONLY, "left-only"},
+  direction_e_str{direction_enum::DIRECTION_RIGHT_ONLY, "right-only"},
+  direction_e_str{direction_enum::DIRECTION_AUTO, "auto"},
+  direction_e_str{direction_enum::DIRECTION_AUTO_DOWN, "auto-down"},
+  direction_e_str{direction_enum::DIRECTION_UP, "up"},
+  direction_e_str{direction_enum::DIRECTION_DOWN, "down"},
+  direction_e_str{direction_enum::direction_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(direction_e, direction_enum)
 
-static const char* justify_alignment_strings[] = {"left",
-                                                  "center", // not 'middle' in order to match CSS
-                                                  "right",
-                                                  "auto",
-                                                  ""};
+using gamma_method_e_str = detail::EnumStringT<gamma_method_enum>;
+constexpr detail::EnumMapT<gamma_method_enum, 6> gamma_method_e_map{{
+  gamma_method_e_str{gamma_method_enum::GAMMA_POWER, "power"},         // agg::gamma_power
+  gamma_method_e_str{gamma_method_enum::GAMMA_LINEAR, "linear"},       // agg::gamma_linear
+  gamma_method_e_str{gamma_method_enum::GAMMA_NONE, "none"},           // agg::gamma_none
+  gamma_method_e_str{gamma_method_enum::GAMMA_THRESHOLD, "threshold"}, // agg::gamma_threshold
+  gamma_method_e_str{gamma_method_enum::GAMMA_MULTIPLY, "multiply"},   // agg::gamma_multiply"
+  gamma_method_e_str{gamma_method_enum::gamma_method_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(gamma_method_e, gamma_method_enum)
 
-IMPLEMENT_ENUM(justify_alignment_e, justify_alignment_strings)
+using line_pattern_e_str = detail::EnumStringT<line_pattern_enum>;
+constexpr detail::EnumMapT<line_pattern_enum, 3> line_pattern_e_map{{
+  line_pattern_e_str{line_pattern_enum::LINE_PATTERN_WARP, "warp"},
+  line_pattern_e_str{line_pattern_enum::LINE_PATTERN_REPEAT, "repeat"},
+  line_pattern_e_str{line_pattern_enum::line_pattern_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(line_pattern_e, line_pattern_enum)
 
-static const char* text_transform_strings[] = {"none", "uppercase", "lowercase", "capitalize", "reverse", ""};
-
-IMPLEMENT_ENUM(text_transform_e, text_transform_strings)
-
-static const char* text_upright_strings[] = {"auto", "auto-down", "left", "right", "left-only", "right-only", ""};
-IMPLEMENT_ENUM(text_upright_e, text_upright_strings)
-
-static const char* direction_strings[] =
-  {"left", "right", "left-only", "right-only", "auto", "auto-down", "up", "down", ""};
-IMPLEMENT_ENUM(direction_e, direction_strings)
-
-static const char* gamma_method_strings[] = {"power",     // agg::gamma_power
-                                             "linear",    // agg::gamma_linear
-                                             "none",      // agg::gamma_none
-                                             "threshold", // agg::gamma_threshold
-                                             "multiply",  // agg::gamma_multiply",
-                                             ""};
-
-IMPLEMENT_ENUM(gamma_method_e, gamma_method_strings)
-
-static const char* line_pattern_strings[] = {"warp", "repeat", ""};
-
-IMPLEMENT_ENUM(line_pattern_e, line_pattern_strings)
-
-static const char* smooth_algorithm_strings[] = {"basic", "adaptive", ""};
-
-IMPLEMENT_ENUM(smooth_algorithm_e, smooth_algorithm_strings)
+using smooth_algorithm_e_str = detail::EnumStringT<smooth_algorithm_enum>;
+constexpr detail::EnumMapT<smooth_algorithm_enum, 3> smooth_algorithm_e_map{{
+  smooth_algorithm_e_str{smooth_algorithm_enum::SMOOTH_ALGORITHM_BASIC, "basic"},
+  smooth_algorithm_e_str{smooth_algorithm_enum::SMOOTH_ALGORITHM_ADAPTIVE, "adaptive"},
+  smooth_algorithm_e_str{smooth_algorithm_enum::smooth_algorithm_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(smooth_algorithm_e, smooth_algorithm_enum)
 
 } // namespace mapnik

--- a/src/symbolizer_keys.cpp
+++ b/src/symbolizer_keys.cpp
@@ -36,13 +36,10 @@ static const property_meta_type key_meta[const_max_key] = {
   property_meta_type{"gamma", nullptr, property_types::target_double},
   property_meta_type{"gamma-method", nullptr, property_types::target_gamma_method},
   property_meta_type{"opacity", nullptr, property_types::target_double},
-  property_meta_type{"alignment",
-                     [](enumeration_wrapper e) {
-                         return enumeration<pattern_alignment_enum, pattern_alignment_enum_MAX>(
-                                  pattern_alignment_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_pattern_alignment},
+  property_meta_type{
+    "alignment",
+    [](enumeration_wrapper e) { return pattern_alignment_e(pattern_alignment_enum(e.value)).as_string(); },
+    property_types::target_pattern_alignment},
   property_meta_type{"offset", nullptr, property_types::target_double},
   property_meta_type{"comp-op",
                      [](enumeration_wrapper e) { return *comp_op_to_string(composite_mode_e(e.value)); },
@@ -54,14 +51,10 @@ static const property_meta_type key_meta[const_max_key] = {
   property_meta_type{"stroke-width", nullptr, property_types::target_double},
   property_meta_type{"stroke-opacity", nullptr, property_types::target_double},
   property_meta_type{"stroke-linejoin",
-                     [](enumeration_wrapper e) {
-                         return enumeration<line_join_enum, line_join_enum_MAX>(line_join_enum(e.value)).as_string();
-                     },
+                     [](enumeration_wrapper e) { return line_join_e(line_join_enum(e.value)).as_string(); },
                      property_types::target_line_join},
   property_meta_type{"stroke-linecap",
-                     [](enumeration_wrapper e) {
-                         return enumeration<line_cap_enum, line_cap_enum_MAX>(line_cap_enum(e.value)).as_string();
-                     },
+                     [](enumeration_wrapper e) { return line_cap_e(line_cap_enum(e.value)).as_string(); },
                      property_types::target_line_cap},
   property_meta_type{"stroke-gamma", nullptr, property_types::target_double},
   property_meta_type{"stroke-gamma-method", nullptr, property_types::target_gamma_method},
@@ -71,12 +64,9 @@ static const property_meta_type key_meta[const_max_key] = {
   property_meta_type{"geometry-transform", nullptr, property_types::target_transform},
   // TODO - should be called 'line-rasterizer' but for back compat with 2.3.x we keep as 'rasterizer'
   // https://github.com/mapnik/mapnik/issues/2503
-  property_meta_type{
-    "rasterizer",
-    [](enumeration_wrapper e) {
-        return enumeration<line_rasterizer_enum, line_rasterizer_enum_MAX>(line_rasterizer_enum(e.value)).as_string();
-    },
-    property_types::target_double},
+  property_meta_type{"rasterizer",
+                     [](enumeration_wrapper e) { return line_rasterizer_e(line_rasterizer_enum(e.value)).as_string(); },
+                     property_types::target_double},
   property_meta_type{"transform", nullptr, property_types::target_transform},
   property_meta_type{"spacing", nullptr, property_types::target_double},
   property_meta_type{"spacing-offset", nullptr, property_types::target_double},
@@ -97,50 +87,32 @@ static const property_meta_type key_meta[const_max_key] = {
   property_meta_type{"mesh-size", nullptr, property_types::target_double},
   property_meta_type{"premultiplied", nullptr, property_types::target_bool},
   property_meta_type{"smooth", nullptr, property_types::target_double},
-  property_meta_type{"smooth-algorithm",
-                     [](enumeration_wrapper e) {
-                         return enumeration<smooth_algorithm_enum, smooth_algorithm_enum_MAX>(
-                                  smooth_algorithm_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_smooth_algorithm},
+  property_meta_type{
+    "smooth-algorithm",
+    [](enumeration_wrapper e) { return smooth_algorithm_e(smooth_algorithm_enum(e.value)).as_string(); },
+    property_types::target_smooth_algorithm},
   property_meta_type{"simplify-algorithm",
                      [](enumeration_wrapper e) { return *simplify_algorithm_to_string(simplify_algorithm_e(e.value)); },
                      property_types::target_simplify_algorithm},
   property_meta_type{"simplify", nullptr, property_types::target_double},
-  property_meta_type{
-    "halo-rasterizer",
-    [](enumeration_wrapper e) {
-        return enumeration<halo_rasterizer_enum, halo_rasterizer_enum_MAX>(halo_rasterizer_enum(e.value)).as_string();
-    },
-    property_types::target_halo_rasterizer},
+  property_meta_type{"halo-rasterizer",
+                     [](enumeration_wrapper e) { return halo_rasterizer_e(halo_rasterizer_enum(e.value)).as_string(); },
+                     property_types::target_halo_rasterizer},
   property_meta_type{"text-placements", nullptr, property_types::target_double},
-  property_meta_type{
-    "placement",
-    [](enumeration_wrapper e) {
-        return enumeration<label_placement_enum, label_placement_enum_MAX>(label_placement_enum(e.value)).as_string();
-    },
-    property_types::target_placement},
-  property_meta_type{"placement", // FIXME - change property name
-                     [](enumeration_wrapper e) {
-                         return enumeration<marker_placement_enum, marker_placement_enum_MAX>(
-                                  marker_placement_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_markers_placement},
-  property_meta_type{"multi-policy",
-                     [](enumeration_wrapper e) {
-                         return enumeration<marker_multi_policy_enum, marker_multi_policy_enum_MAX>(
-                                  marker_multi_policy_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_markers_multipolicy},
+  property_meta_type{"placement",
+                     [](enumeration_wrapper e) { return label_placement_e(label_placement_enum(e.value)).as_string(); },
+                     property_types::target_placement},
   property_meta_type{
     "placement", // FIXME - change property name
-    [](enumeration_wrapper e) {
-        return enumeration<point_placement_enum, point_placement_enum_MAX>(point_placement_enum(e.value)).as_string();
-    },
-    property_types::target_double},
+    [](enumeration_wrapper e) { return marker_placement_e(marker_placement_enum(e.value)).as_string(); },
+    property_types::target_markers_placement},
+  property_meta_type{
+    "multi-policy",
+    [](enumeration_wrapper e) { return marker_multi_policy_e(marker_multi_policy_enum(e.value)).as_string(); },
+    property_types::target_markers_multipolicy},
+  property_meta_type{"placement", // FIXME - change property name
+                     [](enumeration_wrapper e) { return point_placement_e(point_placement_enum(e.value)).as_string(); },
+                     property_types::target_double},
   property_meta_type{"colorizer", nullptr, property_types::target_colorizer},
   property_meta_type{"halo-transform", nullptr, property_types::target_transform},
   property_meta_type{"num-columns", nullptr, property_types::target_integer},
@@ -152,53 +124,33 @@ static const property_meta_type key_meta[const_max_key] = {
   property_meta_type{"halo-comp-op",
                      [](enumeration_wrapper e) { return *comp_op_to_string(composite_mode_e(e.value)); },
                      property_types::target_halo_comp_op},
+  property_meta_type{"text-transform",
+                     [](enumeration_wrapper e) { return text_transform_e(text_transform_enum(e.value)).as_string(); },
+                     property_types::target_text_transform},
   property_meta_type{
-    "text-transform",
-    [](enumeration_wrapper e) {
-        return enumeration<text_transform_enum, text_transform_enum_MAX>(text_transform_enum(e.value)).as_string();
-    },
-    property_types::target_text_transform},
-  property_meta_type{"horizontal-alignment",
-                     [](enumeration_wrapper e) {
-                         return enumeration<horizontal_alignment_enum, horizontal_alignment_enum_MAX>(
-                                  horizontal_alignment_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_horizontal_alignment},
-  property_meta_type{"justify-alignment",
-                     [](enumeration_wrapper e) {
-                         return enumeration<justify_alignment_enum, justify_alignment_enum_MAX>(
-                                  justify_alignment_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_justify_alignment},
-  property_meta_type{"vertical-alignment",
-                     [](enumeration_wrapper e) {
-                         return enumeration<vertical_alignment_enum, vertical_alignment_enum_MAX>(
-                                  vertical_alignment_enum(e.value))
-                           .as_string();
-                     },
-                     property_types::target_vertical_alignment},
+    "horizontal-alignment",
+    [](enumeration_wrapper e) { return horizontal_alignment_e(horizontal_alignment_enum(e.value)).as_string(); },
+    property_types::target_horizontal_alignment},
   property_meta_type{
-    "upright",
-    [](enumeration_wrapper e) {
-        return enumeration<text_upright_enum, text_upright_enum_MAX>(text_upright_enum(e.value)).as_string();
-    },
-    property_types::target_upright},
+    "justify-alignment",
+    [](enumeration_wrapper e) { return justify_alignment_e(justify_alignment_enum(e.value)).as_string(); },
+    property_types::target_justify_alignment},
+  property_meta_type{
+    "vertical-alignment",
+    [](enumeration_wrapper e) { return vertical_alignment_e(vertical_alignment_enum(e.value)).as_string(); },
+    property_types::target_vertical_alignment},
+  property_meta_type{"upright",
+                     [](enumeration_wrapper e) { return text_upright_e(text_upright_enum(e.value)).as_string(); },
+                     property_types::target_upright},
   property_meta_type{"direction",
-                     [](enumeration_wrapper e) {
-                         return enumeration<direction_enum, direction_enum_MAX>(direction_enum(e.value)).as_string();
-                     },
+                     [](enumeration_wrapper e) { return direction_e(direction_enum(e.value)).as_string(); },
                      property_types::target_direction},
   property_meta_type{"avoid-edges", nullptr, property_types::target_bool},
   property_meta_type{"font-feature-settings", nullptr, property_types::target_font_feature_settings},
   property_meta_type{"extend", nullptr, property_types::target_double},
-  property_meta_type{
-    "line-pattern",
-    [](enumeration_wrapper e) {
-        return enumeration<line_pattern_enum, line_pattern_enum_MAX>(line_pattern_enum(e.value)).as_string();
-    },
-    property_types::target_line_pattern},
+  property_meta_type{"line-pattern",
+                     [](enumeration_wrapper e) { return line_pattern_e(line_pattern_enum(e.value)).as_string(); },
+                     property_types::target_line_pattern},
 
 };
 

--- a/src/text/formatting/text.cpp
+++ b/src/text/formatting/text.cpp
@@ -61,16 +61,16 @@ void text_node::apply(evaluated_format_properties_ptr const& p,
       util::apply_visitor(evaluate<feature_impl, value_type, attributes>(feature, vars), *text_).to_unicode();
     switch (p->text_transform)
     {
-        case UPPERCASE:
+        case text_transform_enum::UPPERCASE:
             text_str.toUpper();
             break;
-        case LOWERCASE:
+        case text_transform_enum::LOWERCASE:
             text_str.toLower();
             break;
-        case REVERSE:
+        case text_transform_enum::REVERSE:
             text_str.reverse();
             break;
-        case CAPITALIZE:
+        case text_transform_enum::CAPITALIZE:
 #if !UCONFIG_NO_BREAK_ITERATION
             // note: requires BreakIterator support in ICU which is optional
             text_str.toTitle(nullptr);

--- a/src/text/placement_finder.cpp
+++ b/src/text/placement_finder.cpp
@@ -97,7 +97,7 @@ placement_finder::placement_finder(feature_impl const& feature,
     , marker_unlocked_(false)
     , marker_displacement_()
     , move_dx_(0.0)
-    , horizontal_alignment_(H_LEFT)
+    , horizontal_alignment_(horizontal_alignment_enum::H_LEFT)
 {}
 
 bool placement_finder::next_position()
@@ -135,23 +135,23 @@ bool placement_finder::next_position()
 
 text_upright_e placement_finder::simplify_upright(text_upright_e upright, double angle) const
 {
-    if (upright == UPRIGHT_AUTO)
+    if (upright == text_upright_enum::UPRIGHT_AUTO)
     {
         angle = util::normalize_angle(angle);
-        return std::abs(angle) > util::tau / 4 ? UPRIGHT_LEFT : UPRIGHT_RIGHT;
+        return std::abs(angle) > util::tau / 4 ? text_upright_enum::UPRIGHT_LEFT : text_upright_enum::UPRIGHT_RIGHT;
     }
-    if (upright == UPRIGHT_AUTO_DOWN)
+    if (upright == text_upright_enum::UPRIGHT_AUTO_DOWN)
     {
         angle = util::normalize_angle(angle);
-        return std::abs(angle) < util::tau / 4 ? UPRIGHT_LEFT : UPRIGHT_RIGHT;
+        return std::abs(angle) < util::tau / 4 ? text_upright_enum::UPRIGHT_LEFT : text_upright_enum::UPRIGHT_RIGHT;
     }
-    if (upright == UPRIGHT_LEFT_ONLY)
+    if (upright == text_upright_enum::UPRIGHT_LEFT_ONLY)
     {
-        return UPRIGHT_LEFT;
+        return text_upright_enum::UPRIGHT_LEFT;
     }
-    if (upright == UPRIGHT_RIGHT_ONLY)
+    if (upright == text_upright_enum::UPRIGHT_RIGHT_ONLY)
     {
-        return UPRIGHT_RIGHT;
+        return text_upright_enum::UPRIGHT_RIGHT;
     }
     return upright;
 }
@@ -270,12 +270,12 @@ bool placement_finder::single_line_placement(vertex_cache& pp, text_upright_e or
         text_layout const& layout = *layout_ptr;
         pixel_position align_offset = layout.alignment_offset();
         pixel_position const& layout_displacement = layout.displacement();
-        double sign = (real_orientation == UPRIGHT_LEFT) ? -1 : 1;
+        double sign = (real_orientation == text_upright_enum::UPRIGHT_LEFT) ? -1 : 1;
         // double offset = 0 - (layout_displacement.y + 0.5 * sign * layout.height());
         double offset = layout_displacement.y - 0.5 * sign * layout.height();
         double adjust_character_spacing = .0;
         double layout_width = layout.width();
-        bool adjust = layout.horizontal_alignment() == H_ADJUST;
+        bool adjust = layout.horizontal_alignment() == horizontal_alignment_enum::H_ADJUST;
 
         if (adjust)
         {
@@ -371,23 +371,30 @@ bool placement_finder::single_line_placement(vertex_cache& pp, text_upright_e or
 
     if (upside_down_glyph_count > static_cast<unsigned>(layouts_.text().length() / 2))
     {
-        if (orientation == UPRIGHT_AUTO)
+        if (orientation == text_upright_enum::UPRIGHT_AUTO)
         {
             // Try again with opposite orientation
             begin.restore();
-            return single_line_placement(pp, real_orientation == UPRIGHT_RIGHT ? UPRIGHT_LEFT : UPRIGHT_RIGHT);
+            return single_line_placement(pp,
+                                         real_orientation == text_upright_enum::UPRIGHT_RIGHT
+                                           ? text_upright_enum::UPRIGHT_LEFT
+                                           : text_upright_enum::UPRIGHT_RIGHT);
         }
         // upright==left-only or right-only and more than 50% of characters upside down => no placement
-        else if (orientation == UPRIGHT_LEFT_ONLY || orientation == UPRIGHT_RIGHT_ONLY)
+        else if (orientation == text_upright_enum::UPRIGHT_LEFT_ONLY ||
+                 orientation == text_upright_enum::UPRIGHT_RIGHT_ONLY)
         {
             return false;
         }
     }
-    else if (orientation == UPRIGHT_AUTO_DOWN)
+    else if (orientation == text_upright_enum::UPRIGHT_AUTO_DOWN)
     {
         // Try again with opposite orientation
         begin.restore();
-        return single_line_placement(pp, real_orientation == UPRIGHT_RIGHT ? UPRIGHT_LEFT : UPRIGHT_RIGHT);
+        return single_line_placement(pp,
+                                     real_orientation == text_upright_enum::UPRIGHT_RIGHT
+                                       ? text_upright_enum::UPRIGHT_LEFT
+                                       : text_upright_enum::UPRIGHT_RIGHT);
     }
 
     box2d<double> label_box;
@@ -424,7 +431,7 @@ void placement_finder::path_move_dx(vertex_cache& pp, double dx)
 double placement_finder::get_spacing(double path_length, double layout_width) const
 {
     int num_labels = 1;
-    if (horizontal_alignment_ != H_ADJUST && text_props_->label_spacing > 0)
+    if (horizontal_alignment_ != horizontal_alignment_enum::H_ADJUST && text_props_->label_spacing > 0)
     {
         num_labels =
           static_cast<int>(std::floor(path_length / (text_props_->label_spacing * scale_factor_ + layout_width)));

--- a/src/text/renderer.cpp
+++ b/src/text/renderer.cpp
@@ -32,22 +32,6 @@
 #include <mapnik/image_any.hpp>
 #include <mapnik/agg_rasterizer.hpp>
 
-#include <mapnik/warning.hpp>
-MAPNIK_DISABLE_WARNING_PUSH
-#include <mapnik/warning_ignore_agg.hpp>
-#include "agg_rendering_buffer.h"
-#include "agg_pixfmt_rgba.h"
-#include "agg_color_rgba.h"
-#include "agg_scanline_u.h"
-#include "agg_image_filters.h"
-#include "agg_trans_bilinear.h"
-#include "agg_span_allocator.h"
-#include "agg_image_accessors.h"
-#include "agg_span_image_filter_rgba.h"
-#include "agg_renderer_base.h"
-#include "agg_renderer_scanline.h"
-MAPNIK_DISABLE_WARNING_POP
-
 namespace mapnik {
 
 text_renderer::text_renderer(halo_rasterizer_e rasterizer,
@@ -225,7 +209,7 @@ void agg_text_renderer<T>::render(glyph_positions const& pos)
         if (!error)
         {
             FT_Glyph_Transform(g, &halo_matrix, &start_halo);
-            if (rasterizer_ == HALO_RASTERIZER_FULL)
+            if (rasterizer_ == halo_rasterizer_enum::HALO_RASTERIZER_FULL)
             {
                 stroker_->init(halo_radius);
                 FT_Glyph_Stroke(&g, stroker_->get(), 1);
@@ -479,7 +463,7 @@ void grid_text_renderer<T>::render_halo_id(unsigned char* buffer,
 
 template<typename T>
 grid_text_renderer<T>::grid_text_renderer(pixmap_type& pixmap, composite_mode_e comp_op, double scale_factor)
-    : text_renderer(HALO_RASTERIZER_FAST, comp_op, src_over, scale_factor)
+    : text_renderer(halo_rasterizer_enum::HALO_RASTERIZER_FAST, comp_op, src_over, scale_factor)
     , pixmap_(pixmap)
 {}
 

--- a/src/text/symbolizer_helpers.cpp
+++ b/src/text/symbolizer_helpers.cpp
@@ -277,11 +277,11 @@ void base_symbolizer_helper::initialize_points() const
 
     switch (how_placed)
     {
-        case LINE_PLACEMENT:
+        case label_placement_enum::LINE_PLACEMENT:
             point_placement_ = false;
             return;
-        case GRID_PLACEMENT:
-        case ALTERNATING_GRID_PLACEMENT:
+        case label_placement_enum::GRID_PLACEMENT:
+        case label_placement_enum::ALTERNATING_GRID_PLACEMENT:
             point_placement_ = true;
             // Points for grid placement are generated in text_symbolizer_helper
             // because base_symbolizer_helper doesn't have the vertex converter.
@@ -296,7 +296,7 @@ void base_symbolizer_helper::initialize_points() const
 
     for (auto const& geom : geometries_to_process_)
     {
-        if (how_placed == VERTEX_PLACEMENT)
+        if (how_placed == label_placement_enum::VERTEX_PLACEMENT)
         {
             using apply_vertex_placement = detail::apply_vertex_placement<std::list<pixel_position>>;
             apply_vertex_placement apply(points_, t_, prj_trans_);
@@ -317,7 +317,7 @@ void base_symbolizer_helper::initialize_points() const
                 geometry::line_string_vertex_adapter<double> va(line);
                 success = label::middle_point(va, label_x, label_y);
             }
-            else if (how_placed == POINT_PLACEMENT || type == geometry::geometry_types::Point)
+            else if (how_placed == label_placement_enum::POINT_PLACEMENT || type == geometry::geometry_types::Point)
             {
                 geometry::point<double> pt;
                 if (geometry::centroid(geom, pt))
@@ -335,7 +335,7 @@ void base_symbolizer_helper::initialize_points() const
                 using transform_group_type = geometry::strategy_group<proj_backward_strategy, view_strategy>;
                 transform_group_type transform_group(ps, vs);
                 geometry::polygon<double> tranformed_poly(geometry::transform<double>(poly, transform_group));
-                if (how_placed == INTERIOR_PLACEMENT)
+                if (how_placed == label_placement_enum::INTERIOR_PLACEMENT)
                 {
                     geometry::point<double> pt;
                     if (geometry::interior(tranformed_poly, scale_factor_, pt))
@@ -343,7 +343,7 @@ void base_symbolizer_helper::initialize_points() const
                         points_.emplace_back(pt.x, pt.y);
                     }
                 }
-                else if (how_placed == POLYLABEL_PLACEMENT)
+                else if (how_placed == label_placement_enum::POLYLABEL_PLACEMENT)
                 {
                     double precision = geometry::polylabel_precision(tranformed_poly, scale_factor_);
                     geometry::point<double> pt;
@@ -408,7 +408,8 @@ void text_symbolizer_helper::init_converters()
     if (clip)
     {
         label_placement_enum how_placed = text_props_->label_placement;
-        if (how_placed == GRID_PLACEMENT || how_placed == ALTERNATING_GRID_PLACEMENT)
+        if (how_placed == label_placement_enum::GRID_PLACEMENT ||
+            how_placed == label_placement_enum::ALTERNATING_GRID_PLACEMENT)
         {
             converter_.template set<clip_poly_tag>();
         }
@@ -618,11 +619,11 @@ void text_symbolizer_helper::initialize_points() const
 {
     label_placement_enum how_placed = text_props_->label_placement;
 
-    if (how_placed == GRID_PLACEMENT)
+    if (how_placed == label_placement_enum::GRID_PLACEMENT)
     {
         initialize_grid_points<geometry::regular_grid_vertex_converter>();
     }
-    else if (how_placed == ALTERNATING_GRID_PLACEMENT)
+    else if (how_placed == label_placement_enum::ALTERNATING_GRID_PLACEMENT)
     {
         initialize_grid_points<geometry::alternating_grid_vertex_converter>();
     }

--- a/src/text/text_layout.cpp
+++ b/src/text/text_layout.cpp
@@ -466,32 +466,32 @@ void text_layout::shape_text(text_line& line)
 
 void text_layout::init_auto_alignment()
 {
-    if (valign_ == V_AUTO)
+    if (valign_ == vertical_alignment_enum::V_AUTO)
     {
         if (displacement_.y > 0.0)
-            valign_ = V_BOTTOM;
+            valign_ = vertical_alignment_enum::V_BOTTOM;
         else if (displacement_.y < 0.0)
-            valign_ = V_TOP;
+            valign_ = vertical_alignment_enum::V_TOP;
         else
-            valign_ = V_MIDDLE;
+            valign_ = vertical_alignment_enum::V_MIDDLE;
     }
-    if (halign_ == H_AUTO)
+    if (halign_ == horizontal_alignment_enum::H_AUTO)
     {
         if (displacement_.x > 0.0)
-            halign_ = H_RIGHT;
+            halign_ = horizontal_alignment_enum::H_RIGHT;
         else if (displacement_.x < 0.0)
-            halign_ = H_LEFT;
+            halign_ = horizontal_alignment_enum::H_LEFT;
         else
-            halign_ = H_MIDDLE;
+            halign_ = horizontal_alignment_enum::H_MIDDLE;
     }
-    if (jalign_ == J_AUTO)
+    if (jalign_ == justify_alignment_enum::J_AUTO)
     {
         if (displacement_.x > 0.0)
-            jalign_ = J_LEFT;
+            jalign_ = justify_alignment_enum::J_LEFT;
         else if (displacement_.x < 0.0)
-            jalign_ = J_RIGHT;
+            jalign_ = justify_alignment_enum::J_RIGHT;
         else
-            jalign_ = J_MIDDLE;
+            jalign_ = justify_alignment_enum::J_MIDDLE;
     }
 }
 
@@ -499,20 +499,20 @@ pixel_position text_layout::alignment_offset() const
 {
     pixel_position result(0, 0);
     // if needed, adjust for desired vertical alignment
-    if (valign_ == V_TOP)
+    if (valign_ == vertical_alignment_enum::V_TOP)
     {
         result.y = -0.5 * height(); // move center up by 1/2 the total height
     }
-    else if (valign_ == V_BOTTOM)
+    else if (valign_ == vertical_alignment_enum::V_BOTTOM)
     {
         result.y = 0.5 * height(); // move center down by the 1/2 the total height
     }
     // set horizontal position to middle of text
-    if (halign_ == H_LEFT)
+    if (halign_ == horizontal_alignment_enum::H_LEFT)
     {
         result.x = -0.5 * width(); // move center left by 1/2 the string width
     }
-    else if (halign_ == H_RIGHT)
+    else if (halign_ == horizontal_alignment_enum::H_RIGHT)
     {
         result.x = 0.5 * width(); // move center right by 1/2 the string width
     }
@@ -521,11 +521,11 @@ pixel_position text_layout::alignment_offset() const
 
 double text_layout::jalign_offset(double line_width) const
 {
-    if (jalign_ == J_MIDDLE)
+    if (jalign_ == justify_alignment_enum::J_MIDDLE)
         return -(line_width / 2.0);
-    if (jalign_ == J_LEFT)
+    if (jalign_ == justify_alignment_enum::J_LEFT)
         return -(width() / 2.0);
-    if (jalign_ == J_RIGHT)
+    if (jalign_ == justify_alignment_enum::J_RIGHT)
         return (width() / 2.0) - line_width;
     return 0;
 }

--- a/src/text/text_properties.cpp
+++ b/src/text/text_properties.cpp
@@ -252,9 +252,9 @@ void text_symbolizer_properties::add_expressions(expression_set& output) const
 }
 
 text_layout_properties::text_layout_properties()
-    : halign(enumeration_wrapper(H_AUTO))
-    , jalign(enumeration_wrapper(J_AUTO))
-    , valign(enumeration_wrapper(V_AUTO))
+    : halign(enumeration_wrapper(static_cast<int>(horizontal_alignment_enum::H_AUTO)))
+    , jalign(enumeration_wrapper(static_cast<int>(justify_alignment_enum::J_AUTO)))
+    , valign(enumeration_wrapper(static_cast<int>(vertical_alignment_enum::V_AUTO)))
 {}
 
 void text_layout_properties::from_xml(xml_node const& node, fontset_map const& fontsets)
@@ -343,7 +343,7 @@ format_properties::format_properties()
     , fill(color(0, 0, 0))
     , halo_fill(color(255, 255, 255))
     , halo_radius(0.0)
-    , text_transform(enumeration_wrapper(NONE))
+    , text_transform(enumeration_wrapper(static_cast<int>(text_transform_enum::NONE)))
     , ff_settings()
 {}
 

--- a/src/well_known_srs.cpp
+++ b/src/well_known_srs.cpp
@@ -35,10 +35,11 @@ MAPNIK_DISABLE_WARNING_POP
 #include <cmath>
 
 namespace mapnik {
+constexpr const char MAPNIK_GEOGRAPHIC_PROJ_STR[10]{"epsg:4326"};
+extern std::string const MAPNIK_GEOGRAPHIC_PROJ = MAPNIK_GEOGRAPHIC_PROJ_STR; // wgs84
 
-extern std::string const MAPNIK_GEOGRAPHIC_PROJ = "epsg:4326"; // wgs84
-
-extern std::string const MAPNIK_WEBMERCATOR_PROJ = "epsg:3857"; // webmercator
+constexpr const char MAPNIK_WEBMERCATOR_PROJ_STR[10]{"epsg:3857"};
+extern std::string const MAPNIK_WEBMERCATOR_PROJ = MAPNIK_WEBMERCATOR_PROJ_STR; // webmercator
 
 static const char* well_known_srs_strings[] = {MAPNIK_GEOGRAPHIC_PROJ.c_str(), MAPNIK_WEBMERCATOR_PROJ.c_str(), ""};
 
@@ -46,11 +47,11 @@ boost::optional<well_known_srs_e> is_well_known_srs(std::string const& srs)
 {
     if (srs == MAPNIK_GEOGRAPHIC_PROJ)
     {
-        return boost::optional<well_known_srs_e>(mapnik::WGS_84);
+        return boost::optional<well_known_srs_e>(mapnik::well_known_srs_enum::WGS_84);
     }
     else if (srs == MAPNIK_WEBMERCATOR_PROJ)
     {
-        return boost::optional<well_known_srs_e>(mapnik::WEB_MERC);
+        return boost::optional<well_known_srs_e>(mapnik::well_known_srs_enum::WEB_MERC);
     }
     return boost::optional<well_known_srs_e>();
 }
@@ -69,7 +70,13 @@ boost::optional<bool> is_known_geographic(std::string const& srs)
     return boost::optional<bool>();
 }
 
-IMPLEMENT_ENUM(well_known_srs_e, well_known_srs_strings)
+using well_known_srs_e_str = mapnik::detail::EnumStringT<well_known_srs_enum>;
+constexpr detail::EnumMapT<well_known_srs_enum, 3> well_known_srs_e_map{{
+  well_known_srs_e_str{well_known_srs_enum::WGS_84, detail::mapnik_string_view{MAPNIK_GEOGRAPHIC_PROJ_STR}},
+  well_known_srs_e_str{well_known_srs_enum::WEB_MERC, MAPNIK_WEBMERCATOR_PROJ_STR},
+  well_known_srs_e_str{well_known_srs_enum::well_known_srs_enum_MAX, ""},
+}};
+IMPLEMENT_ENUM(well_known_srs_e, well_known_srs_enum)
 
 bool lonlat2merc(double& x, double& y)
 {

--- a/src/xml_tree.cpp
+++ b/src/xml_tree.cpp
@@ -42,6 +42,7 @@
 namespace mapnik {
 
 class boolean_type;
+
 template<typename T>
 struct name_trait
 {
@@ -74,22 +75,26 @@ DEFINE_NAME_TRAIT(color, "color")
 DEFINE_NAME_TRAIT(expression_ptr, "expression_ptr")
 DEFINE_NAME_TRAIT(font_feature_settings, "font-feature-settings")
 
-template<typename ENUM, int MAX>
-struct name_trait<mapnik::enumeration<ENUM, MAX>>
+template<typename ENUM,
+         char const* (*F_TO_STRING)(ENUM),
+         ENUM (*F_FROM_STRING)(const char*),
+         std::map<ENUM, std::string> (*F_LOOKUP)()>
+struct name_trait<mapnik::enumeration<ENUM, F_TO_STRING, F_FROM_STRING, F_LOOKUP>>
 {
-    using Enum = enumeration<ENUM, MAX>;
-
+    using Enum = mapnik::enumeration<ENUM, F_TO_STRING, F_FROM_STRING, F_LOOKUP>;
     static std::string name()
     {
         std::string value_list("one of [");
-        for (unsigned i = 0; i < Enum::MAX; ++i)
+        const auto lookup{Enum::lookupMap()};
+        for (auto it = lookup.cbegin(); it != lookup.cend(); it++)
         {
-            value_list += Enum::get_string(i);
-            if (i + 1 < Enum::MAX)
+            value_list += it->second;
+            if (std::next(it) != lookup.cend())
+            {
                 value_list += ", ";
+            }
         }
-        value_list += "]";
-
+        value_list += ']';
         return value_list;
     }
 };

--- a/test/unit/numerics/enumeration.cpp
+++ b/test/unit/numerics/enumeration.cpp
@@ -6,7 +6,7 @@
 
 TEST_CASE("enumeration")
 {
-    mapnik::line_cap_e e(mapnik::ROUND_CAP);
+    mapnik::line_cap_e e(mapnik::line_cap_enum::ROUND_CAP);
     CHECK(e.as_string() == "round");
     // note: test the << operator, which calls `as_string` internally
     // is not used in mapnik, but kept for back compat

--- a/test/unit/symbolizer/marker_placement_vertex_last.cpp
+++ b/test/unit/symbolizer/marker_placement_vertex_last.cpp
@@ -27,7 +27,7 @@ TEST_CASE("marker placement vertex last")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -54,7 +54,7 @@ TEST_CASE("marker placement vertex last")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -89,7 +89,7 @@ TEST_CASE("marker placement vertex last")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -128,7 +128,7 @@ TEST_CASE("marker placement vertex last")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);

--- a/test/unit/symbolizer/markers_point_placement.cpp
+++ b/test/unit/symbolizer/markers_point_placement.cpp
@@ -27,7 +27,7 @@ TEST_CASE("marker placement point")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -54,7 +54,7 @@ TEST_CASE("marker placement point")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -89,7 +89,7 @@ TEST_CASE("marker placement point")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);
@@ -124,7 +124,7 @@ TEST_CASE("marker placement point")
                                                 0,
                                                 false,
                                                 false,
-                                                DIRECTION_AUTO,
+                                                direction_enum::DIRECTION_AUTO,
                                                 1.0};
 
         placement_type placement(va, detector, params);

--- a/test/unit/symbolizer/symbolizer_test.cpp
+++ b/test/unit/symbolizer/symbolizer_test.cpp
@@ -12,13 +12,13 @@ TEST_CASE("symbolizer")
     {
         try
         {
-            marker_multi_policy_enum policy_in = MARKER_WHOLE_MULTI;
-            REQUIRE(policy_in == MARKER_WHOLE_MULTI);
+            marker_multi_policy_enum policy_in = marker_multi_policy_enum::MARKER_WHOLE_MULTI;
+            REQUIRE(policy_in == marker_multi_policy_enum::MARKER_WHOLE_MULTI);
             markers_symbolizer sym;
             put(sym, keys::markers_multipolicy, policy_in);
             REQUIRE(sym.properties.count(keys::markers_multipolicy) == static_cast<unsigned long>(1));
             marker_multi_policy_enum policy_out = get<mapnik::marker_multi_policy_enum>(sym, keys::markers_multipolicy);
-            REQUIRE(policy_out == MARKER_WHOLE_MULTI);
+            REQUIRE(policy_out == marker_multi_policy_enum::MARKER_WHOLE_MULTI);
         }
         catch (std::exception const& ex)
         {


### PR DESCRIPTION
I've stumbeled across the enumeration class and I think we could do a little better.  For a quick proposal I've just used the `filter_mode_enum` enum. 
First by fixing the limitations: 

 *    - The enum must start at zero.
 *    - The enum must be consecutive.
 *    - The enum must be terminated with a special token consisting of the enum's
 *      name plus "_MAX".
 *    - The corresponding char pointer array must be terminated with an empty string.

I belive the last point is mainly because of tokenization?
 *    - The names must only consist of characters and digits (<i>a-z, A-Z, 0-9</i>), underscores (<i>_</i>) and dashes (<i>-</i>).

Further: 

* The enums itself can now be enum classes. 
* use more constexpr functions. `mapnik_string_view` should extracted either into `mapnik_string_view.hpp` And it either includes the simple string_view or when c++17 `std::string_view`

@artemp Do you see any problems or do you have more suggestions?
