### PR TITLE
Fix two compile issues with mingw

### DIFF
--- a/include/mapnik/util/utf_conv_win.hpp
+++ b/include/mapnik/util/utf_conv_win.hpp
@@ -28,6 +28,7 @@
 #include <mapnik/config.hpp>
 // stl
 #include <string>
+#include <filesystem>
 
 namespace mapnik {
 
@@ -35,6 +36,7 @@ namespace mapnik {
 
 MAPNIK_DECL std::string utf16_to_utf8(std::wstring const& wstr);
 MAPNIK_DECL std::wstring utf8_to_utf16(std::string const& str);
+MAPNIK_DECL std::filesystem::path utf8_to_utf16_path(std::string const& str);
 
 } // namespace mapnik
 #endif // _WIN32

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -121,7 +121,7 @@ PluginInfo::~PluginInfo() {}
 void* PluginInfo::get_symbol(std::string const& sym_name) const
 {
 #ifdef MAPNIK_SUPPORTS_DLOPEN
-    return static_cast<void*>(dlsym(module_->dl, sym_name.c_str()));
+    return reinterpret_cast<void*>(dlsym(module_->dl, sym_name.c_str()));
 #else
     return nullptr;
 #endif

--- a/src/rapidxml_loader.cpp
+++ b/src/rapidxml_loader.cpp
@@ -63,7 +63,7 @@ class rapidxml_loader : util::noncopyable
         }
         filename_ = filename;
 #ifdef _WIN32
-        std::basic_ifstream<char> stream(mapnik::utf8_to_utf16(filename));
+        std::basic_ifstream<char> stream(mapnik::utf8_to_utf16_path(filename));
 #else
         std::basic_ifstream<char> stream(filename.c_str());
 #endif

--- a/src/svg/svg_parser.cpp
+++ b/src/svg/svg_parser.cpp
@@ -1654,7 +1654,7 @@ svg_parser::~svg_parser() {}
 void svg_parser::parse(std::string const& filename)
 {
 #ifdef _WIN32
-    std::basic_ifstream<char> stream(mapnik::utf8_to_utf16(filename));
+    std::basic_ifstream<char> stream(mapnik::utf8_to_utf16_path(filename));
 #else
     std::basic_ifstream<char> stream(filename.c_str());
 #endif

--- a/src/util/utf_conv_win.cpp
+++ b/src/util/utf_conv_win.cpp
@@ -56,6 +56,11 @@ std::wstring utf8_to_utf16(std::string const& str)
     return wstr;
 }
 
+std::filesystem::path utf8_to_utf16_path(std::string const& str)
+{
+    return std::filesystem::path(utf8_to_utf16(str));
+}
+
 } // namespace mapnik
 
 #endif // _WIN32


### PR DESCRIPTION
Hi,

This PR fixes two compile issues with MINGW:

1. Result type of `dlsym` is `FARPROC` on WIN32, which can not be converted via `static_cast`
2. `std::ifstream(std::wstring)` is not an std interface ([see here](https://en.cppreference.com/w/cpp/io/basic_ifstream/basic_ifstream.html)); we need to use `filesystem::path` to wrap the path

The fixed code now compiles with mingw 15.1.0 by cross-compile from Linux. I don't have an MSVC environment at hand so I don't know if it breaks any existing things. If necessary, I can wrap the fix with MINGW guards.