### PR TITLE
No need to install `mapnik-test-visual`

### DIFF
--- a/test/visual/CMakeLists.txt
+++ b/test/visual/CMakeLists.txt
@@ -14,5 +14,3 @@ target_link_libraries(mapnik-test-visual PRIVATE
 
 # needed for cleanup.hpp
 target_include_directories(mapnik-test-visual PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
-
-mapnik_install_utility(mapnik-test-visual)


### PR DESCRIPTION
The target `mapnik-test-visual` is installed whenever `BUILD_TESTING` is enabled, there does not appear to be any reason for this target to be installed as it is only useful for testing purposes.
E.g.:
```shell
$ DESTDIR="/tmp/mapnik-git" cmake --install build
...
-- Installing: /tmp/mapnik-git/usr/bin/mapnik-test-visual
-- Set non-toolchain portion of runtime path of "/tmp/mapnik-git/usr/bin/mapnik-test-visual" to ""
-- Installing: /tmp/mapnik-git/usr/lib/cmake/mapnik/mapnikUtilityTargets_mapnik-test-visual.cmake
-- Installing: /tmp/mapnik-git/usr/lib/cmake/mapnik/mapnikUtilityTargets_mapnik-test-visual-release.cmake
...
```

It won't even work without having the expected data anyhow:
```shell
$ mapnik-test-visual
Error running tests: filesystem error: directory iterator cannot open directory: No such file or directory [test/data-visual/styles]
```