### PR TITLE
`macos-latest` was migrated from `macOS 12` on `amd64` to `macOS 14` on `arm64`

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -74,7 +74,7 @@ runs:
       shell: "bash"
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          LCOV_EXTRA_OPTIONS="--ignore-errors gcov --ignore-errors inconsistent --ignore-errors unused"
+          LCOV_EXTRA_OPTIONS="--ignore-errors count,gcov,inconsistent,range,unused --keep-going"
         fi
         lcov ${LCOV_EXTRA_OPTIONS:-} --directory . --capture --output-file coverage.info
         lcov ${LCOV_EXTRA_OPTIONS:-} --remove coverage.info '/usr/*' '*/vcpkg_installed/*'  '/.cache/*' '*/test/*'  --output-file coverage.info

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,10 +83,16 @@ jobs:
           nuget-pat: ${{ secrets.GITHUB_TOKEN }}
           mono: ${{ matrix.mono }}
 
-      - name: set lower case runner os
+      - name: Set PRESET environment variable to lower case runner OS
         shell: bash
         run: |
-          echo "PRESET=$(echo "${{ runner.os }}" | perl -ne "print lc")-ci" >> ${GITHUB_ENV}
+          LC_RUNNER_OS=$(echo "${RUNNER_OS}" | perl -ne "print lc")
+          if [ "${RUNNER_OS}" == "macOS" ]; then
+            MACOS_ARCH=${{ (matrix.os == 'macos-14' || matrix.os == 'macos-latest') && 'arm64' || 'x64' }}
+            echo "PRESET=${LC_RUNNER_OS}-ci-${MACOS_ARCH}" >> ${GITHUB_ENV}
+          else
+            echo "PRESET=${LC_RUNNER_OS}-ci" >> ${GITHUB_ENV}
+          fi
 
       - name: Ensure libtool is installed on macOS
         shell: bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,6 +88,11 @@ jobs:
         run: |
           echo "PRESET=$(echo "${{ runner.os }}" | perl -ne "print lc")-ci" >> ${GITHUB_ENV}
 
+      - name: Ensure libtool is installed on macOS
+        shell: bash
+        run: brew install libtool
+        if: runner.os == 'macOS'
+
       - name: Configure CMake
         shell: bash
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,16 +29,24 @@ jobs:
       Build & Test
       (${{ matrix.os }})
       (C++ ${{ matrix.cxx-standard }})
+      ${{ startsWith(matrix.os, 'macos-') && (matrix.os == 'macos-14' && '(ARM64)' || '(AMD64)') || '' }}
     needs: checkSource
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        cxx-standard: [17]
+        os:
+          - macos-13
+          - macos-14
+          - ubuntu-latest
+          - windows-latest
+        cxx-standard:
+          - 17
         include:
-          - os: ubuntu-latest
+          - os: macos-13
             mono: mono
-          - os: macos-latest
+          - os: macos-14
+            mono: mono
+          - os: ubuntu-latest
             mono: mono
           - os: windows-latest
 
@@ -75,15 +83,10 @@ jobs:
           nuget-pat: ${{ secrets.GITHUB_TOKEN }}
           mono: ${{ matrix.mono }}
 
-      - id: lc_platform
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ runner.os }}
-
       - name: set lower case runner os
         shell: bash
         run: |
-          echo "PRESET=${{ steps.lc_platform.outputs.lowercase }}-ci" >>${GITHUB_ENV}
+          echo "PRESET=$(echo "${{ runner.os }}" | perl -ne "print lc")-ci" >> ${GITHUB_ENV}
 
       - name: Configure CMake
         shell: bash

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -228,7 +228,23 @@
             }
         },
         {
-            "name": "macos-ci",
+            "name": "macos-ci-arm64",
+            "description": "used by the ci pipeline",
+            "inherits": [
+                "use-ninja",
+                "release-with-debug-build",
+                "default-build-dir",
+                "ci-options"
+            ],
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fprofile-arcs -ftest-coverage"
+            },
+            "environment": {
+                "PROJ_LIB": "${sourceDir}/build/vcpkg_installed/arm64-osx/share/proj"
+            }
+        },
+        {
+            "name": "macos-ci-x64",
             "description": "used by the ci pipeline",
             "inherits": [
                 "use-ninja",
@@ -282,8 +298,12 @@
             "configurePreset": "linux-ci-release"
         },
         {
-            "name": "macos-ci",
-            "configurePreset": "macos-ci"
+            "name": "macos-ci-arm64",
+            "configurePreset": "macos-ci-arm64"
+        },
+        {
+            "name": "macos-ci-x64",
+            "configurePreset": "macos-ci-x64"
         }
     ],
     "testPresets": [
@@ -313,8 +333,15 @@
             ]
         },
         {
-            "name": "macos-ci",
-            "configurePreset": "macos-ci",
+            "name": "macos-ci-arm64",
+            "configurePreset": "macos-ci-arm64",
+            "inherits": [
+                "test-default"
+            ]
+        },
+        {
+            "name": "macos-ci-x64",
+            "configurePreset": "macos-ci-x64",
             "inherits": [
                 "test-default"
             ]


### PR DESCRIPTION
The switchover appears to have been made on or around `2024.04.22`:
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

There seems to be an issue building the `freexl` dependency on `arm64` using `vcpkg`, which was reported last September (https://github.com/microsoft/vcpkg/issues/33548) but lacked sufficient information in order to be resolved. This issue seems to be caused by `libtool` not being present in the `macos-14`/`macos-latest` image.

This pull request adds building with both `macos-13` and `macos-14` (`macos-latest`) in order to test `macOS` on both architectures.

_Also_:
* Removed the `ASzc/change-string-case-action` dependency in favor of using `perl` (which is installed on all runners.)
* Addressed coverage capturing issues exhibited after recent upgrade to LCOV 2.1 on macOS runners

---
Here are some example CI job runs:

2024.04.22 (`macos-latest` -> [macos-12](https://github.com/mapnik/mapnik/actions/runs/8785850518/job/24107328188#step:1:8))
* https://github.com/mapnik/mapnik/actions/runs/8785850518/job/24107328188#step:8:643

2024.04.25 (`macos-latest` -> [macos-14-arm64](https://github.com/mapnik/mapnik/actions/runs/8830567852/job/24244012779#step:1:8)):
* https://github.com/mapnik/mapnik/actions/runs/8830567852/job/24244012779#step:8:2529