### PR TITLE
Address `lcov`/`geninfo` errors on macOS CI builds

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -73,9 +73,12 @@ runs:
       if: runner.os != 'Windows'
       shell: "bash"
       run: |
-        lcov --directory . --capture --output-file coverage.info
-        lcov --remove coverage.info '/usr/*' '*/vcpkg_installed/*'  '/.cache/*' '*/test/*'  --output-file coverage.info
-        lcov --list coverage.info
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          LCOV_EXTRA_OPTIONS="--ignore-errors gcov --ignore-errors inconsistent --ignore-errors unused"
+        fi
+        lcov ${LCOV_EXTRA_OPTIONS:-} --directory . --capture --output-file coverage.info
+        lcov ${LCOV_EXTRA_OPTIONS:-} --remove coverage.info '/usr/*' '*/vcpkg_installed/*'  '/.cache/*' '*/test/*'  --output-file coverage.info
+        lcov ${LCOV_EXTRA_OPTIONS:-} --list coverage.info
 
     - name: Upload coverage to Codecov (linux & macos)
       if: runner.os != 'Windows'


### PR DESCRIPTION
The `lcov` application needs to ignore some errors on `macOS` which don't otherwise seem to be present in `Linux` builds.

A [similar solution](https://github.com/openstreetmap/mod_tile/blob/9834df0e38a6cd55e06dec8608a64077d32f819a/.github/workflows/build-and-test.yml#L206) was needed for `macOS` CI builds of `mod_tile` as well
