### PR TITLE
add cstdint header for gcc13 compilation.

### DIFF
--- a/include/mapnik/util/geometry_to_wkt.hpp
+++ b/include/mapnik/util/geometry_to_wkt.hpp
@@ -27,6 +27,7 @@
 #include <mapnik/geometry.hpp>
 // stl
 #include <string>
+#include <cstdint>
 
 namespace mapnik {
 namespace util {


### PR DESCRIPTION
i was trying to compile project with gcc13 and i got the error `int64_t is not part of the std name space` I added needed header file.