### PR TITLE
Add !unbuffered_bbox!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Developers: Please commit along with changes.
 
 For a complete change history, see the git log.
 
+## Unreleased
+
+- Add `!unbuffered_bbox!` SQL token to the `postgis` and `pgraster` plugins.
+  It expands to the metatile boundary — the same extent as `!bbox!` but
+  without `buffer-size` padding. Clipped to `!bbox!` so it is never larger.
+  Containment via `ST_Covers(!unbuffered_bbox!, way)` is guaranteed when
+  the map SRS and the layer SRS are the same.
+
 ## Mapnik 4.2.2
 
 Released March 30th, 2026

--- a/include/mapnik/feature_style_processor_impl.hpp
+++ b/include/mapnik/feature_style_processor_impl.hpp
@@ -245,6 +245,7 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material&
     processor_context_ptr current_ctx = ds->get_context(ctx_map);
     proj_transform const* proj_trans_ptr = proj_transform_cache::get(mat.proj0_.params(), mat.proj1_.params());
     box2d<double> query_ext = extent;            // unbuffered
+    box2d<double> unbuffered_query_ext = extent; // metatile, reprojected below for !unbuffered_bbox!
     box2d<double> buffered_query_ext(query_ext); // buffered
 
     double buffer_padding = 2.0 * scale * p.scale_factor();
@@ -354,6 +355,12 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material&
         }
     }
 
+    // !unbuffered_bbox! is the metatile boundary forward-projected into the
+    // layer SRS, then intersected with the final !bbox! so it can never be
+    // larger than !bbox!.
+    proj_trans_ptr->forward(unbuffered_query_ext, PROJ_ENVELOPE_POINTS);
+    unbuffered_query_ext = unbuffered_query_ext.intersect(layer_ext);
+
     std::vector<rule_cache>& rule_caches = mat.rule_caches_;
     attribute_collector collector(names);
 
@@ -398,7 +405,7 @@ void feature_style_processor<Processor>::prepare_layer(layer_rendering_material&
     double qh = query_ext.height() > 0 ? query_ext.height() : 1;
     query::resolution_type res(width / qw, height / qh);
 
-    query q(layer_ext, res, scale_denom, extent);
+    query q(layer_ext, res, scale_denom, unbuffered_query_ext);
     q.set_variables(p.variables());
 
     if (p.attribute_collection_policy() == COLLECT_ALL)

--- a/plugins/input/pgraster/pgraster_datasource.cpp
+++ b/plugins/input/pgraster/pgraster_datasource.cpp
@@ -599,18 +599,14 @@ std::string pgraster_datasource::sql_bbox(box2d<double> const& env) const
 
 std::string pgraster_datasource::populate_tokens(std::string const& sql) const
 {
-    return populate_tokens(sql,
-                           FLT_MAX,
-                           box2d<double>(-FLT_MAX, -FLT_MAX, FLT_MAX, FLT_MAX),
-                           0,
-                           0,
-                           mapnik::attributes{},
-                           false);
+    box2d<double> const world(-FLT_MAX, -FLT_MAX, FLT_MAX, FLT_MAX);
+    return populate_tokens(sql, FLT_MAX, world, world, 0, 0, mapnik::attributes{}, false);
 }
 
 std::string pgraster_datasource::populate_tokens(std::string const& sql,
                                                  double scale_denom,
                                                  box2d<double> const& env,
+                                                 box2d<double> const& unbuffered_env,
                                                  double pixel_width,
                                                  double pixel_height,
                                                  mapnik::attributes const& vars,
@@ -648,6 +644,10 @@ std::string pgraster_datasource::populate_tokens(std::string const& sql,
         {
             populated_sql << sql_bbox(env);
             intersect = false;
+        }
+        else if (boost::algorithm::equals(m1, "unbuffered_bbox"))
+        {
+            populated_sql << sql_bbox(unbuffered_env);
         }
         else if (boost::algorithm::equals(m1, "pixel_height"))
         {
@@ -868,7 +868,8 @@ featureset_ptr pgraster_datasource::features_with_context(query const& q, proces
             boost::algorithm::replace_all(table_with_bbox, parsed_schema_, sch);
             boost::algorithm::replace_all(table_with_bbox, geometryColumn_, col);
         }
-        table_with_bbox = populate_tokens(table_with_bbox, scale_denom, box, px_gw, px_gh, q.variables());
+        table_with_bbox =
+          populate_tokens(table_with_bbox, scale_denom, box, q.get_unbuffered_bbox(), px_gw, px_gh, q.variables());
 
         std::ostringstream s;
 
@@ -1024,7 +1025,7 @@ featureset_ptr pgraster_datasource::features_at_point(coord2d const& pt, double 
             }
 
             box2d<double> box(pt.x - tol, pt.y - tol, pt.x + tol, pt.y + tol);
-            std::string table_with_bbox = populate_tokens(table_, FLT_MAX, box, 0, 0, mapnik::attributes{});
+            std::string table_with_bbox = populate_tokens(table_, FLT_MAX, box, box, 0, 0, mapnik::attributes{});
 
             s << " FROM " << table_with_bbox;
 

--- a/plugins/input/pgraster/pgraster_datasource.hpp
+++ b/plugins/input/pgraster/pgraster_datasource.hpp
@@ -43,6 +43,7 @@
 #include <boost/optional.hpp>
 
 // stl
+#include <optional>
 #include <regex>
 #include <vector>
 #include <string>
@@ -95,6 +96,7 @@ class pgraster_datasource : public datasource
     std::string populate_tokens(std::string const& sql,
                                 double scale_denom,
                                 box2d<double> const& env,
+                                box2d<double> const& unbuffered_env,
                                 double pixel_width,
                                 double pixel_height,
                                 mapnik::attributes const& vars,

--- a/plugins/input/postgis/postgis_datasource.cpp
+++ b/plugins/input/postgis/postgis_datasource.cpp
@@ -509,18 +509,14 @@ std::string postgis_datasource::sql_bbox(box2d<double> const& env) const
 
 std::string postgis_datasource::populate_tokens(std::string const& sql) const
 {
-    return populate_tokens(sql,
-                           FLT_MAX,
-                           box2d<double>(-FLT_MAX, -FLT_MAX, FLT_MAX, FLT_MAX),
-                           0,
-                           0,
-                           mapnik::attributes{},
-                           false);
+    box2d<double> const world(-FLT_MAX, -FLT_MAX, FLT_MAX, FLT_MAX);
+    return populate_tokens(sql, FLT_MAX, world, world, 0, 0, mapnik::attributes{}, false);
 }
 
 std::string postgis_datasource::populate_tokens(std::string const& sql,
                                                 double scale_denom,
                                                 box2d<double> const& env,
+                                                box2d<double> const& unbuffered_env,
                                                 double pixel_width,
                                                 double pixel_height,
                                                 mapnik::attributes const& vars,
@@ -558,6 +554,10 @@ std::string postgis_datasource::populate_tokens(std::string const& sql,
         {
             populated_sql << sql_bbox(env);
             intersect = false;
+        }
+        else if (boost::algorithm::equals(m1, "unbuffered_bbox"))
+        {
+            populated_sql << sql_bbox(unbuffered_env);
         }
         else if (boost::algorithm::equals(m1, "pixel_height"))
         {
@@ -870,7 +870,8 @@ featureset_ptr postgis_datasource::features_with_context(query const& q, process
             }
         }
 
-        std::string table_with_bbox = populate_tokens(table_, scale_denom, box, px_gw, px_gh, q.variables());
+        std::string table_with_bbox =
+          populate_tokens(table_, scale_denom, box, q.get_unbuffered_bbox(), px_gw, px_gh, q.variables());
 
         s << " FROM " << table_with_bbox;
 
@@ -952,7 +953,7 @@ featureset_ptr postgis_datasource::features_at_point(coord2d const& pt, double t
             }
 
             box2d<double> box(pt.x - tol, pt.y - tol, pt.x + tol, pt.y + tol);
-            std::string table_with_bbox = populate_tokens(table_, FLT_MAX, box, 0, 0, mapnik::attributes{});
+            std::string table_with_bbox = populate_tokens(table_, FLT_MAX, box, box, 0, 0, mapnik::attributes{});
 
             s << " FROM " << table_with_bbox;
 

--- a/plugins/input/postgis/postgis_datasource.hpp
+++ b/plugins/input/postgis/postgis_datasource.hpp
@@ -41,6 +41,7 @@
 
 // stl
 #include <memory>
+#include <optional>
 #include <regex>
 #include <vector>
 #include <string>
@@ -84,6 +85,7 @@ class postgis_datasource : public datasource
     std::string populate_tokens(std::string const& sql,
                                 double scale_denom,
                                 box2d<double> const& env,
+                                box2d<double> const& unbuffered_env,
                                 double pixel_width,
                                 double pixel_height,
                                 mapnik::attributes const& vars,

--- a/test/unit/datasource/postgis.cpp
+++ b/test/unit/datasource/postgis.cpp
@@ -312,6 +312,37 @@ TEST_CASE("postgis")
             REQUIRE(ext.maxy() == 4);
         }
 
+        SECTION("Postgis !unbuffered_bbox! yields the pre-buffer extent")
+        {
+            mapnik::parameters params(base_params);
+            // !bbox! expands to the buffered render extent; !unbuffered_bbox!
+            // expands to the extent before Mapnik's buffer-size padding -- i.e.
+            // the exact (meta)tile boundary. Expose both as WKT to compare.
+            params["table"] = "(SELECT gid, geom,"
+                              " ST_AsText(!bbox!) as buffered,"
+                              " ST_AsText(!unbuffered_bbox!) as unbuffered"
+                              " FROM public.test LIMIT 1) as data";
+            auto ds = mapnik::datasource_cache::instance().create(params);
+            REQUIRE(ds != nullptr);
+
+            // Mimic a layer rendered with a non-zero buffer-size: the query's
+            // buffered bbox is larger than its unbuffered bbox.
+            mapnik::box2d<double> unbuffered(0, 0, 100, 100);
+            mapnik::box2d<double> buffered(-10, -10, 110, 110);
+            mapnik::query qry(buffered, mapnik::query::resolution_type(1.0, 1.0), 1.0, unbuffered);
+            qry.add_property_name("buffered");
+            qry.add_property_name("unbuffered");
+
+            auto featureset = ds->features(qry);
+            auto feature = featureset->next();
+            CHECKED_IF(feature != nullptr)
+            {
+                CHECK(feature->get("buffered").to_string() ==
+                      "POLYGON((-10 -10,-10 110,110 110,110 -10,-10 -10))");
+                CHECK(feature->get("unbuffered").to_string() == "POLYGON((0 0,0 100,100 100,100 0,0 0))");
+            }
+        }
+
         SECTION("Postgis substitutes numeric !tokens! always with decimal point")
         {
             mapnik::parameters params(base_params);

--- a/test/unit/renderer/feature_style_processor.cpp
+++ b/test/unit/renderer/feature_style_processor.cpp
@@ -12,6 +12,7 @@
 #include <mapnik/value/types.hpp>
 #include <mapnik/symbolizer.hpp>
 #include <mapnik/geometry/geometry_type.hpp>
+#include <mapnik/well_known_srs.hpp>
 
 struct rendering_result
 {
@@ -82,6 +83,39 @@ class test_renderer : public mapnik::feature_style_processor<test_renderer>
     rendering_result& result_;
     bool painted_;
     mapnik::attributes vars_;
+};
+
+class unbuffered_bbox_datasource : public mapnik::memory_datasource
+{
+  public:
+    unbuffered_bbox_datasource()
+        : mapnik::memory_datasource(prepare_params()),
+          query_count_(0)
+    {}
+
+    mapnik::featureset_ptr features(mapnik::query const& q) const override
+    {
+        last_bbox_ = q.get_bbox();
+        last_unbuffered_bbox_ = q.get_unbuffered_bbox();
+        ++query_count_;
+        return mapnik::memory_datasource::features(q);
+    }
+
+    unsigned query_count() const { return query_count_; }
+    mapnik::box2d<double> const& last_bbox() const { return last_bbox_; }
+    mapnik::box2d<double> const& last_unbuffered_bbox() const { return last_unbuffered_bbox_; }
+
+  private:
+    static mapnik::parameters prepare_params()
+    {
+        mapnik::parameters params;
+        params["type"] = "memory";
+        return params;
+    }
+
+    mutable mapnik::box2d<double> last_bbox_;
+    mutable mapnik::box2d<double> last_unbuffered_bbox_;
+    mutable unsigned query_count_;
 };
 
 std::shared_ptr<mapnik::memory_datasource> prepare_datasource()
@@ -220,5 +254,91 @@ TEST_CASE("feature_style_processor")
         REQUIRE(result.geometries.size() == 2);
         REQUIRE(mapnik::geometry::geometry_type(result.geometries[0]) == mapnik::geometry::geometry_types::Point);
         REQUIRE(mapnik::geometry::geometry_type(result.geometries[1]) == mapnik::geometry::geometry_types::LineString);
+    }
+
+    SECTION("query unbuffered bbox equals the metatile before buffer padding when unclipped")
+    {
+        // Same SRS everywhere with no query clipping: !unbuffered_bbox! must
+        // equal the render extent exactly and must not include buffer padding.
+        auto datasource = std::make_shared<unbuffered_bbox_datasource>();
+        mapnik::context_ptr ctx = std::make_shared<mapnik::context_type>();
+        {
+            mapnik::feature_ptr feature(mapnik::feature_factory::create(ctx, 1));
+            mapnik::geometry::line_string<double> path;
+            path.emplace_back(-2000000, -2000000);
+            path.emplace_back(2000000, 2000000);
+            feature->set_geometry(std::move(path));
+            datasource->push(feature);
+        }
+
+        mapnik::Map map(256, 256, mapnik::MAPNIK_WEBMERCATOR_PROJ);
+        map.set_buffer_size(64);
+
+        mapnik::feature_type_style lines_style;
+        mapnik::rule rule;
+        mapnik::line_symbolizer line_sym;
+        rule.append(std::move(line_sym));
+        lines_style.add_rule(std::move(rule));
+        map.insert_style("lines", std::move(lines_style));
+
+        mapnik::layer lyr("layer", mapnik::MAPNIK_WEBMERCATOR_PROJ);
+        lyr.set_datasource(datasource);
+        lyr.add_style("lines");
+        map.add_layer(lyr);
+
+        mapnik::box2d<double> const render_extent(-1000000, -1000000, 1000000, 1000000);
+        map.zoom_to_box(render_extent);
+
+        rendering_result result;
+        test_renderer renderer(map, result);
+        renderer.apply();
+
+        REQUIRE(datasource->query_count() == 1);
+        CHECK(datasource->last_bbox().contains(render_extent));
+        CHECK(datasource->last_unbuffered_bbox() == render_extent);
+    }
+
+    SECTION("query unbuffered bbox is clipped to the regular query bbox")
+    {
+        // If maximum_extent clips the regular datasource query, the unbuffered
+        // token must be clipped too so it can never be larger than !bbox!.
+        auto datasource = std::make_shared<unbuffered_bbox_datasource>();
+        mapnik::context_ptr ctx = std::make_shared<mapnik::context_type>();
+        {
+            mapnik::feature_ptr feature(mapnik::feature_factory::create(ctx, 1));
+            mapnik::geometry::line_string<double> path;
+            path.emplace_back(-2000000, -2000000);
+            path.emplace_back(2000000, 2000000);
+            feature->set_geometry(std::move(path));
+            datasource->push(feature);
+        }
+
+        mapnik::Map map(256, 256, mapnik::MAPNIK_WEBMERCATOR_PROJ);
+        map.set_buffer_size(64);
+        map.set_maximum_extent(mapnik::box2d<double>(-500000, -500000, 500000, 500000));
+
+        mapnik::feature_type_style lines_style;
+        mapnik::rule rule;
+        mapnik::line_symbolizer line_sym;
+        rule.append(std::move(line_sym));
+        lines_style.add_rule(std::move(rule));
+        map.insert_style("lines", std::move(lines_style));
+
+        mapnik::layer lyr("layer", mapnik::MAPNIK_WEBMERCATOR_PROJ);
+        lyr.set_datasource(datasource);
+        lyr.add_style("lines");
+        map.add_layer(lyr);
+
+        mapnik::box2d<double> const render_extent(-1000000, -1000000, 1000000, 1000000);
+        mapnik::box2d<double> const clipped_extent(-500000, -500000, 500000, 500000);
+        map.zoom_to_box(render_extent);
+
+        rendering_result result;
+        test_renderer renderer(map, result);
+        renderer.apply();
+
+        REQUIRE(datasource->query_count() == 1);
+        CHECK(datasource->last_bbox() == clipped_extent);
+        CHECK(datasource->last_unbuffered_bbox() == clipped_extent);
     }
 }


### PR DESCRIPTION
When writing SQL in mapping styles, we don't know what our metatile size is or in other words we don't know how much buffer was applied. We can't hardcode it in the style, because these things are frequently (re)configured at the level of the tile renderer (mod_tile or some such).

This PR allows the SQL to see `!unbuffered_bbox!`, which is intended to be the metatile.

I think this will have lots of potential uses, but the one I have in mind can be found [here](https://redirect.github.com/openstreetmap-carto/openstreetmap-carto/issues/951#issuecomment-4526397288). In short, we would like to alter the geometry of various ways on-the-fly, to avoid segmented rendering. But, if we combine these geometries across metatile boundaries, then we will likely cause metatile boundary seams, because now each of the metatiles has a differing opinion on what is the length of this boundary-spanning way. In order to avoid this, **we want some kind of way to determine if a given way is completely within the metatile being rendered, excluding the buffer region.** Hence, `ST_Covers(!unbuffered_bbox!, way)` is the intended use case.

I hope you will consider this PR, it would be a great help to me 🙏 