### PR TITLE
Add support for open_options in OGR input plugin

### DIFF
--- a/plugins/input/ogr/build.py
+++ b/plugins/input/ogr/build.py
@@ -31,6 +31,7 @@ plugin_sources = Split(
   """
   %(PLUGIN_NAME)s_converter.cpp
   %(PLUGIN_NAME)s_datasource.cpp
+  %(PLUGIN_NAME)s_utils.cpp
   %(PLUGIN_NAME)s_featureset.cpp
   %(PLUGIN_NAME)s_index_featureset.cpp
   """ % locals()

--- a/plugins/input/ogr/ogr_datasource.hpp
+++ b/plugins/input/ogr/ogr_datasource.hpp
@@ -47,6 +47,7 @@ MAPNIK_DISABLE_WARNING_PUSH
 #include <ogrsf_frmts.h>
 MAPNIK_DISABLE_WARNING_POP
 #include "ogr_layer_ptr.hpp"
+#include "ogr_utils.hpp"
 
 DATASOURCE_PLUGIN_DEF(ogr_datasource_plugin, ogr);
 

--- a/plugins/input/ogr/ogr_utils.cpp
+++ b/plugins/input/ogr/ogr_utils.cpp
@@ -1,0 +1,85 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2023 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#include "ogr_utils.hpp"
+#include <mapnik/datasource.hpp>
+
+std::vector<ogr_utils::option_ptr> ogr_utils::split_open_options(const std::string& options)
+{
+    size_t i;
+    bool escaped = false; // if previous character was a backslash to escape a backslash or space
+    std::vector<ogr_utils::option_ptr> opts;
+    std::string unescaped_str; // copy of input string but unescaped
+    for (i = 0; i < options.size(); ++i)
+    {
+        char current = options.at(i);
+        if (current == '\\')
+        {
+            if (escaped)
+            {
+                unescaped_str.push_back(current);
+            }
+            escaped = !escaped;
+        }
+        else if (current != ' ') {
+            unescaped_str.push_back(current);
+        }
+        if (current == ' ' || i + 1 == options.size())
+        {
+            if (!escaped) {
+                size_t count = unescaped_str.size();
+                if (count > 0)
+                {
+                    option_ptr opt (new char[count + 1], [](char* arr) { delete[] arr; });
+                    unescaped_str.copy(opt.get(), count);
+                    opt[count] = '\0';
+                    opts.push_back(std::move(opt));
+                }
+                unescaped_str = "";
+            }
+            else
+            {
+                escaped = false;
+                unescaped_str.push_back(current);
+            }
+        }
+    }
+    if (escaped)
+    {
+        throw mapnik::datasource_exception("<open_options> parameter ends with single backslash");
+    }
+    opts.emplace_back(nullptr);
+    return opts;
+}
+
+
+char** ogr_utils::open_options_for_ogr(std::vector<ogr_utils::option_ptr>& options)
+{
+    char** for_ogr = new char*[options.size() + 1];
+    for (size_t i = 0; i < options.size(); ++i)
+    {
+        for_ogr[i] = options.at(i).get();
+    }
+    for_ogr[options.size()] = nullptr;
+    return for_ogr;
+}
+

--- a/plugins/input/ogr/ogr_utils.hpp
+++ b/plugins/input/ogr/ogr_utils.hpp
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2023 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+#ifndef PLUGINS_INPUT_OGR_OGR_UTILS_HPP_
+#define PLUGINS_INPUT_OGR_OGR_UTILS_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ogr_utils {
+
+using option_ptr = std::unique_ptr<char[], std::function<void(char*)>>;
+
+std::vector<option_ptr> split_open_options(const std::string& options);
+
+char** open_options_for_ogr(std::vector<ogr_utils::option_ptr>& options);
+
+}  // namespace ogr_utils
+
+
+
+#endif /* PLUGINS_INPUT_OGR_OGR_UTILS_HPP_ */

--- a/test/build.py
+++ b/test/build.py
@@ -35,6 +35,7 @@ else:
     # unit tests
     sources = glob.glob('./unit/*/*.cpp')
     sources.extend(glob.glob('./unit/*.cpp'))
+    sources.append('../plugins/input/ogr/ogr_utils.cpp')
     test_program = test_env_local.Program("./unit/run", source=sources)
     Depends(test_program, env.subst('../src/%s' % env['MAPNIK_LIB_NAME']))
     Depends(test_program, env.subst('../src/json/libmapnik-json${LIBSUFFIX}'))


### PR DESCRIPTION
Various OGR drivers require so-called *open options*. In my use case, I want to access vector tiles (MVT format) stored in a MBTiles file. OGR [requires](https://gdal.org/drivers/raster/mbtiles.html#opening-options) the open option `ZOOM_LEVEL=<NUMBER>` to indicate which zoom level should be used.

At Geofabrik, we currently use plain files as tile storage (z/x/y.pbf on disk) and the OGR input plugin for our vector to raster tool chain. By replacing it with a MBTiles file all the file system overhead can be saved and tile rendering is as fast as with files on the disk.

This pull request does implement the new option for the OGR input plugin and OGR/GDAL version 2 and newer. I did not implement it for old versions of GDAL. See #4403 for the reasons. I suggest to merge #4419 first. I will rebase afterwards.