### PR TITLE
Fix build failure with GDAL 3.12.0.

### DIFF
--- a/plugins/input/ogr/ogr_datasource.cpp
+++ b/plugins/input/ogr/ogr_datasource.cpp
@@ -378,7 +378,11 @@ void ogr_datasource::init(mapnik::parameters const& params)
         }
     }
     mapnik::parameters& extra_params = desc_.get_extra_parameters();
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 12, 0)
+    const OGRSpatialReference* srs_ref = layer->GetSpatialRef();
+#else
     OGRSpatialReference* srs_ref = layer->GetSpatialRef();
+#endif
     char* srs_output = nullptr;
     if (srs_ref && srs_ref->exportToProj4(&srs_output) == OGRERR_NONE)
     {


### PR DESCRIPTION
Fixes:
```
/build/mapnik-4.1.3+ds/plugins/input/ogr/ogr_datasource.cpp: In member function 'void ogr_datasource::init(const mapnik::parameters&)':
/build/mapnik-4.1.3+ds/plugins/input/ogr/ogr_datasource.cpp:381:56: error: invalid conversion from 'const OGRSpatialReference*' to 'OGRSpatialReference*' [-fpermissive]
  381 |     OGRSpatialReference* srs_ref = layer->GetSpatialRef();
      |                                    ~~~~~~~~~~~~~~~~~~~~^~
      |                                                        |
      |                                                        const OGRSpatialReference*
```
From [MIGRATION_GUIDE.TXT](https://github.com/OSGeo/gdal/blob/master/MIGRATION_GUIDE.TXT):
>   * OGRLayer::GetSpatialRef() is now a const method that returns a const OGRSpatialReference*