### PR TITLE
ISSUE-4546 - fix missed key rename

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -752,7 +752,7 @@ def parse_pg_config(context, config):
     if ret:
         env.AppendUnique(CPPPATH = fix_path(inc_path))
         env.AppendUnique(LIBPATH = fix_path(lib_path))
-        lpq = env['PLUGINS']['postgis']['lib']
+        lpq = env['PLUGINS']['postgis+pgraster']['lib']
         env.Append(LIBS = lpq)
     else:
         env['SKIPPED_DEPS'].append(tool)


### PR DESCRIPTION
* updates `SConstruct` to account for the input plugin combining and renaming from #4542 - resolves #4546