### PR TITLE
Font FallBackup

### DIFF
--- a/include/mapnik/text/harfbuzz_shaper.hpp
+++ b/include/mapnik/text/harfbuzz_shaper.hpp
@@ -359,13 +359,12 @@ struct harfbuzz_shaper
                             break;
                         }
                     }
-                    if (valid)
+                    if (glyphinfos[cluster_id].empty())
                     {
-                        glyphinfos[cluster_id] = cluster_glyphs;
-                    }
-                    else if (glyphinfos[cluster_id].empty())
-                    {
-                        glyphinfos[cluster_id] = cluster_glyphs;
+                        if (valid || pos == num_faces)
+                        {
+                            glyphinfos[cluster_id] = cluster_glyphs;
+                        }
                     }
                 }
                 bool all_set = true;


### PR DESCRIPTION

This code uses the first font that can render the cluster correctly, like https://github.com/mapnik/mapnik/pull/4574 .

But if no font can render the cluster, the `cluster_glyphs` from the last font in the fallback stack are used as the final fallback. Even if the codepoint is `0` (`.notdef`). So the unit tests are fine now.

