### PR TITLE
Split bounding box along (0, 0) before reprojecting  [WIP] [skip ci]

### DIFF
--- a/include/mapnik/projection.hpp
+++ b/include/mapnik/projection.hpp
@@ -81,6 +81,7 @@ class MAPNIK_DECL projection
     std::string description() const;
     void init_proj();
     std::optional<box2d<double>> area_of_use() const;
+
   private:
     void swap(projection& rhs);
 

--- a/include/mapnik/projection.hpp
+++ b/include/mapnik/projection.hpp
@@ -26,7 +26,7 @@
 // mapnik
 #include <mapnik/config.hpp>
 #include <mapnik/well_known_srs.hpp>
-
+#include <mapnik/geometry/box2d.hpp>
 #include <mapnik/warning.hpp>
 MAPNIK_DISABLE_WARNING_PUSH
 #include <mapnik/warning_ignore.hpp>
@@ -79,15 +79,16 @@ class MAPNIK_DECL projection
     void inverse(double& x, double& y) const;
     std::string definition() const;
     std::string description() const;
-    void init_proj() const;
-
+    void init_proj();
+    std::optional<box2d<double>> area_of_use() const;
   private:
     void swap(projection& rhs);
 
   private:
     std::string params_;
     bool defer_proj_init_;
-    mutable bool is_geographic_;
+    bool is_geographic_;
+    std::optional<box2d<double>> area_of_use_;
     mutable PJ* proj_;
     mutable PJ_CONTEXT* proj_ctx_;
 };

--- a/src/projection.cpp
+++ b/src/projection.cpp
@@ -94,7 +94,7 @@ bool projection::operator!=(const projection& other) const
     return !(*this == other);
 }
 
-void projection::init_proj() const
+void projection::init_proj()
 {
 #ifdef MAPNIK_USE_PROJ
     if (!proj_)
@@ -117,6 +117,11 @@ void projection::init_proj() const
         }
         PJ_TYPE type = proj_get_type(proj_);
         is_geographic_ = (type == PJ_TYPE_GEOGRAPHIC_2D_CRS || type == PJ_TYPE_GEOGRAPHIC_3D_CRS) ? true : false;
+        double west_lon, south_lat, east_lon, north_lat;
+        if (proj_get_area_of_use(proj_ctx_, proj_, &west_lon, &south_lat, &east_lon, &north_lat, nullptr))
+        {
+            area_of_use_ = box2d<double>{west_lon, south_lat, east_lon, north_lat};
+        }
     }
 #endif
 }
@@ -129,6 +134,11 @@ bool projection::is_initialized() const
 bool projection::is_geographic() const
 {
     return is_geographic_;
+}
+
+std::optional<box2d<double>> projection::area_of_use() const
+{
+    return area_of_use_;
 }
 
 std::optional<well_known_srs_e> projection::well_known() const

--- a/test/unit/projection/proj_transform.cpp
+++ b/test/unit/projection/proj_transform.cpp
@@ -210,15 +210,14 @@ TEST_CASE("projection transform")
         mapnik::projection prj_geog("epsg:4326");
         mapnik::projection prj_proj("epsg:3995");
 
-
         mapnik::proj_transform prj_trans_fwd(prj_proj, prj_geog);
         mapnik::proj_transform prj_trans_rev(prj_geog, prj_proj);
 
         // bounds
-        const mapnik::box2d<double> bounds{-180.0,60.0,180.0,90.0};
+        const mapnik::box2d<double> bounds{-180.0, 60.0, 180.0, 90.0};
         {
-             // projected bounds
-            mapnik::box2d<double> projected_bounds{-3299207.53,-3333134.03, 3299207.53, 3333134.03};
+            // projected bounds
+            mapnik::box2d<double> projected_bounds{-3299207.53, -3333134.03, 3299207.53, 3333134.03};
             CHECKED_IF(prj_trans_fwd.forward(projected_bounds, PROJ_ENVELOPE_POINTS))
             {
                 CHECK(projected_bounds.minx() == Approx(bounds.minx()));
@@ -230,7 +229,7 @@ TEST_CASE("projection transform")
 
         {
             // check the same logic works for .backward()
-            mapnik::box2d<double> projected_bounds{-3299207.53,-3333134.03, 3299207.53, 3333134.03};
+            mapnik::box2d<double> projected_bounds{-3299207.53, -3333134.03, 3299207.53, 3333134.03};
             CHECKED_IF(prj_trans_rev.backward(projected_bounds, PROJ_ENVELOPE_POINTS))
             {
                 CHECK(projected_bounds.minx() == Approx(bounds.minx()));

--- a/test/unit/projection/proj_transform.cpp
+++ b/test/unit/projection/proj_transform.cpp
@@ -16,6 +16,8 @@ TEST_CASE("projection transform")
         CHECK(proj_4326.is_geographic());
         CHECK(!proj_3857.is_geographic());
 
+        CHECK(*proj_4326.area_of_use() == mapnik::box2d<double>(-180, -90, 180, 90));
+        CHECK(*proj_3857.area_of_use() == mapnik::box2d<double>(-180, -85.06, 180, 85.06));
         mapnik::proj_transform prj_trans(proj_4326, proj_3857);
 
         double minx = -45.0;
@@ -48,6 +50,7 @@ TEST_CASE("projection transform")
     {
         mapnik::projection proj_4269("epsg:4269");
         mapnik::projection proj_3857("epsg:3857");
+
         mapnik::proj_transform prj_trans(proj_4269, proj_3857);
         mapnik::proj_transform prj_trans2(proj_3857, proj_4269);
 
@@ -200,7 +203,43 @@ TEST_CASE("projection transform")
             }
         }
     }
-#endif
+    SECTION("Test proj north/south poles bbox")
+    {
+        // WGS 84 / Arctic Polar Stereographic
+
+        mapnik::projection prj_geog("epsg:4326");
+        mapnik::projection prj_proj("epsg:3995");
+
+
+        mapnik::proj_transform prj_trans_fwd(prj_proj, prj_geog);
+        mapnik::proj_transform prj_trans_rev(prj_geog, prj_proj);
+
+        // bounds
+        const mapnik::box2d<double> bounds{-180.0,60.0,180.0,90.0};
+        {
+             // projected bounds
+            mapnik::box2d<double> projected_bounds{-3299207.53,-3333134.03, 3299207.53, 3333134.03};
+            CHECKED_IF(prj_trans_fwd.forward(projected_bounds, PROJ_ENVELOPE_POINTS))
+            {
+                CHECK(projected_bounds.minx() == Approx(bounds.minx()));
+                CHECK(projected_bounds.miny() == Approx(48.65640)); // this is expected
+                CHECK(projected_bounds.maxx() == Approx(bounds.maxx()));
+                CHECK(projected_bounds.maxy() == Approx(bounds.maxy()));
+            }
+        }
+
+        {
+            // check the same logic works for .backward()
+            mapnik::box2d<double> projected_bounds{-3299207.53,-3333134.03, 3299207.53, 3333134.03};
+            CHECKED_IF(prj_trans_rev.backward(projected_bounds, PROJ_ENVELOPE_POINTS))
+            {
+                CHECK(projected_bounds.minx() == Approx(bounds.minx()));
+                CHECK(projected_bounds.miny() == Approx(48.65640)); // this is expected
+                CHECK(projected_bounds.maxx() == Approx(bounds.maxx()));
+                CHECK(projected_bounds.maxy() == Approx(bounds.maxy()));
+            }
+        }
+    }
 
     SECTION("proj_transform of coordinate arrays with stride > 1")
     {
@@ -237,7 +276,6 @@ TEST_CASE("projection transform")
             }
         }
 
-#ifdef MAPNIK_USE_PROJ
         SECTION("lonlat <-> New Zealand Transverse Mercator 2000")
         {
             mapnik::projection const proj_2193("epsg:2193");


### PR DESCRIPTION
(improves handling stereographic projections e.g epsg:3995)

![image](https://github.com/user-attachments/assets/9a8aa729-cfb6-425d-aa53-9676189a49ec)
