### PR TITLE
v3.1.x: Add support for building with Boost 1.83

### DIFF
--- a/include/mapnik/geometry/boost_spirit_karma_adapter.hpp
+++ b/include/mapnik/geometry/boost_spirit_karma_adapter.hpp
@@ -25,6 +25,7 @@
 #define MAPNIK_BOOST_SPIRIT_KARMA_ADAPTER_HPP
 
 #include <mapnik/geometry.hpp>
+#include <cstdint>
 
 namespace boost { using mapbox::util::get; }
 

--- a/include/mapnik/geometry_fusion_adapted.hpp
+++ b/include/mapnik/geometry_fusion_adapted.hpp
@@ -26,6 +26,7 @@
 
 #include <mapnik/geometry.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
+#include <cstdint>
 
 BOOST_FUSION_ADAPT_STRUCT(
     mapnik::geometry::point<double>,

--- a/include/mapnik/json/generic_json.hpp
+++ b/include/mapnik/json/generic_json.hpp
@@ -32,6 +32,7 @@
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/fusion/include/std_pair.hpp>
+#include <boost/regex/pending/unicode_iterator.hpp>
 #pragma GCC diagnostic pop
 
 #include <vector>

--- a/plugins/input/csv/csv_utils.cpp
+++ b/plugins/input/csv/csv_utils.cpp
@@ -32,6 +32,7 @@
 // csv grammar
 #include <mapnik/csv/csv_grammar_impl.hpp>
 //
+#include <boost/algorithm/string/trim.hpp>
 #include "csv_getline.hpp"
 #include "csv_utils.hpp"
 


### PR DESCRIPTION
Mapnik `v3.1.0` fails to build with Boost 1.83, this fixes that issue.

Sourced from: https://gitlab.archlinux.org/archlinux/packaging/packages/mapnik/-/blob/f9f723222c0af50e4db747e7c4e8138dbc769f53/boost-1.83.patch