### PR TITLE
Add cstdint header include to `include/mapnik/geometry/boost_spirit_karma_adapter.hpp`

### DIFF
--- a/include/mapnik/geometry/boost_spirit_karma_adapter.hpp
+++ b/include/mapnik/geometry/boost_spirit_karma_adapter.hpp
@@ -23,7 +23,11 @@
 #ifndef MAPNIK_BOOST_SPIRIT_KARMA_ADAPTER_HPP
 #define MAPNIK_BOOST_SPIRIT_KARMA_ADAPTER_HPP
 
+// mapnik
 #include <mapnik/geometry.hpp>
+
+// stl
+#include <cstdint>
 
 namespace boost {
 using mapbox::util::get;


### PR DESCRIPTION
Needed for compilation with GCC 13 as it is no longer being included implicitly:

https://gcc.gnu.org/gcc-13/porting_to.html

I.E.:
```
mapnik/include/mapnik/geometry/boost_spirit_karma_adapter.hpp:53:54: error: ‘int64_t’ is not a member of ‘std’
   53 | struct variant_which<mapnik::geometry::geometry<std::int64_t>>
```

Relates to #4389