### PR TITLE
v3.1.x: Backporting more patches to fix builds with modern Boost & GCC

### DIFF
--- a/include/mapnik/wkb.hpp
+++ b/include/mapnik/wkb.hpp
@@ -28,6 +28,9 @@
 #include <mapnik/geometry.hpp>
 #include <mapnik/util/noncopyable.hpp>
 
+// stl
+#include <cstdint>
+
 namespace mapnik
 {
 

--- a/test/unit/serialization/wkb_test.cpp
+++ b/test/unit/serialization/wkb_test.cpp
@@ -57,6 +57,23 @@ struct spatially_equal_visitor
         return true;
     }
 
+    result_type operator()(mapnik::geometry::multi_line_string<double> const& lhs,
+                           mapnik::geometry::multi_line_string<double> const& rhs) const
+    {
+
+        std::size_t size0 = lhs.size();
+        std::size_t size1 = rhs.size();
+        if (size0 != size1)
+            return false;
+
+        for (std::size_t index = 0; index < size0; ++index)
+        {
+            if (!boost::geometry::equals(lhs[index], rhs[index]))
+                return false;
+        }
+        return true;
+    }
+
     template <typename T>
     result_type operator() (T const& lhs, T const& rhs) const
     {


### PR DESCRIPTION
- `Include cstdint for uint16_t`
  - c62e03344fe3af8d061f3ff881ab3cb7bfa0e1e9
- `Fix building with boost_1_80`
  - 81103491b467e17218140f50bc0bb9dc8c1f0317