### PR TITLE
Fix configure script for variables read from mapnik-settings.env

### DIFF
--- a/configure
+++ b/configure
@@ -15,4 +15,6 @@ if [ -f mapnik-settings.env ]; then
     . ./mapnik-settings.env
 fi
 
-$PYTHON scons/scons.py --implicit-deps-changed configure "$@"
+VARS=( $(cat mapnik-settings.env) )
+
+$PYTHON scons/scons.py --implicit-deps-changed configure ${VARS[*]} "$@"


### PR DESCRIPTION
Custom build variables (e.g. CXX_STD or CXX) read from mapnik-settings.env have to be provided as command line arguments because SCons does not respect the environment variables.

I tried to build Mapnik with `CXX_STD=17` and added this to my `mapnik-settings.env` however, SCons called the compiler with `--std=c++14`.