### PR TITLE
Cache rasterized SVG polygon patterns

### DIFF
--- a/include/mapnik/renderer_common/render_pattern.hpp
+++ b/include/mapnik/renderer_common/render_pattern.hpp
@@ -40,6 +40,11 @@ struct marker_svg;
 template<typename T>
 void render_pattern(marker_svg const& marker, agg::trans_affine const& tr, double opacity, T& image);
 
+// SVG pattern pixels depend on the source and evaluated image transform, not
+// on the polygon that will be filled with them. Images use opacity 1 here;
+// polygon opacity and compositing are applied afterward.
+std::shared_ptr<image_rgba8 const> rasterized_pattern(marker_svg const& marker, agg::trans_affine const& tr);
+
 } // namespace mapnik
 
 #endif // MAPNIK_RENDER_PATTERN_HPP

--- a/src/agg/process_polygon_pattern_symbolizer.cpp
+++ b/src/agg/process_polygon_pattern_symbolizer.cpp
@@ -86,10 +86,8 @@ struct agg_renderer_process_visitor_p
         auto image_transform = get_optional<transform_type>(sym_, keys::image_transform);
         if (image_transform)
             evaluate_transform(image_tr, feature_, common_.vars_, *image_transform, common_.scale_factor_);
-        mapnik::box2d<double> const& bbox_image = marker.get_data()->bounding_box() * image_tr;
-        mapnik::image_rgba8 image(bbox_image.width(), bbox_image.height());
-        render_pattern<buffer_type>(marker, image_tr, 1.0, image);
-        render(image);
+        auto image = rasterized_pattern(marker, image_tr);
+        render(*image);
     }
 
     void operator()(marker_rgba8 const& marker) const { render(marker.get_data()); }

--- a/src/renderer_common/render_pattern.cpp
+++ b/src/renderer_common/render_pattern.cpp
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  *****************************************************************************/
+// stl
+#include <array>
+#include <list>
 // mapnik
 #include <mapnik/renderer_common/render_pattern.hpp>
 #include <mapnik/geometry/box2d.hpp>
@@ -73,6 +76,63 @@ void render_pattern<image_rgba8>(marker_svg const& marker,
       marker.get_data()->svg_group());
     rasterizer ras;
     svg_renderer.render(ras, sl, renb, mtx, opacity, bbox);
+}
+
+namespace {
+
+struct pattern_cache_entry
+{
+    // Retaining the source prevents a cleared marker-cache entry's address
+    // from being reused for a different SVG while these pixels are cached.
+    svg_path_ptr source;
+    std::array<double, 6> transform;
+    std::shared_ptr<image_rgba8 const> image;
+};
+
+struct pattern_cache
+{
+    std::list<pattern_cache_entry> entries;
+    std::size_t bytes = 0;
+};
+
+} // namespace
+
+std::shared_ptr<image_rgba8 const> rasterized_pattern(marker_svg const& marker, agg::trans_affine const& tr)
+{
+    // Workers can reuse patterns across metatiles without sharing mutable
+    // lookup state. Bound both pixel storage and metadata for dynamic styles.
+    static thread_local pattern_cache cache;
+    constexpr std::size_t max_bytes = 64 * 1024 * 1024;
+    constexpr std::size_t max_entries = 64;
+
+    auto source = marker.get_data();
+    std::array<double, 6> transform;
+    tr.store_to(transform.data());
+    for (auto it = cache.entries.begin(); it != cache.entries.end(); ++it)
+    {
+        if (it->source == source && it->transform == transform)
+        {
+            cache.entries.splice(cache.entries.begin(), cache.entries, it);
+            return cache.entries.front().image;
+        }
+    }
+
+    auto const bbox = source->bounding_box() * tr;
+    auto image = std::make_shared<image_rgba8>(bbox.width(), bbox.height());
+    render_pattern<image_rgba8>(marker, tr, 1.0, *image);
+    auto const bytes = std::size_t(image->width()) * image->height() * 4;
+    if (bytes <= max_bytes)
+    {
+        while (!cache.entries.empty() && (cache.bytes + bytes > max_bytes || cache.entries.size() >= max_entries))
+        {
+            auto const& old = cache.entries.back().image;
+            cache.bytes -= std::size_t(old->width()) * old->height() * 4;
+            cache.entries.pop_back();
+        }
+        cache.bytes += bytes;
+        cache.entries.push_front({std::move(source), transform, image});
+    }
+    return image;
 }
 
 } // namespace mapnik


### PR DESCRIPTION
Polygon patterns for landcover/landuse are used in OSM Carto. I wanted to optimize them so that we could fully move from PNG patterns to SVG patterns, so that HiDPI rendering becomes more consistent (see: https://github.com/openstreetmap-carto/openstreetmap-carto/pull/5302). However, I found that for some of the patterns it would cause a significant performance regression. The reason is that some of them, in particular rock https://github.com/openstreetmap-carto/openstreetmap-carto/blob/master/symbols/rock_overlay.png, are rather heavy as SVGs. The issue is that mapnik is currently re-rasterizing the pattern SVGs for each polygon in the metatile. The XML parsing is cached, but the actual drawing could be cached too since it gets path clipped from the overall pattern per polygon (for pattern consistency across landuse/landcover boundaries I imagine?). Therefore, this can be optimized with a per-thread LRU cache, where the key is the SVG source identity and the final affine transform. This will use up to 256kb per pattern per thread, up to 16mb total per thread if there are many distinct tiles. The key in that case will always be `(1,0,0,1,0,0)`. For retina / 2x rendering, it will be `(2,0,0,2,0,0)` and memory usage is up to 64mb per thread. Note that opacity, gamma, and compositing is unaffected (they are further downstream). OSM Carto has 41 polygon patterns, of which currently 27 are SVG and 14 are PNG, so in the tile.osm.org case, the RAM usage increase is a little under ten megabytes (even if all remaining PNGs are converted to SVG patterns). In my prior performance PRs I had picked urban areas which have some land cover patterns but not that many, leaving this change having no measurable effect except by chance that the Z13 selection had a lot of landcover pattern polygons. So I have changed the measurement area here to be two locations with such landcover, while still being urban. Measurements still taken mostly the same as #4578 (as similar to tile.osm.org as I can get, Mapnik CPU seconds, average of 5 runs, etc). Starting at Z13 since that's when the patterns appear. The only difference from #4578 methodology is that I am now measuring the tiles warm with mapnik having rendered tiles beforehand in the same process. This is more faithful to tile.osm.org mod_tile renderd processes, and it also helps in this case because of the caching. Note that the before and after numbers below are both warm of course.

As you can see, the speedup for such metatiles is realistic and nontrivial. "Why is London Z13 sped up so much???" Because it has **2,731 distinct forest pattern polygons**, all of which previously caused the entire forest pattern to be redrawn. Now the forest pattern is only drawn once and cached as a bitmap. The resulting PNGs are identical.

|Zoom|London|NYC|
|---|---|---|
|13|<b>−29.77%</b> (2.073s → 1.456s)|−16.78% (2.831s → 2.356s)|
|14|−19.26% (1.790s → 1.445s)|−5.65% (2.294s → 2.165s)|
|15|−14.51% (1.335s → 1.142s)|−3.84% (1.908s → 1.835s)|
|16|−14.69% (0.821s → 0.700s)|−6.32% (1.051s → 0.985s)|
|17|−8.92% (0.420s → 0.383s)|−2.36% (0.792s → 0.773s)|
|18|−8.77% (0.337s → 0.308s)|−3.48% (0.388s → 0.374s)|
|19|−6.54% (0.241s → 0.225s)|−8.95% (0.229s → 0.208s)|

<details>
<summary><b>See the metatiles in question (click to expand)</b></summary>

<img width="2048" height="2048" alt="london_z13" src="https://github.com/user-attachments/assets/2b86290d-679b-4bc2-b7be-8c0567e9fb66" />
<img width="2048" height="2048" alt="london_z14" src="https://github.com/user-attachments/assets/18af081c-d42b-4e7f-9676-557b5138f636" />
<img width="2048" height="2048" alt="london_z15" src="https://github.com/user-attachments/assets/1644cca5-f32e-4df8-af3a-94955b47f3ca" />
<img width="2048" height="2048" alt="london_z16" src="https://github.com/user-attachments/assets/e5564e9b-f3f7-42ea-b660-7e14612abccf" />
<img width="2048" height="2048" alt="london_z17" src="https://github.com/user-attachments/assets/469ae4c7-b18d-47a3-ae32-4512f747ccf9" />
<img width="2048" height="2048" alt="london_z18" src="https://github.com/user-attachments/assets/519b5639-3c11-4d1a-a639-2d838d442984" />
<img width="2048" height="2048" alt="london_z19" src="https://github.com/user-attachments/assets/8d6746ba-87bf-4b6f-a63b-934e4f9d68f6" />


<img width="2048" height="2048" alt="nyc_z13" src="https://github.com/user-attachments/assets/7eb85101-9dac-4a4a-a082-479a880ac116" />
<img width="2048" height="2048" alt="nyc_z14" src="https://github.com/user-attachments/assets/3a90aab6-9cc0-4d5d-84b0-5e0da5c6c3cf" />
<img width="2048" height="2048" alt="nyc_z15" src="https://github.com/user-attachments/assets/959ecb58-f907-4f6d-87b4-3f965e32a8fe" />
<img width="2048" height="2048" alt="nyc_z16" src="https://github.com/user-attachments/assets/7055e15f-2887-4310-af3a-58bfff4b7cdd" />
<img width="2048" height="2048" alt="nyc_z17" src="https://github.com/user-attachments/assets/124b3c0d-90fb-473f-b947-3872908223ba" />
<img width="2048" height="2048" alt="nyc_z18" src="https://github.com/user-attachments/assets/7b8a1a6b-6755-441a-99f9-88591383f616" />
<img width="2048" height="2048" alt="nyc_z19" src="https://github.com/user-attachments/assets/8be8a6e7-7dc7-4ed4-b716-ad766e786af8" />
</details>