### PR TITLE
Fix broken builds with libxml2 >= v2.12.0

### DIFF
--- a/src/libxml2_loader.cpp
+++ b/src/libxml2_loader.cpp
@@ -88,7 +88,7 @@ class libxml2_loader : util::noncopyable
 
         if (!doc)
         {
-            xmlError* error = xmlCtxtGetLastError(ctx_);
+            const xmlError* error = xmlCtxtGetLastError(ctx_);
             if (error)
             {
                 std::string msg("XML document not well formed:\n");
@@ -128,7 +128,7 @@ class libxml2_loader : util::noncopyable
         if (!doc)
         {
             std::string msg("XML document not well formed");
-            xmlError* error = xmlCtxtGetLastError(ctx_);
+            const xmlError* error = xmlCtxtGetLastError(ctx_);
             if (error)
             {
                 msg += ":\n";


### PR DESCRIPTION
**I.E.: (https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0#improvements)**
```
src/libxml2_loader.cpp:91:50: error: invalid conversion from ‘const xmlError*’ {aka ‘const _xmlError*’} to ‘xmlError*’ {aka ‘_xmlError*’} [-fpermissive]
src/libxml2_loader.cpp:131:50: error: invalid conversion from ‘const xmlError*’ {aka ‘const _xmlError*’} to ‘xmlError*’ {aka ‘_xmlError*’} [-fpermissive]
```
