### PR TITLE
Rendering complex Unicode sequences across multiple fonts in a fontset

### DIFF
--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -345,6 +345,11 @@ struct harfbuzz_shaper
                     {
                         c.push_back({face, glyphs[i], positions[i]});
                     }
+                    else if (c.front().face != face)
+                    {
+                        c.clear();
+                        c.push_back({face, glyphs[i], positions[i]});
+                    }
                     else if (c.front().glyph.codepoint == 0)
                     {
                         c.front() = {face, glyphs[i], positions[i]};


### PR DESCRIPTION
There is a rendering issue in [openstreetmap-carto](https://github.com/openstreetmap-carto/openstreetmap-carto/issues/5215) and I think this PR solves it.

With this PR, the cluster containing `ශ්‍රී` is rendered using a single font that fully supports the glyph sequence.

If I understand correctly, without this PR, `ශ්‍රී` is rendered using the first font in the fontset that maybe only partially supported the cluster, resulting in inconsistent shaping.

My Test case `hellosinhala.xml`:

```xml
<?xml version="1.0" encoding="utf-8"?>
<Map srs="EPSG:3857">

  <FontSet name="fallback">
    <Font face-name="Noto Sans Regular"/>
    <Font face-name="Noto Sans Sinhala Regular"/>
  </FontSet>

  <Style name="s">
    <Rule>
      <TextSymbolizer fontset-name="fallback"
                       size="32"
                       fill="black">
        [name]
      </TextSymbolizer>
    </Rule>
  </Style>

  <Layer name="t" srs="EPSG:4326">
    <StyleName>s</StyleName>

    <Datasource>
      <Parameter name="type">geojson</Parameter>
      <Parameter name="inline">
        {
          "type": "FeatureCollection",
          "features": [
            {
              "type": "Feature",
              "properties": { "name": "Hello ශ්‍රී ලංකා" },
              "geometry": { "type": "Point", "coordinates": [0, 0] }
            }
          ]
        }
      </Parameter>
    </Datasource>

  </Layer>
</Map>
```

I rendered it via:

```bash
mapnik-render --bbox -10,-10,10,10 \
  --plugins-dir /usr/local/lib/mapnik/input \
  --fonts-dir /usr/share/fonts/truetype/noto/ \
  hellosinhala.xml output.png
```

### Note

This is my first time with Mapnik, so I am still learning. Because of that, I am not fully confident yet about negative side effects.

I compiled Mapnik on Debian 13 using:

```bash
git clone https://github.com/mapnik/mapnik.git --depth 1 --recursive
cd mapnik

sudo rm -rf /usr/local/lib/mapnik
sudo rm -rf /usr/local/include/mapnik

rm -rf build
mkdir build && cd build

cmake .. \
  -DCMAKE_BUILD_TYPE=Debug \
  -DBUILD_BENCHMARK=OFF \
  -DBUILD_TESTING=OFF \
  -DBUILD_DEMO_VIEWER=OFF

make -j2
sudo make install
```
 
For debugging, I added temporary logging (I was not able to make MAPNIK_LOG_DEBUG visible):

```cpp
if (c.empty()) {
    std::cerr << "Cluster " << cluster << " empty, add glyph font "
              << face->family_name() << std::endl;
    c.push_back({face, glyphs[i], positions[i]});
}
else if (c.front().face != face) {
    std::cerr << "Cluster " << cluster << " switch font "
              << c.front().face->family_name()
              << " -> " << face->family_name() << std::endl;

    c.clear();
    c.push_back({face, glyphs[i], positions[i]});
}
else if (c.front().glyph.codepoint == 0) {
    std::cerr << "Cluster " << cluster << " replace missing glyph font "
              << face->family_name() << std::endl;

    c.front() = {face, glyphs[i], positions[i]};
}
else if (in_cluster) {
    std::cerr << "Cluster " << cluster << " add glyph font "
              << face->family_name() << std::endl;

    c.push_back({face, glyphs[i], positions[i]});
}
```
