### PR TITLE
Fixed check for `__cpp_lib_filesystem` in `filesystem.hpp`

### DIFF
--- a/include/mapnik/filesystem.hpp
+++ b/include/mapnik/filesystem.hpp
@@ -23,6 +23,8 @@
 #ifndef MAPNIK_FILESYSTEM_HPP
 #define MAPNIK_FILESYSTEM_HPP
 
+#include <version>
+
 #if defined(__cpp_lib_filesystem) && !defined(USE_BOOST_FILESYSTEM)
 #include <filesystem>
 #else

--- a/include/mapnik/filesystem.hpp
+++ b/include/mapnik/filesystem.hpp
@@ -23,9 +23,7 @@
 #ifndef MAPNIK_FILESYSTEM_HPP
 #define MAPNIK_FILESYSTEM_HPP
 
-#include <version>
-
-#if defined(__cpp_lib_filesystem) && !defined(USE_BOOST_FILESYSTEM)
+#if (__cplusplus >= 201703L) && !defined(USE_BOOST_FILESYSTEM)
 #include <filesystem>
 #else
 #include <boost/filesystem/operations.hpp> // for absolute, exists, etc


### PR DESCRIPTION
`__cpp_lib_filesystem` is only defined within `filesystem` & `version`, therefore `#if defined(__cpp_lib_filesystem)` is always `false` which causes all subsequent `std::filesystem` function calls to fail.

I.E.:
```
mapnik/src/fs.cpp:40:16: error: ‘exists’ is not a member of ‘mapnik::fs’
   40 |     return fs::exists(filepath);
      |                ^~~~~~
```
```shell
$ find /usr/include/c++/12.2.1 | xargs grep -sn '__cpp_lib_filesystem'
/usr/include/c++/12.2.1/filesystem:49:#define __cpp_lib_filesystem 201703L
/usr/include/c++/12.2.1/version:145:#define __cpp_lib_filesystem 201703L
```