### PR TITLE
Resolve `Node.js 16 actions are deprecated` GitHub Actions warnings

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,7 +76,7 @@ jobs:
           mono: ${{ matrix.mono }}
 
       - id: lc_platform
-        uses: ASzc/change-string-case-action@v5
+        uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ runner.os }}
 


### PR DESCRIPTION
### E.g.:
![image](https://github.com/mapnik/mapnik/assets/6109326/c8e1a596-1907-4d7c-9a85-dc6e78d7c977)

----

_There are still [these errors](https://github.com/mapnik/mapnik/actions/runs/8757764205/job/24037134987#step:10:2907) which will require setting up a `CodeCov` token:_
![image](https://github.com/mapnik/mapnik/assets/6109326/c06597df-8db5-4a58-a40d-8f323dea288c)



_Tokenless submissions from public repositories were recently disallowed. More info on this process can be found [here](https://github.com/codecov/codecov-action?tab=readme-ov-file#usage)._