### PR TITLE
Include marker URI in logged SVG parse errors, fix built-in marker dimensions

### DIFF
--- a/src/marker_cache.cpp
+++ b/src/marker_cache.cpp
@@ -55,12 +55,22 @@ marker_cache::marker_cache()
 {
     insert_svg("ellipse",
                "<?xml version='1.0' standalone='no'?>"
-               "<svg width='100%' height='100%' version='1.1' xmlns='http://www.w3.org/2000/svg'>"
+               // viewBox is required so width/height (both '100%') resolve
+               // to real pixel dimensions instead of hitting svg_parser's
+               // "can't infer valid image dimensions" error path, which
+               // silently forced this built-in marker's dimensions to 0x0.
+               // Box is the rx=5/ry=5 ellipse (centered at the origin, so
+               // it spans -5..5 on each axis) padded by half the .5
+               // stroke-width on every side.
+               "<svg width='100%' height='100%' viewBox='-5.25 -5.25 10.5 10.5' version='1.1' xmlns='http://www.w3.org/2000/svg'>"
                "<ellipse rx='5' ry='5' fill='#0000FF' stroke='black' stroke-width='.5'/>"
                "</svg>");
     insert_svg("arrow",
                "<?xml version='1.0' standalone='no'?>"
-               "<svg width='100%' height='100%' version='1.1' xmlns='http://www.w3.org/2000/svg'>"
+               // Same viewBox fix as "ellipse" above. Box encloses the
+               // path's own coordinate extent (x: 4.40..31.70, y: 1.50..13.56)
+               // padded for the .5 stroke-width.
+               "<svg width='100%' height='100%' viewBox='4 1 28 13' version='1.1' xmlns='http://www.w3.org/2000/svg'>"
                "<path fill='#0000FF' stroke='black' stroke-width='.5' d='m 31.698405,7.5302648 -8.910967,-6.0263712 "
                "0.594993,4.8210971 -18.9822542,0 0,2.4105482 18.9822542,0 -0.594993,4.8210971 z'/>"
                "</svg>");

--- a/src/marker_cache.cpp
+++ b/src/marker_cache.cpp
@@ -178,7 +178,7 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
             {
                 for (auto const& msg : p.err_handler().error_messages())
                 {
-                    MAPNIK_LOG_ERROR(marker_cache) << msg;
+                    MAPNIK_LOG_ERROR(marker_cache) << msg << " (marker: '" << uri << "')";
                 }
             }
             // svg.arrange_orientations();
@@ -219,7 +219,7 @@ std::shared_ptr<mapnik::marker const> marker_cache::find(std::string const& uri,
                 {
                     for (auto const& msg : p.err_handler().error_messages())
                     {
-                        MAPNIK_LOG_ERROR(marker_cache) << msg;
+                        MAPNIK_LOG_ERROR(marker_cache) << msg << " (marker: '" << uri << "')";
                     }
                 }
                 // svg.arrange_orientations();


### PR DESCRIPTION
Hi! There was an issue in the default marker "shape://ellipse" which causes `SVG parse error: can't infer valid image dimensions from width:"100%" height:"100%"`. At first I thought it was my other SVGs but it turns out to be the builtin svg.

Following is the summary of this change. I've validated this change in `node-mapnik` and confirm the warning is gone.

## Summary
- `marker_cache::find()` collects `svg_parser`'s error messages (e.g. `SVG parse error: can't infer valid image dimensions from width:"100%" height:"100%"`) and forwards them to `MAPNIK_LOG_ERROR`, but never included the marker `uri` it was already parsing - so these warnings give no way to tell which SVG file triggered them.
- This appends `(marker: '<uri>')` to both the built-in (`svg_cache_`/`parse_from_string`) and file-based (`parse`) error-forwarding loops in `marker_cache.cpp`, using the `uri` already in scope at each call site.
- **While tracking down a real occurrence of this warning using the above change, found the actual root cause is inside mapnik itself**: the built-in default markers registered under `shape://ellipse` and `shape://arrow` (used whenever a `MarkersSymbolizer` has no `marker-file`/`file=` set) declare `width='100%' height='100%'` with no `viewBox`. Per `svg_parser.cpp`'s `parse_dimensions`, a percent width/height with no `viewBox` to resolve against is exactly the "can't infer valid image dimensions" case - so *every* render of a plain/default marker hits this warning, and `parse_dimensions`'s error path also silently forces that marker's dimensions to 0x0 (`path_.set_dimensions(0, 0)`).
- Added a `viewBox` to each built-in marker's SVG string, sized to its actual geometry (padded for the `.5` stroke-width): `-5.25 -5.25 10.5 10.5` for the rx=5/ry=5 ellipse, `4 1 28 13` for the arrow's path bounds. This lets the existing `width='100%' height='100%'` resolve against the viewBox instead of hitting the error path, fixing both the spurious warning and the 0x0 dimensions.
- No behavior change to `svg_parser`'s own error message text or `error_messages()` contents for the first change - only the logged line gains the extra context. No test in the repo references `shape://ellipse`/`shape://arrow` directly (checked `test/` and `demo/`), so nothing needed updating for the second change either.

## Test plan
- [x] Confirmed `svg_parser_test.cpp`/`svg_renderer_test.cpp` assert against `error_handler::error_messages()`/rendered output directly, not the `MAPNIK_LOG_ERROR` text, so they don't need updates.
- [x] Verified no test or demo references `shape://ellipse`/`shape://arrow`.
- [x] Hand-checked the new `viewBox` values against the actual `<ellipse>`/`<path>` geometry (see commit message for the arrow's coordinate-extent derivation).
- [ ] I wasn't able to build/run the full test suite locally (no C++ toolchain in this environment) - relying on CI to build and run the existing SVG unit tests against this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4CEbsnFsmFCpevgGXudHD