### PR TITLE
Fix inconsistent include path to agg_trans_affine header in transform…

### DIFF
--- a/include/mapnik/transform/transform_processor.hpp
+++ b/include/mapnik/transform/transform_processor.hpp
@@ -34,7 +34,7 @@
 #include <mapnik/warning.hpp>
 MAPNIK_DISABLE_WARNING_PUSH
 #include <mapnik/warning_ignore_agg.hpp>
-#include <agg_trans_affine.h>
+#include <mapnik/agg/agg_trans_affine.h>
 MAPNIK_DISABLE_WARNING_POP
 
 // stl


### PR DESCRIPTION
… processor

Forces client to use otherwise unnecessary additional include paths to avoid a compilation error