### PR TITLE
Use CMAKE_INSTALL_LIBDIR for libdir in pkg-config files

### DIFF
--- a/cmake/MapnikExportPkgConfig.cmake
+++ b/cmake/MapnikExportPkgConfig.cmake
@@ -3,7 +3,7 @@ function(create_pkg_config_file _target _lib_name _description)
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: @_lib_name@
 Description: @_description@
@@ -64,7 +64,7 @@ function(create_pkg_config_file_mapnik _lib_name _description)
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 fonts_dir=${prefix}/@FONTS_INSTALL_DIR@
 plugins_dir=${prefix}/@PLUGINS_INSTALL_DIR@
 


### PR DESCRIPTION
This ensure that we use `lib64` instead of `lib` when appropriate.