### PR TITLE
Add missing `#include <string>` to `include/mapnik/png_io.hpp`

### DIFF
--- a/include/mapnik/png_io.hpp
+++ b/include/mapnik/png_io.hpp
@@ -40,6 +40,7 @@ extern "C" {
 #include <png.h>
 }
 #include <set>
+#include <string>
 MAPNIK_DISABLE_WARNING_POP
 
 #define MAX_OCTREE_LEVELS 4


### PR DESCRIPTION
In order to resolve build errors being seen when using some compilers and systems not being tested in the CI builds.

E.g. with `Clang 16.0.6`:
```
[  9%] Building CXX object CMakeFiles/mapnik.dir/src/image_util_png.cpp.o
In file included from /tmp/nix-build-mapnik-4.0.0-rc1.drv-0/source/src/image_util_png.cpp:34:
/tmp/nix-build-mapnik-4.0.0-rc1.drv-0/source/include/mapnik/png_io.hpp:690:21: error: implicit instantiation of undefined template 'std::basic_string<char>'
        std::string str;
                    ^
/nix/store/y4lqgdhph7qjzsyah9ijdagy9p9jzm31-libcxx-16.0.6-dev/include/c++/v1/__fwd/string.h:45:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS basic_string;
                           ^
/tmp/nix-build-mapnik-4.0.0-rc1.drv-0/source/src/image_util_png.cpp:275:13: error: no matching function for call to 'save_as_png8_hex'
            save_as_png8_hex(stream, image, opts);
            ^~~~~~~~~~~~~~~~
```