### PR TITLE
Fix GitHub Actions `Build and Test` CI workflow failing `Windows` jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: setup vcpkg
         uses: ./.github/actions/setup_vcpkg
         with:
-          vcpkg-sha: a960fde0b60b6392d70375fe513dfa7eb083cc3a
+          vcpkg-sha: 2023.11.20
           nuget-source: https://nuget.pkg.github.com/mapnik/index.json
           nuget-username: ${{ github.actor }}
           nuget-pat: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By updating the `vcpkg` commit ref in the `Build and Test` CI configuration. It seems that some of the dependency build artifacts no longer exist.

**I.E.:**
- [Before](https://github.com/mapnik/mapnik/actions/runs/7016337651/job/19087364805)
- [After](https://github.com/mapnik/mapnik/actions/runs/7035152357/job/19144891731)