### PR TITLE
Add `fonts_dir` & `plugins_dir` variables to `libmapnik.pc`

### DIFF
--- a/cmake/MapnikExportPkgConfig.cmake
+++ b/cmake/MapnikExportPkgConfig.cmake
@@ -65,6 +65,8 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
 libdir=${exec_prefix}/lib
+fonts_dir=${prefix}/@FONTS_INSTALL_DIR@
+plugins_dir=${prefix}/@PLUGINS_INSTALL_DIR@
 
 Name: @_lib_name@
 Description: @_description@


### PR DESCRIPTION
In order to provide some of the functionality previously provided by `mapnik-config`

* `mapnik-config --fonts` => `pkg-config libmapnik --variable=fonts_dir`
* `mapnik-config --input-plugins` => `pkg-config libmapnik --variable=plugins_dir`