### PR TITLE
Drop support for old versions of GDAL/OGR (older than 2.0)

### DIFF
--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -24,8 +24,6 @@
 #include "ogr_featureset.hpp"
 #include "ogr_index_featureset.hpp"
 
-#include <gdal_version.h>
-
 // mapnik
 #include <mapnik/debug.hpp>
 #include <mapnik/boolean.hpp>
@@ -93,11 +91,7 @@ ogr_datasource::~ogr_datasource()
 {
     // free layer before destroying the datasource
     layer_.free_layer();
-#if GDAL_VERSION_MAJOR >= 2
     GDALClose((GDALDatasetH)dataset_);
-#else
-    OGRDataSource::DestroyDataSource(dataset_);
-#endif
 }
 
 void ogr_datasource::init(mapnik::parameters const& params)
@@ -136,27 +130,15 @@ void ogr_datasource::init(mapnik::parameters const& params)
 
     if (!driver.empty())
     {
-#if GDAL_VERSION_MAJOR >= 2
         unsigned int nOpenFlags = GDAL_OF_READONLY | GDAL_OF_VECTOR;
         const char* papszAllowedDrivers[] = {driver.c_str(), nullptr};
         dataset_ = reinterpret_cast<gdal_dataset_type>(
           GDALOpenEx(dataset_name_.c_str(), nOpenFlags, papszAllowedDrivers, nullptr, nullptr));
-#else
-        OGRSFDriver* ogr_driver = OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName(driver.c_str());
-        if (ogr_driver && ogr_driver != nullptr)
-        {
-            dataset_ = ogr_driver->Open((dataset_name_).c_str(), false);
-        }
-#endif
     }
     else
     {
         // open ogr driver
-#if GDAL_VERSION_MAJOR >= 2
         dataset_ = reinterpret_cast<gdal_dataset_type>(OGROpen(dataset_name_.c_str(), false, nullptr));
-#else
-        dataset_ = OGRSFDriverRegistrar::Open(dataset_name_.c_str(), false);
-#endif
     }
 
     if (!dataset_)
@@ -353,9 +335,7 @@ void ogr_datasource::init(mapnik::parameters const& params)
             switch (type_oid)
             {
                 case OFTInteger:
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64:
-#endif
                     desc_.add_descriptor(attribute_descriptor(fld_name, mapnik::Integer));
                     break;
 
@@ -373,9 +353,7 @@ void ogr_datasource::init(mapnik::parameters const& params)
                     break;
 
                 case OFTIntegerList:
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64List:
-#endif
                 case OFTRealList:
                 case OFTStringList:
                 case OFTWideStringList: // deprecated !

--- a/plugins/input/ogr/ogr_featureset.cpp
+++ b/plugins/input/ogr/ogr_featureset.cpp
@@ -122,12 +122,10 @@ feature_ptr ogr_featureset::next()
                     feature->put<mapnik::value_integer>(fld_name, poFeature->GetFieldAsInteger(i));
                     break;
                 }
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64: {
                     feature->put<mapnik::value_integer>(fld_name, poFeature->GetFieldAsInteger64(i));
                     break;
                 }
-#endif
 
                 case OFTReal: {
                     feature->put(fld_name, poFeature->GetFieldAsDouble(i));
@@ -142,9 +140,7 @@ feature_ptr ogr_featureset::next()
                 }
 
                 case OFTIntegerList:
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64List:
-#endif
                 case OFTRealList:
                 case OFTStringList:
                 case OFTWideStringList: // deprecated !

--- a/plugins/input/ogr/ogr_index_featureset.cpp
+++ b/plugins/input/ogr/ogr_index_featureset.cpp
@@ -48,8 +48,6 @@ MAPNIK_DISABLE_WARNING_POP
 #include "ogr_converter.hpp"
 #include "ogr_index.hpp"
 
-#include <gdal_version.h>
-
 using mapnik::box2d;
 using mapnik::feature_factory;
 using mapnik::feature_ptr;
@@ -153,12 +151,10 @@ feature_ptr ogr_index_featureset<filterT>::next()
                     feature->put<mapnik::value_integer>(fld_name, poFeature->GetFieldAsInteger(i));
                     break;
                 }
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64: {
                     feature->put<mapnik::value_integer>(fld_name, poFeature->GetFieldAsInteger64(i));
                     break;
                 }
-#endif
 
                 case OFTReal: {
                     feature->put(fld_name, poFeature->GetFieldAsDouble(i));
@@ -173,9 +169,7 @@ feature_ptr ogr_index_featureset<filterT>::next()
                 }
 
                 case OFTIntegerList:
-#if GDAL_VERSION_MAJOR >= 2
                 case OFTInteger64List:
-#endif
                 case OFTRealList:
                 case OFTStringList:
                 case OFTWideStringList: // deprecated !

--- a/plugins/input/ogr/ogr_layer_ptr.hpp
+++ b/plugins/input/ogr/ogr_layer_ptr.hpp
@@ -30,14 +30,9 @@
 #include <stdexcept>
 
 // gdal
-#include <gdal_version.h>
 #include <ogrsf_frmts.h>
 
-#if GDAL_VERSION_MAJOR >= 2
 using gdal_dataset_type = GDALDataset*;
-#else
-using gdal_dataset_type = OGRDataSource*;
-#endif
 
 class ogr_layer_ptr
 {


### PR DESCRIPTION
Fixes #4403.

GDAL 2.0.0 was released in March 2018 (more than five years ago). Almost all Linux distributions (apart from few long-term support versions) should come with at least GDAL >= 2.0.