### PR TITLE
Include cstdint for uint16_t

### DIFF
--- a/include/mapnik/wkb.hpp
+++ b/include/mapnik/wkb.hpp
@@ -28,6 +28,9 @@
 #include <mapnik/geometry.hpp>
 #include <mapnik/util/noncopyable.hpp>
 
+// stl
+#include <cstdint>
+
 namespace mapnik {
 
 /*!


### PR DESCRIPTION
Discovered during Fedora mass rebuild with upcoming gcc 13 - older compilers must have been including it as a side effec of another header.