### PR TITLE
don't pollute global include dir when installing agg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,8 +448,8 @@ feature_summary(FILENAME "${CMAKE_CURRENT_BINARY_DIR}/packages.log" WHAT PACKAGE
 include(MapnikExport)
 include(MapnikExportPkgConfig)
 
-install(DIRECTORY include/ DESTINATION "${MAPNIK_INCLUDE_DIR}")
-install(DIRECTORY deps/agg/include/ DESTINATION "${MAPNIK_INCLUDE_DIR}")
+install(DIRECTORY include/mapnik/ DESTINATION "${MAPNIK_INCLUDE_DIR}/mapnik")
+install(DIRECTORY deps/agg/include/ DESTINATION "${MAPNIK_INCLUDE_DIR}/mapnik/agg")
 install(DIRECTORY deps/mapnik DESTINATION "${MAPNIK_INCLUDE_DIR}")
 file(GLOB TTF_FONT_FILES "fonts/*/*/*.ttf")
 install(FILES ${TTF_FONT_FILES} DESTINATION "${FONTS_INSTALL_DIR}")

--- a/cmake/MapnikExportPkgConfig.cmake
+++ b/cmake/MapnikExportPkgConfig.cmake
@@ -9,7 +9,7 @@ Name: @_lib_name@
 Description: @_description@
 Version: @MAPNIK_VERSION@
 Libs: -L"${libdir}" -l$<TARGET_FILE_BASE_NAME:@_target@>$<TARGET_PROPERTY:@_target@,$<CONFIG>_POSTFIX>
-Cflags: -I"${includedir}" ]]
+Cflags: -I"${includedir}" -I"${includedir}/mapnik" ]]
     _contents @ONLY)
 
     file(GENERATE
@@ -73,7 +73,7 @@ Description: @_description@
 Version: @MAPNIK_VERSION@
 Requires: @m_requires@
 Libs: -L"${libdir}" -l$<TARGET_FILE_BASE_NAME:mapnik>$<TARGET_PROPERTY:mapnik,$<CONFIG>_POSTFIX>
-Cflags: -I"${includedir}" @m_str_compile_defs@]]
+Cflags: -I"${includedir}" -I"${includedir}/mapnik" -I"${includedir}/mapnik/agg" @m_str_compile_defs@]]
     _contents @ONLY)
     file(GENERATE
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_lib_name}-$<CONFIG>.pc


### PR DESCRIPTION
Mostly as suggested by #4439 
Tested with an external cmake and pkgconfig application

fixes #4439 thanks @sebastic 