### PR TITLE
Fix CMake build issues after OGR open_options support addition

### DIFF
--- a/plugins/input/ogr/CMakeLists.txt
+++ b/plugins/input/ogr/CMakeLists.txt
@@ -4,6 +4,7 @@ add_plugin_target(input-ogr "ogr")
 target_sources(input-ogr ${_plugin_visibility}
     ogr_converter.cpp
     ogr_datasource.cpp
+    ogr_utils.cpp
     ogr_featureset.cpp
     ogr_index_featureset.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(mapnik-test-unit
     unit/datasource/geobuf.cpp
     unit/datasource/geojson.cpp
     unit/datasource/memory.cpp
+    ../plugins/input/ogr/ogr_utils.cpp
     unit/datasource/ogr.cpp
     unit/datasource/postgis.cpp
     unit/datasource/shapeindex.cpp


### PR DESCRIPTION
`mapnik` currently has issues building with `CMake` after merging #4420, this resolves those issues.

- The newly added file `plugins/input/ogr/ogr_utils.cpp` was missing from two `CMakeLists.txt` files

Before: https://github.com/mapnik/mapnik/actions/runs/6941668588/job/18883003006#step:9:2862
After: https://github.com/mapnik/mapnik/actions/runs/6934483283/job/18862689256#step:9:2864