### PR TITLE
Fix build with Boost 1.85.0

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -29,6 +29,10 @@
 #include <mapnik/warning_ignore.hpp>
 #include <boost/filesystem/operations.hpp>  // for absolute, exists, etc
 #include <boost/filesystem/path.hpp>    // for path, operator/
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108500
+#include <boost/filesystem/directory.hpp>  // for directory_iterator
+#endif
 #pragma GCC diagnostic pop
 
 // stl


### PR DESCRIPTION
Build was failing with Boost 1.85.0:
```
src/fs.cpp:124:28: error: no type named 'directory_iterator' in namespace 'boost::filesystem'; did you mean 'directory_entry'?
        boost::filesystem::directory_iterator end_itr;
        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
                           directory_entry
/opt/homebrew/opt/boost/include/boost/filesystem/detail/path_traits.hpp:51:7: note: 'directory_entry' declared here
class directory_entry;
      ^
src/fs.cpp:124:47: error: variable has incomplete type 'boost::filesystem::directory_entry'
        boost::filesystem::directory_iterator end_itr;
                                              ^
/opt/homebrew/opt/boost/include/boost/filesystem/detail/path_traits.hpp:51:7: note: forward declaration of 'boost::filesystem::directory_entry'
class directory_entry;
      ^
src/fs.cpp:132:33: error: no member named 'directory_iterator' in namespace 'boost::filesystem'
        for (boost::filesystem::directory_iterator itr(dir); itr != end_itr; ++itr)
             ~~~~~~~~~~~~~~~~~~~^
src/fs.cpp:132:62: error: use of undeclared identifier 'itr'
        for (boost::filesystem::directory_iterator itr(dir); itr != end_itr; ++itr)
                                                             ^
src/fs.cpp:132:80: error: use of undeclared identifier 'itr'
        for (boost::filesystem::directory_iterator itr(dir); itr != end_itr; ++itr)
                                                                               ^
src/fs.cpp:134:34: error: use of undeclared identifier 'itr'
            listing.emplace_back(itr->path().string());
                                 ^
6 errors generated.
```

Recommendation mentioned in https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html:
> Explicitly include headers `exception.hpp`, `file_status.hpp` and/or `directory.hpp` to introduce the required components.

Header was added in 1.72.0 (https://www.boost.org/users/history/version_1_72_0.html) but I just included it for 1.85.0+ where deprecated behavior was removed.