### PR TITLE
Geojson empty geometries

### DIFF
--- a/include/mapnik/geometry/is_empty.hpp
+++ b/include/mapnik/geometry/is_empty.hpp
@@ -39,18 +39,36 @@ struct geometry_is_empty
 
     bool operator()(mapnik::geometry::point<double> const&) const { return false; }
 
-    bool operator()(mapnik::geometry::line_string<double> const& geom) const { return geom.empty(); }
+    bool operator()(mapnik::geometry::line_string<double> const& line) const { return line.empty(); }
 
-    bool operator()(mapnik::geometry::polygon<double> const& geom) const
+    bool operator()(mapnik::geometry::polygon<double> const& poly) const
     {
-        return geom.empty() || geom.front().empty();
+        for (auto const& ring : poly)
+        {
+            if (!ring.empty()) return false;
+        }
+        return true;
     }
 
     bool operator()(mapnik::geometry::multi_point<double> const& geom) const { return geom.empty(); }
 
-    bool operator()(mapnik::geometry::multi_line_string<double> const& geom) const { return geom.empty(); }
+    bool operator()(mapnik::geometry::multi_line_string<double> const& mline) const
+    {
+        for (auto const& line : mline)
+        {
+            if (!line.empty()) return false;
+        }
+        return true;
+    }
 
-    bool operator()(mapnik::geometry::multi_polygon<double> const& geom) const { return geom.empty(); }
+    bool operator()(mapnik::geometry::multi_polygon<double> const& mpoly) const
+    {
+        for (auto const& poly : mpoly)
+        {
+            if (!operator()(poly)) return false;
+        }
+        return true;
+    }
 
     bool operator()(mapnik::geometry::geometry_collection<double> const& geom) const { return geom.empty(); }
 

--- a/include/mapnik/geometry/is_empty.hpp
+++ b/include/mapnik/geometry/is_empty.hpp
@@ -45,7 +45,8 @@ struct geometry_is_empty
     {
         for (auto const& ring : poly)
         {
-            if (!ring.empty()) return false;
+            if (!ring.empty())
+                return false;
         }
         return true;
     }
@@ -56,7 +57,8 @@ struct geometry_is_empty
     {
         for (auto const& line : mline)
         {
-            if (!line.empty()) return false;
+            if (!line.empty())
+                return false;
         }
         return true;
     }
@@ -65,7 +67,8 @@ struct geometry_is_empty
     {
         for (auto const& poly : mpoly)
         {
-            if (!operator()(poly)) return false;
+            if (!operator()(poly))
+                return false;
         }
         return true;
     }

--- a/include/mapnik/json/create_geometry.hpp
+++ b/include/mapnik/json/create_geometry.hpp
@@ -64,10 +64,11 @@ struct create_linestring
     {
         mapnik::geometry::line_string<double> line;
         std::size_t size = points.size();
-        //if (size < 2)
+        // if (size < 2)
         //{
-        //    throw std::runtime_error("RFC 7946: For type \"LineString\", the \"coordinates\" member is an array of two or more positions.");
-        //}
+        //     throw std::runtime_error("RFC 7946: For type \"LineString\", the \"coordinates\" member is an array of
+        //     two or more positions.");
+        // }
         line.reserve(size);
         for (auto&& pt : points)
         {
@@ -114,7 +115,7 @@ struct create_polygon
 
     void operator()(ring const& points) const
     {
-        //POLYGON EMPTY
+        // POLYGON EMPTY
         geom_ = std::move(mapnik::geometry::polygon<double>{});
     }
 
@@ -182,7 +183,7 @@ struct create_multilinestring
 
     void operator()(ring const& points) const
     {
-        //MULTILINESTRING EMPTY
+        // MULTILINESTRING EMPTY
         geom_ = std::move(mapnik::geometry::multi_line_string<double>{});
     }
 
@@ -231,7 +232,7 @@ struct create_multipolygon
 
     void operator()(rings const& rngs) const
     {
-        //MULTIPOLYGON
+        // MULTIPOLYGON
         mapnik::geometry::multi_polygon<double> multi_poly;
         mapnik::geometry::polygon<double> poly;
         std::size_t num_rings = rngs.size();
@@ -245,7 +246,7 @@ struct create_multipolygon
 
     void operator()(ring const& points) const
     {
-        //MULTIPOLYGON EMPTY
+        // MULTIPOLYGON EMPTY
         geom_ = std::move(mapnik::geometry::multi_polygon<double>{});
     }
 

--- a/include/mapnik/json/create_geometry.hpp
+++ b/include/mapnik/json/create_geometry.hpp
@@ -64,6 +64,10 @@ struct create_linestring
     {
         mapnik::geometry::line_string<double> line;
         std::size_t size = points.size();
+        //if (size < 2)
+        //{
+        //    throw std::runtime_error("RFC 7946: For type \"LineString\", the \"coordinates\" member is an array of two or more positions.");
+        //}
         line.reserve(size);
         for (auto&& pt : points)
         {
@@ -106,6 +110,12 @@ struct create_polygon
         }
         geom_ = std::move(poly);
         mapnik::geometry::correct(geom_);
+    }
+
+    void operator()(ring const& points) const
+    {
+        //POLYGON EMPTY
+        geom_ = std::move(mapnik::geometry::polygon<double>{});
     }
 
     template<typename T>
@@ -170,6 +180,12 @@ struct create_multilinestring
         geom_ = std::move(multi_line);
     }
 
+    void operator()(ring const& points) const
+    {
+        //MULTILINESTRING EMPTY
+        geom_ = std::move(mapnik::geometry::multi_line_string<double>{});
+    }
+
     template<typename T>
     void operator()(T const&) const
     {
@@ -211,6 +227,26 @@ struct create_multipolygon
         }
         geom_ = std::move(multi_poly);
         mapnik::geometry::correct(geom_);
+    }
+
+    void operator()(rings const& rngs) const
+    {
+        //MULTIPOLYGON
+        mapnik::geometry::multi_polygon<double> multi_poly;
+        mapnik::geometry::polygon<double> poly;
+        std::size_t num_rings = rngs.size();
+        for (std::size_t i = 0; i < num_rings; ++i)
+        {
+            // POLYGON EMPTY
+            multi_poly.emplace_back(mapnik::geometry::polygon<double>{});
+        }
+        geom_ = std::move(multi_poly);
+    }
+
+    void operator()(ring const& points) const
+    {
+        //MULTIPOLYGON EMPTY
+        geom_ = std::move(mapnik::geometry::multi_polygon<double>{});
     }
 
     template<typename T>

--- a/include/mapnik/json/geometry_generator_grammar_impl.hpp
+++ b/include/mapnik/json/geometry_generator_grammar_impl.hpp
@@ -83,16 +83,16 @@ geometry_generator_grammar<OutputIterator, Geometry>::geometry_generator_grammar
     linear_ring_coord = lit('[') << -(point_coord % lit(',')) << lit(']')//linestring_coord.alias()
         ;
 
-    polygon_coord = lit('[') << linear_ring_coord % lit(',') << lit(']')
+    polygon_coord = lit('[') << -(linear_ring_coord % lit(',')) << lit(']')
         ;
 
     multi_point_coord = lit('[') << -(point_coord % lit(',')) << lit(']');//linestring_coord.alias()
         ;
 
-    multi_linestring_coord = lit('[') << linestring_coord  % lit(',') << lit(']')
+    multi_linestring_coord = lit('[') << -(linestring_coord  % lit(',')) << lit(']')
         ;
 
-    multi_polygon_coord = lit('[') << polygon_coord  % lit(',') << lit("]")
+    multi_polygon_coord = lit('[') << -(polygon_coord  % lit(',')) << lit("]")
         ;
 
     geometries = geometry % lit(',')

--- a/test/unit/datasource/geojson.cpp
+++ b/test/unit/datasource/geojson.cpp
@@ -141,11 +141,7 @@ TEST_CASE("geojson")
                 std::string json(in);
                 mapnik::geometry::geometry<double> geom;
                 CHECK(mapnik::json::from_geojson(json, geom));
-                if (!mapnik::geometry::is_empty(geom))
-                {
-                    std::cerr << json << std::endl;
-                }
-                // REQUIRE(mapnik::geometry::is_empty(geom));
+                REQUIRE(mapnik::geometry::is_empty(geom));
                 //  round trip
                 std::string json_out;
                 CHECK(mapnik::util::to_geojson(json_out, geom));

--- a/test/unit/datasource/geojson.cpp
+++ b/test/unit/datasource/geojson.cpp
@@ -145,8 +145,8 @@ TEST_CASE("geojson")
                 {
                     std::cerr << json << std::endl;
                 }
-                //REQUIRE(mapnik::geometry::is_empty(geom));
-                // round trip
+                // REQUIRE(mapnik::geometry::is_empty(geom));
+                //  round trip
                 std::string json_out;
                 CHECK(mapnik::util::to_geojson(json_out, geom));
                 json.erase(std::remove_if(std::begin(json),

--- a/test/unit/datasource/geojson.cpp
+++ b/test/unit/datasource/geojson.cpp
@@ -125,11 +125,15 @@ TEST_CASE("geojson")
         SECTION("GeoJSON empty Geometries handling")
         {
             auto valid_empty_geometries = {"null", // Point can't be empty
-                                           "{ \"type\": \"LineString\", \"coordinates\": [] }",
-                                           "{ \"type\": \"Polygon\", \"coordinates\": [ [ ] ] } ",
-                                           "{ \"type\": \"MultiPoint\", \"coordinates\": [ ] }",
-                                           "{ \"type\": \"MultiLineString\", \"coordinates\": [ [] ] }",
-                                           "{ \"type\": \"MultiPolygon\", \"coordinates\": [[ []] ] }"};
+                                           "{ \"type\": \"LineString\", \"coordinates\":[]}",
+                                           "{ \"type\": \"Polygon\", \"coordinates\":[]} ",
+                                           "{ \"type\": \"Polygon\", \"coordinates\":[[]]} ",
+                                           "{ \"type\": \"MultiPoint\", \"coordinates\":[]}",
+                                           "{ \"type\": \"MultiLineString\", \"coordinates\":[]}",
+                                           "{ \"type\": \"MultiLineString\", \"coordinates\":[[]]}",
+                                           "{ \"type\": \"MultiPolygon\", \"coordinates\":[]}",
+                                           "{ \"type\": \"MultiPolygon\", \"coordinates\":[[]]}",
+                                           "{ \"type\": \"MultiPolygon\", \"coordinates\": [[[]]] }"};
 
             for (auto const& in : valid_empty_geometries)
             {

--- a/test/unit/datasource/geojson.cpp
+++ b/test/unit/datasource/geojson.cpp
@@ -28,6 +28,7 @@
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/geometry.hpp>
 #include <mapnik/geometry/geometry_type.hpp>
+#include <mapnik/geometry/is_empty.hpp>
 #include <mapnik/json/geometry_parser.hpp>
 #include <mapnik/util/geometry_to_geojson.hpp>
 #include <mapnik/util/fs.hpp>
@@ -140,6 +141,11 @@ TEST_CASE("geojson")
                 std::string json(in);
                 mapnik::geometry::geometry<double> geom;
                 CHECK(mapnik::json::from_geojson(json, geom));
+                if (!mapnik::geometry::is_empty(geom))
+                {
+                    std::cerr << json << std::endl;
+                }
+                //REQUIRE(mapnik::geometry::is_empty(geom));
                 // round trip
                 std::string json_out;
                 CHECK(mapnik::util::to_geojson(json_out, geom));

--- a/test/unit/geometry/is_empty.cpp
+++ b/test/unit/geometry/is_empty.cpp
@@ -20,7 +20,6 @@
  *
  *****************************************************************************/
 
-
 #include "catch.hpp"
 
 #include <mapnik/geometry/is_empty.hpp>

--- a/test/unit/geometry/is_empty.cpp
+++ b/test/unit/geometry/is_empty.cpp
@@ -1,3 +1,26 @@
+/*****************************************************************************
+ *
+ * This file is part of Mapnik (c++ mapping toolkit)
+ *
+ * Copyright (C) 2024 Artem Pavlenko
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *****************************************************************************/
+
+
 #include "catch.hpp"
 
 #include <mapnik/geometry/is_empty.hpp>

--- a/test/unit/geometry/is_empty.cpp
+++ b/test/unit/geometry/is_empty.cpp
@@ -118,7 +118,7 @@ TEST_CASE("geometry is_empty")
             mapnik::geometry::multi_line_string<double> geom;
             mapnik::geometry::line_string<double> line;
             geom.emplace_back(std::move(line));
-            REQUIRE(!mapnik::geometry::is_empty(geom));
+            REQUIRE(mapnik::geometry::is_empty(geom));
         }
     }
 
@@ -134,7 +134,7 @@ TEST_CASE("geometry is_empty")
             mapnik::geometry::linear_ring<double> ring;
             poly.push_back(std::move(ring));
             geom.emplace_back(std::move(poly));
-            REQUIRE(!mapnik::geometry::is_empty(geom));
+            REQUIRE(mapnik::geometry::is_empty(geom));
         }
     }
 }


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc7946


Allow `"coordinates": []` in Multi* geometries (ref #4431)