### PR TITLE
2.  Correction for "Rendering complex Unicode sequences across multiple fonts in a fontset"

### DIFF
--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -359,11 +359,7 @@ struct harfbuzz_shaper
                             break;
                         }
                     }
-                    if (valid)
-                    {
-                        glyphinfos[cluster_id] = cluster_glyphs;
-                    }
-                    else if (glyphinfos[cluster_id].empty())
+                    if (valid && glyphinfos[cluster_id].empty())
                     {
                         glyphinfos[cluster_id] = cluster_glyphs;
                     }


### PR DESCRIPTION
This PR implements the FallBackup contract and also has the advantage of better performance.

Please see: https://github.com/mapnik/mapnik/pull/4556#issuecomment-4621227980