### PR TITLE
Fix building with GCC 14

### DIFF
--- a/include/mapnik/geometry/fusion_adapted.hpp
+++ b/include/mapnik/geometry/fusion_adapted.hpp
@@ -26,6 +26,8 @@
 #include <mapnik/geometry/polygon.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 
+#include <cstdint>
+
 BOOST_FUSION_ADAPT_STRUCT(mapnik::geometry::point<double>, (double, x)(double, y))
 
 BOOST_FUSION_ADAPT_STRUCT(mapnik::geometry::point<std::int64_t>, (std::int64_t, x)(std::int64_t, y))

--- a/include/mapnik/util/singleton.hpp
+++ b/include/mapnik/util/singleton.hpp
@@ -39,7 +39,7 @@
 namespace mapnik {
 
 template<typename T>
-class CreateUsingNew
+class MAPNIK_DECL CreateUsingNew
 {
   public:
     static T* create() { return new T; }
@@ -47,7 +47,7 @@ class CreateUsingNew
 };
 
 template<typename T>
-class CreateStatic
+class MAPNIK_DECL CreateStatic
 {
   private:
     using storage_type = typename std::aligned_storage<sizeof(T), alignof(T)>::type;

--- a/include/mapnik/util/singleton.hpp
+++ b/include/mapnik/util/singleton.hpp
@@ -39,7 +39,11 @@
 namespace mapnik {
 
 template<typename T>
+#ifdef _WIN32
+class CreateUsingNew
+#else
 class MAPNIK_DECL CreateUsingNew
+#endif
 {
   public:
     static T* create() { return new T; }
@@ -47,7 +51,11 @@ class MAPNIK_DECL CreateUsingNew
 };
 
 template<typename T>
+#ifdef _WIN32
+class CreateStatic
+#else
 class MAPNIK_DECL CreateStatic
+#endif
 {
   private:
     using storage_type = typename std::aligned_storage<sizeof(T), alignof(T)>::type;


### PR DESCRIPTION
Fails to build with GCC 14.
```
/usr/bin/ld: /tmp/cc90QIs2.ltrans0.ltrans.o: in function `main':
<artificial>:(.text.startup+0xb1): undefined reference to `mapnik::singleton<mapnik::datasource_cache, mapnik::CreateStatic>::instance()'
/usr/bin/ld: <artificial>:(.text.startup+0x278): undefined reference to `mapnik::singleton<mapnik::datasource_cache, mapnik::CreateStatic>::instance()'
collect2: error: ld returned 1 exit status
make[2]: *** [utils/geometry_to_wkb/CMakeFiles/geometry_to_wkb.dir/build.make:115: out/geometry_to_wkb] Error 1
make[1]: *** [CMakeFiles/Makefile2:1724: utils/geometry_to_wkb/CMakeFiles/geometry_to_wkb.dir/all] Error 2
```