### PR TITLE
Support CJK characters by adding a lang attribute to TextSymbolizer

### DIFF
--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -226,7 +226,7 @@ struct harfbuzz_shaper
                            std::map<unsigned, double>& width_map,
                            face_manager_freetype& font_manager,
                            double scale_factor,
-                           const std::string &lang)
+                           const std::optional<std::string> lang)
     {
         unsigned start = line.first_char();
         unsigned end = line.last_char();
@@ -283,8 +283,8 @@ struct harfbuzz_shaper
                 hb_font_t* font(hb_ft_font_create(face->get_face(), nullptr));
                 auto script = detail::_icu_script_to_script(text_item.script);
                 hb_language_t hb_lang;
-                if (!lang.empty()) {
-                    hb_lang = hb_language_from_string(lang.c_str(), -1);
+                if (lang) {
+                    hb_lang = hb_language_from_string(lang->c_str(), -1);
                 } else {
                     hb_lang = detail::script_to_language(script);
                     MAPNIK_LOG_DEBUG(harfbuzz_shaper) << "RUN:[" << text_item.start << "," << text_item.end << "]"

--- a/include/mapnik/text/text_layout.hpp
+++ b/include/mapnik/text/text_layout.hpp
@@ -167,7 +167,7 @@ class text_layout
     // Precalculated values for maximum performance
     rotation orientation_ = {0, 1.0};
     char wrap_char_ = ' ';
-    std::string lang_ = "";
+    std::optional<std::string> lang_;
     double wrap_width_ = 0.0;
     bool wrap_before_ = false;
     bool repeat_wrap_char_ = false;

--- a/include/mapnik/text/text_layout.hpp
+++ b/include/mapnik/text/text_layout.hpp
@@ -167,6 +167,7 @@ class text_layout
     // Precalculated values for maximum performance
     rotation orientation_ = {0, 1.0};
     char wrap_char_ = ' ';
+    std::string lang_ = "";
     double wrap_width_ = 0.0;
     bool wrap_before_ = false;
     bool repeat_wrap_char_ = false;

--- a/include/mapnik/text/text_properties.hpp
+++ b/include/mapnik/text/text_properties.hpp
@@ -155,6 +155,7 @@ struct MAPNIK_DECL text_layout_properties
     symbolizer_base::value_type jalign;
     symbolizer_base::value_type valign;
     directions_e dir = EXACT_POSITION;
+    std::string lang;
 };
 
 struct text_properties_expressions

--- a/src/text/text_layout.cpp
+++ b/src/text/text_layout.cpp
@@ -113,6 +113,7 @@ text_layout::text_layout(face_manager_freetype& font_manager,
       util::apply_visitor(extract_value<std::string>(feature, attrs), layout_properties_.wrap_char);
     if (!wrap_str.empty())
         wrap_char_ = wrap_str[0];
+    if (!layout_properties_.lang.empty()) lang_ = layout_properties_.lang;
     wrap_width_ = util::apply_visitor(extract_value<value_double>(feature, attrs), layout_properties_.wrap_width);
     double angle = util::apply_visitor(extract_value<value_double>(feature, attrs), layout_properties_.orientation);
     orientation_.init(util::radians(angle));
@@ -456,7 +457,7 @@ void text_layout::clear()
 
 void text_layout::shape_text(text_line& line)
 {
-    harfbuzz_shaper::shape_text(line, itemizer_, width_map_, font_manager_, scale_factor_);
+    harfbuzz_shaper::shape_text(line, itemizer_, width_map_, font_manager_, scale_factor_, lang_);
 }
 
 void text_layout::init_auto_alignment()

--- a/src/text/text_properties.cpp
+++ b/src/text/text_properties.cpp
@@ -270,6 +270,10 @@ void text_layout_properties::from_xml(xml_node const& node, fontset_map const& f
     set_property_from_xml<vertical_alignment_e>(valign, "vertical-alignment", node);
     set_property_from_xml<horizontal_alignment_e>(halign, "horizontal-alignment", node);
     set_property_from_xml<justify_alignment_e>(jalign, "justify-alignment", node);
+    std::string lang_ = node.get_attr<std::string>("lang", "");
+    if (!lang_.empty()) {
+        lang = lang_;
+    }
 }
 
 void text_layout_properties::to_xml(boost::property_tree::ptree& node,

--- a/src/text/text_properties.cpp
+++ b/src/text/text_properties.cpp
@@ -270,10 +270,8 @@ void text_layout_properties::from_xml(xml_node const& node, fontset_map const& f
     set_property_from_xml<vertical_alignment_e>(valign, "vertical-alignment", node);
     set_property_from_xml<horizontal_alignment_e>(halign, "horizontal-alignment", node);
     set_property_from_xml<justify_alignment_e>(jalign, "justify-alignment", node);
-    std::string lang_ = node.get_attr<std::string>("lang", "");
-    if (!lang_.empty()) {
-        lang = lang_;
-    }
+    std::optional<std::string> lang_ = node.get_attr<std::string>("lang");
+    if (lang_) lang = *lang_;
 }
 
 void text_layout_properties::to_xml(boost::property_tree::ptree& node,

--- a/test/unit/text/shaping.cpp
+++ b/test/unit/text/shaping.cpp
@@ -28,7 +28,7 @@ void test_shaping(mapnik::font_set const& fontset,
     itemizer.add_text(ustr, props);
 
     mapnik::text_line line(0, length);
-    mapnik::harfbuzz_shaper::shape_text(line, itemizer, width_map, fm, scale_factor);
+    mapnik::harfbuzz_shaper::shape_text(line, itemizer, width_map, fm, scale_factor, "");
 
     std::size_t index = 0;
     for (auto const& g : line)


### PR DESCRIPTION
I've been looking into how Mapnik and OpenStreetMap can display Simplified and Traditional Chinese characters, which was discussed in Issue #3655

This PR updates `TextSymbolizer` to have an optional `lang` attribute which gets passed to harfbuzz.
The code implementing this is @bdon's commit on that thread, with two small updates for the current codebase.

This also adds a visual test (https://github.com/mapnik/test-data-visual/pull/86) which can be rendered using the updated `TextSymbolizer`