### PR TITLE
Re-apply 32-bits fix from 5ed68a80c35259909ce80f37a236a5c83b6f8cea

### DIFF
--- a/plugins/input/tiles/pmtiles_source.hpp
+++ b/plugins/input/tiles/pmtiles_source.hpp
@@ -470,7 +470,7 @@ class pmtiles_source : public tiles_source,
             {
                 std::string decompressed_dir;
 #if defined(MAPNIK_MEMORY_MAPPED_FILE)
-                std::string_view buffer{file_.buffer().first + dir_offset, dir_length};
+                std::string_view buffer{file_.buffer().first + dir_offset, static_cast<std::size_t>(dir_length)};
 #else
                 std::string buffer;
                 buffer.resize(dir_length);
@@ -559,7 +559,7 @@ class pmtiles_source : public tiles_source,
     {
         std::string metadata;
 #if defined(MAPNIK_MEMORY_MAPPED_FILE)
-        std::string_view buffer{file_.buffer().first + metadata_offset_, metadata_length_};
+        std::string_view buffer{file_.buffer().first + metadata_offset_, static_cast<std::size_t>(metadata_length_)};
 #else
         std::string buffer;
         buffer.resize(metadata_length_);


### PR DESCRIPTION
It appears to have been lost during some recent refactoring.

Re: https://github.com/mapnik/mapnik/issues/4517