### PR TITLE
Correction for "Rendering complex Unicode sequences across multiple fonts in a fontset"

### DIFF
--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -345,6 +345,28 @@ struct harfbuzz_shaper
                     current_clusters[cluster]
                         .push_back({face, glyphs[i], positions[i]});
                 }
+                for (unsigned cluster_id = 0;
+                    cluster_id < current_clusters.size();
+                    ++cluster_id)
+                {
+                    auto const& cluster_glyphs = current_clusters[cluster_id];
+
+                    if (cluster_glyphs.empty())
+                        continue;
+                    bool valid = true;
+                    for (auto const& info : cluster_glyphs)
+                    {
+                        if (info.glyph.codepoint == 0)
+                        {
+                            valid = false;
+                            break;
+                        }
+                    }
+                    if (valid)
+                    {
+                        glyphinfos[cluster_id] = cluster_glyphs;
+                    }
+                }
                 bool all_set = true;
                 for (auto c_id : clusters)
                 {

--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -366,6 +366,10 @@ struct harfbuzz_shaper
                     {
                         glyphinfos[cluster_id] = cluster_glyphs;
                     }
+                    else if (glyphinfos[cluster_id].empty())
+                    {
+                        glyphinfos[cluster_id] = cluster_glyphs;
+                    }
                 }
                 bool all_set = true;
                 for (auto c_id : clusters)

--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -318,6 +318,8 @@ struct harfbuzz_shaper
                 unsigned cluster = 0;
                 bool in_cluster = false;
                 std::vector<unsigned> clusters;
+                std::vector<std::vector<glyph_face_info>> current_clusters;
+                current_clusters.resize(text.length());
 
                 for (unsigned i = 0; i < num_glyphs; ++i)
                 {

--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -342,12 +342,9 @@ struct harfbuzz_shaper
                     {
                         glyphinfos.resize(cluster + 1);
                     }
-                    current_clusters[cluster]
-                        .push_back({face, glyphs[i], positions[i]});
+                    current_clusters[cluster].push_back({face, glyphs[i], positions[i]});
                 }
-                for (unsigned cluster_id = 0;
-                    cluster_id < current_clusters.size();
-                    ++cluster_id)
+                for (unsigned cluster_id = 0; cluster_id < current_clusters.size(); ++cluster_id)
                 {
                     auto const& cluster_glyphs = current_clusters[cluster_id];
 

--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -342,19 +342,8 @@ struct harfbuzz_shaper
                     {
                         glyphinfos.resize(cluster + 1);
                     }
-                    auto& c = glyphinfos[cluster];
-                    if (c.empty())
-                    {
-                        c.push_back({face, glyphs[i], positions[i]});
-                    }
-                    else if (c.front().glyph.codepoint == 0)
-                    {
-                        c.front() = {face, glyphs[i], positions[i]};
-                    }
-                    else if (in_cluster)
-                    {
-                        c.push_back({face, glyphs[i], positions[i]});
-                    }
+                    current_clusters[cluster]
+                        .push_back({face, glyphs[i], positions[i]});
                 }
                 bool all_set = true;
                 for (auto c_id : clusters)

--- a/src/text/itemizer.cpp
+++ b/src/text/itemizer.cpp
@@ -144,7 +144,7 @@ void text_itemizer::itemize_script()
     {
         UScriptCode code = runs.getScriptCode();
         unsigned start = runs.getScriptStart();
-        unsigned end   = runs.getScriptEnd();
+        unsigned end = runs.getScriptEnd();
 
         unsigned current_pos = start;
 
@@ -153,20 +153,15 @@ void text_itemizer::itemize_script()
             UChar32 c = text_.char32At(current_pos);
             unsigned next_pos = text_.moveIndex32(current_pos, 1);
 
-            UScriptCode usc =
-                u_ispunct(c) ? USCRIPT_COMMON : code;
+            UScriptCode usc = u_ispunct(c) ? USCRIPT_COMMON : code;
 
-            if (!script_runs_.empty() &&
-                script_runs_.back().data == usc &&
-                script_runs_.back().end == current_pos)
+            if (!script_runs_.empty() && script_runs_.back().data == usc && script_runs_.back().end == current_pos)
             {
                 script_runs_.back().end = next_pos;
             }
             else
             {
-                script_runs_.emplace_back(usc,
-                                        current_pos,
-                                        next_pos);
+                script_runs_.emplace_back(usc, current_pos, next_pos);
             }
 
             current_pos = next_pos;

--- a/src/text/itemizer.cpp
+++ b/src/text/itemizer.cpp
@@ -142,7 +142,35 @@ void text_itemizer::itemize_script()
     ScriptRun runs(text_.getBuffer(), text_.length());
     while (runs.next())
     {
-        script_runs_.emplace_back(runs.getScriptCode(), runs.getScriptStart(), runs.getScriptEnd());
+        UScriptCode code = runs.getScriptCode();
+        unsigned start = runs.getScriptStart();
+        unsigned end   = runs.getScriptEnd();
+
+        unsigned current_pos = start;
+
+        while (current_pos < end)
+        {
+            UChar32 c = text_.char32At(current_pos);
+            unsigned next_pos = text_.moveIndex32(current_pos, 1);
+
+            UScriptCode usc =
+                u_ispunct(c) ? USCRIPT_COMMON : code;
+
+            if (!script_runs_.empty() &&
+                script_runs_.back().data == usc &&
+                script_runs_.back().end == current_pos)
+            {
+                script_runs_.back().end = next_pos;
+            }
+            else
+            {
+                script_runs_.emplace_back(usc,
+                                        current_pos,
+                                        next_pos);
+            }
+
+            current_pos = next_pos;
+        }
     }
 }
 


### PR DESCRIPTION
After thinking, I believe this solution is much better:

> The solution would be- to check if all the glyph indices codepoints in the cluster are valid before considering a cluster as covered, I think.  https://github.com/mapnik/mapnik/pull/4554#issuecomment-4428077057
