### PR TITLE
Set proper soversion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ set_target_properties(mapnik PROPERTIES
     IMPORT_PREFIX "lib" # for the archive on dll platforms
     VERSION ${MAPNIK_VERSION}
     # see https://github.com/mapnik/mapnik/pull/4248#issuecomment-925596509 => ABI compability only with the full version
-    SOVERSION ${MAPNIK_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 if(MSVC)


### PR DESCRIPTION
Soversion should only reflects the major version, since the soname
link cannot be created due to equal name as the library. Library
libmapnik.so.4.0.0 prevents soname libmapnik.so.4.0.0 from being
created.