### PR TITLE
Fix PostGIS async connection pool churn

### DIFF
--- a/plugins/input/postgis/connection.hpp
+++ b/plugins/input/postgis/connection.hpp
@@ -199,6 +199,13 @@ class Connection
     PGresult* getResult()
     {
         PGresult* result = PQgetResult(conn_);
+        // NULL means all async results consumed; connection is idle.
+        // Clear pending_ so AsyncResultSet::close() returns the
+        // connection to the pool instead of destroying it.
+        // Note: if a caller abandons an AsyncResultSet before fully
+        // draining results, pending_ stays true and close() will
+        // still tear down the connection — that's intentional.
+        if (!result) pending_ = false;
         return result;
     }
 


### PR DESCRIPTION
Connection::pending_ was never cleared in the normal success path, causing AsyncResultSet::close() to always abort and destroy the connection instead of returning it to the pool.

This fixes new connections being opened for every request as mentioned in mapnik/mapnik#4520